### PR TITLE
Seed Harn canon predicate pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ fn no_floating_promises(slice: Slice, ctx: Context, repo_at_base: Repo) -> Invar
 
 See the Harn Flow design docs for the full predicate language spec.
 
+## Packs
+
+- [Harn](./harn/) — v0 draft predicates for `.harn` scripts, Flow workflows, and agent-facing Harn modules.
+
 ## Status
 
 🚧 **Early — design-first.** The predicate language, `InvariantResult` type, and runtime harness are still being specified in `burin-labs/harn`. This repo exists now to:

--- a/harn/README.md
+++ b/harn/README.md
@@ -1,0 +1,59 @@
+# Harn Seed Predicate Pack
+
+This pack covers Harn scripts, Flow workflows, and agent-facing Harn modules. It is intentionally focused on the mistakes most likely to create nondeterminism, runaway cost, schema drift, or unsafe agent behavior.
+
+## Stack Assumptions
+
+- Files use the `.harn` extension and current Harn syntax.
+- The Flow predicate runtime provides `Slice`, `Context`, `Repo`, and `ctx.semantic_judge(...)` as described by the Harn Flow umbrella.
+- Deterministic predicates run over changed Harn source text. They prefer conservative warnings when regex matching can produce false positives.
+- Semantic predicates are strict-gate candidates only when the judge can cite a concrete changed span.
+
+## Predicate Coverage
+
+| Predicate | Mode | Verdict | Purpose |
+|---|---|---|---|
+| `llm_call_schema_sets_schema_retries` | deterministic | Block | Schema-mode `llm_call` must opt into schema repair or use `llm_call_structured`. |
+| `parallel_io_sets_max_concurrent` | deterministic | Warn | Parallel fan-out that calls LLM, HTTP, host, or MCP tools should cap in-flight work. |
+| `no_source_heredocs` | deterministic | Block | Harn source uses triple-quoted strings; heredocs are only valid in tool-call JSON. |
+| `no_legacy_transcript_options` | deterministic | Block | Legacy transcript option keys must not be reintroduced. |
+| `schema_objects_reject_unknown_properties` | deterministic | Warn | Closed LLM/output schemas should reject unexpected object properties. |
+| `dynamic_boundaries_use_unknown` | deterministic | Warn | Dynamic JSON/LLM/tool boundaries should use `unknown` plus schema narrowing, not `any`. |
+| `tests_mock_time_for_sleep` | deterministic | Warn | Tests that exercise time, sleep, retry, or deadlines should use mock time. |
+| `prefer_enumerate_over_index_loops` | deterministic | Warn | Prefer direct iteration or `.enumerate()` over `range(len(xs))` loops. |
+| `llm_prompts_do_not_embed_secrets` | semantic | Block | Prompts must not embed secrets, credentials, or sensitive customer data. |
+| `acp_tool_side_effects_are_honest` | semantic | Block | ACP tool metadata must describe the strongest side effect a tool can perform. |
+
+## Evidence
+
+Evidence scanned on 2026-04-26.
+
+- Harn quick reference: attributes, strings, typing, iteration, JSON querying, concurrency, and time mocking.
+- Harn builtins reference: JSON/schema helpers, list methods, string helpers, and regex functions.
+- Harn changelog: `llm_call_structured`, schema retries, and removed legacy transcript options.
+- OpenAI Structured Outputs guide: schema-backed model outputs and strict structured output behavior.
+- OpenAI and Anthropic rate-limit guidance: short bursts and uncapped concurrency can trip provider limits.
+- JSON Schema object reference: `properties`, `required`, and `additionalProperties` object validation.
+- OWASP, OpenAI, and Microsoft AI security guidance: prompt-injection, system-prompt leakage, sensitive-information disclosure, and excessive-agency risks.
+
+## Known False Positives
+
+- Regex predicates are syntax-aware only at the source-text level until Flow exposes a stable Harn AST query API.
+- `parallel_io_sets_max_concurrent` warns on helper calls whose names look like external IO, even when a wrapper has its own limiter.
+- `schema_objects_reject_unknown_properties` assumes closed schemas by default; extension-point schemas should document intentional `additional_properties`.
+- `dynamic_boundaries_use_unknown` is advisory because some low-level generic helpers legitimately use `any`.
+- The semantic predicates depend on a cheap judge. They should stay high-threshold and cite concrete spans before blocking.
+
+## Fixtures
+
+Each fixture in `fixtures/` contains one blocked or warned example and one allowed example for the corresponding predicate. The fixture shape is deliberately simple until the Flow replay harness lands:
+
+```json
+{
+  "predicate": "name",
+  "cases": [
+    {"expect": "Block", "files": [{"path": "workflow.harn", "text": "..."}]},
+    {"expect": "Allow", "files": [{"path": "workflow.harn", "text": "..."}]}
+  ]
+}
+```

--- a/harn/fixtures/acp_tool_side_effects_are_honest.json
+++ b/harn/fixtures/acp_tool_side_effects_are_honest.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "acp_tool_side_effects_are_honest",
+  "cases": [
+    {
+      "name": "blocks_read_only_annotation_on_mutation",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "tools/deploy.harn",
+          "text": "@acp_tool(name: \"deploy\", kind: \"read\", side_effect_level: \"none\")\nfn deploy(env) {\n  return host_tool_call(\"deploy_service\", {env: env})\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_mutation_annotation",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "tools/deploy.harn",
+          "text": "@acp_tool(name: \"deploy\", kind: \"edit\", side_effect_level: \"mutation\")\nfn deploy(env) {\n  return host_tool_call(\"deploy_service\", {env: env})\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/harn/fixtures/dynamic_boundaries_use_unknown.json
+++ b/harn/fixtures/dynamic_boundaries_use_unknown.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "dynamic_boundaries_use_unknown",
+  "cases": [
+    {
+      "name": "warns_any_at_json_boundary",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "agent/config.harn",
+          "text": "fn load(raw: any) {\n  let parsed = json_parse(raw)\n  return parsed.name\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_unknown_with_schema_expect",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "agent/config.harn",
+          "text": "fn load(raw: unknown) {\n  let parsed = schema_expect(json_parse(raw), Config)\n  return parsed.name\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/harn/fixtures/llm_call_schema_sets_schema_retries.json
+++ b/harn/fixtures/llm_call_schema_sets_schema_retries.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "llm_call_schema_sets_schema_retries",
+  "cases": [
+    {
+      "name": "blocks_schema_call_without_retry_budget",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "agent/grade.harn",
+          "text": "fn grade(prompt) {\n  return llm_call(prompt, nil, {provider: \"mock\", output_schema: Grade})\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_structured_helper",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "agent/grade.harn",
+          "text": "fn grade(prompt) {\n  return llm_call_structured(prompt, Grade, {provider: \"mock\"})\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/harn/fixtures/llm_prompts_do_not_embed_secrets.json
+++ b/harn/fixtures/llm_prompts_do_not_embed_secrets.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "llm_prompts_do_not_embed_secrets",
+  "cases": [
+    {
+      "name": "blocks_secret_in_system_prompt",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "agent/deploy.harn",
+          "text": "let system = \"\"\"\nUse production token sk-live-abc123 when calling deployment APIs.\n\"\"\"\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_runtime_secret_lookup",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "agent/deploy.harn",
+          "text": "fn deploy() {\n  let token = secret_get(\"deploy_api_token\")\n  return host_tool_call(\"deploy\", {token: token})\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/harn/fixtures/no_legacy_transcript_options.json
+++ b/harn/fixtures/no_legacy_transcript_options.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_legacy_transcript_options",
+  "cases": [
+    {
+      "name": "blocks_legacy_transcript_key",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "agent/session.harn",
+          "text": "fn ask(prompt, transcript_id) {\n  return llm_call(prompt, nil, {provider: \"mock\", transcript: transcript_id})\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_session_id",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "agent/session.harn",
+          "text": "fn ask(prompt, session_id) {\n  return llm_call(prompt, nil, {provider: \"mock\", session_id: session_id})\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/harn/fixtures/no_source_heredocs.json
+++ b/harn/fixtures/no_source_heredocs.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_source_heredocs",
+  "cases": [
+    {
+      "name": "blocks_source_heredoc",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "agent/prompt.harn",
+          "text": "let system = <<SYS\nYou are precise.\nSYS\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_triple_quoted_prompt",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "agent/prompt.harn",
+          "text": "let system = \"\"\"\nYou are precise.\n\"\"\"\n"
+        }
+      ]
+    }
+  ]
+}

--- a/harn/fixtures/parallel_io_sets_max_concurrent.json
+++ b/harn/fixtures/parallel_io_sets_max_concurrent.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "parallel_io_sets_max_concurrent",
+  "cases": [
+    {
+      "name": "warns_uncapped_llm_fanout",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "agent/summarize.harn",
+          "text": "fn summarize(paths) {\n  return parallel each paths { path ->\n    llm_call(read_file(path), nil, {provider: \"mock\"})\n  }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_capped_llm_fanout",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "agent/summarize.harn",
+          "text": "fn summarize(paths) {\n  return parallel each paths with {max_concurrent: 4} { path ->\n    llm_call(read_file(path), nil, {provider: \"mock\"})\n  }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/harn/fixtures/prefer_enumerate_over_index_loops.json
+++ b/harn/fixtures/prefer_enumerate_over_index_loops.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "prefer_enumerate_over_index_loops",
+  "cases": [
+    {
+      "name": "warns_range_len_loop",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "agent/files.harn",
+          "text": "fn print_files(files) {\n  for i in range(len(files)) {\n    println(files[i])\n  }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_enumerate_loop",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "agent/files.harn",
+          "text": "fn print_files(files) {\n  for {index, value} in files.enumerate() {\n    println(\"${index}: ${value}\")\n  }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/harn/fixtures/schema_objects_reject_unknown_properties.json
+++ b/harn/fixtures/schema_objects_reject_unknown_properties.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "schema_objects_reject_unknown_properties",
+  "cases": [
+    {
+      "name": "warns_open_object_schema",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "agent/schema.harn",
+          "text": "let Grade = {\n  type: \"dict\",\n  required: [\"score\"],\n  properties: {score: {type: \"int\"}}\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_closed_object_schema",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "agent/schema.harn",
+          "text": "let Grade = {\n  type: \"dict\",\n  required: [\"score\"],\n  properties: {score: {type: \"int\"}},\n  additional_properties: false\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/harn/fixtures/tests_mock_time_for_sleep.json
+++ b/harn/fixtures/tests_mock_time_for_sleep.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "tests_mock_time_for_sleep",
+  "cases": [
+    {
+      "name": "warns_sleeping_test_without_mock_time",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "tests/retry.harn",
+          "text": "@test\npipeline retry_waits() {\n  sleep_ms(1000)\n  return Ok(nil)\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_mocked_time_test",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "tests/retry.harn",
+          "text": "@test\npipeline retry_waits() {\n  mock_time(0)\n  sleep_ms(1000)\n  return Ok(nil)\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/harn/invariants.harn
+++ b/harn/invariants.harn
@@ -1,0 +1,288 @@
+let _EVIDENCE_SCHEMA_RETRIES = [
+  "https://harnlang.com/docs/llm/harn-quickref.html#json-querying",
+  "https://github.com/burin-labs/harn/blob/main/CHANGELOG.md#v0735",
+  "https://platform.openai.com/docs/guides/structured-outputs",
+]
+
+let _EVIDENCE_PARALLEL_IO = [
+  "https://harnlang.com/docs/llm/harn-quickref.html#concurrency",
+  "https://harnlang.com/concurrency.html",
+  "https://help.openai.com/en/articles/6891753-rate-limit-advice",
+  "https://docs.anthropic.com/en/api/rate-limits",
+]
+
+let _EVIDENCE_SOURCE_STRINGS = [
+  "https://harnlang.com/docs/llm/harn-quickref.html#files-and-execution",
+  "https://harnlang.com/docs/llm/harn-quickref.html#strings",
+]
+
+let _EVIDENCE_TRANSCRIPTS = [
+  "https://harnlang.com/docs/llm/harn-quickref.html#module-scope",
+  "https://github.com/burin-labs/harn/blob/main/CHANGELOG.md#v070",
+]
+
+let _EVIDENCE_SCHEMA_OBJECTS = [
+  "https://harnlang.com/docs/llm/harn-quickref.html#json-querying",
+  "https://json-schema.org/understanding-json-schema/reference/object",
+  "https://platform.openai.com/docs/guides/structured-outputs",
+]
+
+let _EVIDENCE_DYNAMIC_BOUNDARIES = [
+  "https://harnlang.com/docs/llm/harn-quickref.html#typing-any-vs-unknown-vs-no-annotation",
+  "https://harnlang.com/builtins.html#json",
+]
+
+let _EVIDENCE_MOCK_TIME = [
+  "https://harnlang.com/docs/llm/harn-quickref.html#time-sleep-monotonic-clock",
+  "https://harnlang.com/concurrency.html#retry",
+]
+
+let _EVIDENCE_ITERATION = [
+  "https://harnlang.com/docs/llm/harn-quickref.html#iteration",
+  "https://harnlang.com/builtins.html#list-methods",
+]
+
+let _EVIDENCE_PROMPT_SECRETS = [
+  "https://genai.owasp.org/llmrisk/llm07-insecure-plugin-design/",
+  "https://openai.com/index/prompt-injections/",
+  "https://learn.microsoft.com/en-us/security/zero-trust/sfi/defend-indirect-prompt-injection",
+]
+
+let _EVIDENCE_ACP_SIDE_EFFECTS = [
+  "https://harnlang.com/docs/llm/harn-quickref.html#attributes--name",
+  "https://genai.owasp.org/llmrisk/llm062025-excessive-agency/",
+  "https://platform.openai.com/docs/guides/agent-builder-safety",
+]
+
+fn harn_files(slice) {
+  return slice.files.filter({ file -> file.path.ends_with(".harn") })
+}
+
+fn scan(slice, pattern) {
+  var findings = []
+  for file in harn_files(slice) {
+    if regex_match(pattern, file.text, "s") != nil {
+      findings = findings
+        .push({path: file.path, pattern: pattern})
+    }
+  }
+  return findings
+}
+
+fn scan_if(slice, predicate) {
+  var findings = []
+  for file in harn_files(slice) {
+    if predicate(file.text) {
+      findings = findings
+        .push({path: file.path})
+    }
+  }
+  return findings
+}
+
+fn scan_without(slice, include_pattern, exclude_pattern) {
+  return scan_if(
+    slice,
+    { text -> regex_match(include_pattern, text, "s") != nil && regex_match(exclude_pattern, text, "s") == nil },
+  )
+}
+
+fn allow(rule) {
+  return {verdict: "Allow", rule: rule, findings: [], remediation: ""}
+}
+
+fn warn(rule, remediation, findings) {
+  return {verdict: "Warn", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block(rule, remediation, findings) {
+  return {verdict: "Block", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block_on_match(slice, rule, pattern, remediation) {
+  let findings = scan(slice, pattern)
+  if findings.none() {
+    return allow(rule)
+  }
+  return block(rule, remediation, findings)
+}
+
+fn warn_on_match(slice, rule, pattern, remediation) {
+  let findings = scan(slice, pattern)
+  if findings.none() {
+    return allow(rule)
+  }
+  return warn(rule, remediation, findings)
+}
+
+fn block_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return block(rule, remediation, findings)
+}
+
+fn warn_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return warn(rule, remediation, findings)
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_SCHEMA_RETRIES, confidence: 0.86, source_date: "2026-04-26")
+/** Blocks schema-mode llm_call calls that omit a schema retry budget. */
+pub fn llm_call_schema_sets_schema_retries(slice, _ctx, _repo_at_base) {
+  let findings = scan_if(
+    slice,
+    { text -> regex_match(r"llm_call\s*\(", text, "s") != nil
+    && (contains(text, "output_schema:") || contains(text, "response_schema:")
+    || contains(text, "schema:"))
+    && !contains(text, "schema_retries:") },
+  )
+  return block_on_findings(
+    "llm_call_schema_sets_schema_retries",
+    "Use llm_call_structured or set schema_retries for schema-mode llm_call.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_PARALLEL_IO, confidence: 0.82, source_date: "2026-04-26")
+/** Warns when external IO is fanned out without max_concurrent. */
+pub fn parallel_io_sets_max_concurrent(slice, _ctx, _repo_at_base) {
+  let findings = scan_without(
+    slice,
+    r"parallel\s+(each|settle)\s+[^{]*\{[^}]*\b(llm_call|http_get|http_post|host_tool_call|mcp_tool_call)\s*\(",
+    r"parallel\s+(each|settle)\s+[^{]*with\s*\{[^}]*max_concurrent\s*:",
+  )
+  return warn_on_findings(
+    "parallel_io_sets_max_concurrent",
+    "Add with { max_concurrent: N } around parallel IO or document why unlimited fan-out is safe.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_SOURCE_STRINGS, confidence: 0.93, source_date: "2026-04-26")
+/** Blocks heredoc syntax in Harn source files. */
+pub fn no_source_heredocs(slice, _ctx, _repo_at_base) {
+  return block_on_match(
+    slice,
+    "no_source_heredocs",
+    r"<<[A-Z][A-Z0-9_]*",
+    "Use triple-quoted strings in Harn source; heredocs are only valid in tool-call JSON.",
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_TRANSCRIPTS, confidence: 0.88, source_date: "2026-04-26")
+/** Blocks removed transcript option keys on LLM and agent calls. */
+pub fn no_legacy_transcript_options(slice, _ctx, _repo_at_base) {
+  return block_on_match(
+    slice,
+    "no_legacy_transcript_options",
+    r"\b(llm_call|agent_loop)\s*\([^)]*\{[^}]*\b(transcript|transcript_id|transcript_metadata)\s*:",
+    "Replace legacy transcript options with explicit agent_session_* lifecycle or session_id.",
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_SCHEMA_OBJECTS, confidence: 0.78, source_date: "2026-04-26")
+/** Warns when closed-looking object schemas allow unknown fields. */
+pub fn schema_objects_reject_unknown_properties(slice, _ctx, _repo_at_base) {
+  let findings = scan_if(
+    slice,
+    { text -> (contains(text, "type: \"dict\"") || contains(text, "type:\"dict\""))
+    && contains(text, "properties:")
+    && contains(text, "required:")
+    && !contains(text, "additional_properties:") },
+  )
+  return warn_on_findings(
+    "schema_objects_reject_unknown_properties",
+    "Set additional_properties: false on closed LLM/output schemas unless extension fields are intended.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_DYNAMIC_BOUNDARIES, confidence: 0.74, source_date: "2026-04-26")
+/** Warns when dynamic boundaries accept any instead of unknown. */
+pub fn dynamic_boundaries_use_unknown(slice, _ctx, _repo_at_base) {
+  return warn_on_match(
+    slice,
+    "dynamic_boundaries_use_unknown",
+    r"fn\s+\w+\s*\([^)]*:\s*any[^)]*\)[^{]*\{[^}]*\b(json_parse|yaml_parse|toml_parse|llm_call|host_tool_call|mcp_tool_call)\s*\(",
+    "Use unknown plus schema_is/schema_expect at dynamic boundaries instead of any.",
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_MOCK_TIME, confidence: 0.8, source_date: "2026-04-26")
+/** Warns when tests use time-sensitive operations without mock_time. */
+pub fn tests_mock_time_for_sleep(slice, _ctx, _repo_at_base) {
+  let findings = scan_without(
+    slice,
+    r"@test\s+pipeline\s+\w+\s*\([^)]*\)\s*\{[^}]*\b(sleep_ms|sleep|deadline)\b",
+    r"@test\s+pipeline\s+\w+\s*\([^)]*\)\s*\{[^}]*\bmock_time\s*\(",
+  )
+  return warn_on_findings(
+    "tests_mock_time_for_sleep",
+    "Call mock_time in tests that exercise sleep, deadlines, retry, or timeout logic.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_ITERATION, confidence: 0.7, source_date: "2026-04-26")
+/** Warns on range(len(xs)) loops where direct iteration is clearer. */
+pub fn prefer_enumerate_over_index_loops(slice, _ctx, _repo_at_base) {
+  return warn_on_match(
+    slice,
+    "prefer_enumerate_over_index_loops",
+    r"for\s+\w+\s+in\s+range\s*\(\s*len\s*\(\s*\w+\s*\)\s*\)",
+    "Iterate values directly, or use .enumerate() when the index is needed.",
+  )
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_PROMPT_SECRETS, confidence: 0.67, source_date: "2026-04-26")
+/** Blocks prompts that embed secrets or sensitive customer data. */
+pub fn llm_prompts_do_not_embed_secrets(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when a Harn LLM prompt, system prompt, or tool instruction embeds credentials, tokens, private keys, production URLs with secrets, or sensitive customer data instead of retrieving them at runtime."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: harn_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "llm_prompts_do_not_embed_secrets",
+      "Move secrets and sensitive data out of prompts; fetch scoped values at runtime.",
+      judgement.findings,
+    )
+  }
+  return allow("llm_prompts_do_not_embed_secrets")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_ACP_SIDE_EFFECTS, confidence: 0.64, source_date: "2026-04-26")
+/** Blocks ACP tool metadata that understates real side effects. */
+pub fn acp_tool_side_effects_are_honest(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when an @acp_tool annotation understates a tool's side effects, for example declaring read-only metadata around file writes, network mutation, shell execution, billing, deployment, or irreversible external changes."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: harn_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "acp_tool_side_effects_are_honest",
+      "Align @acp_tool kind and side_effect_level with the strongest operation it can perform.",
+      judgement.findings,
+    )
+  }
+  return allow("acp_tool_side_effects_are_honest")
+}


### PR DESCRIPTION
## Summary
- add the Harn v0 seed predicate pack with 8 deterministic predicates and 2 semantic predicates
- document pack assumptions, evidence, known false positives, and fixture format
- add allow/block fixture cases for every predicate and index the pack from the root README

## Verification
- harn fmt --check harn/invariants.harn
- harn check harn/invariants.harn (passes with expected unknown @archivist warnings until Flow attributes land)
- harn lint harn/invariants.harn
- jq empty harn/fixtures/*.json
- git diff --check
- local fixture replay for deterministic predicate expectations
- evidence link check for every URL in harn/invariants.harn

Refs #1
Closes #2