### PR TITLE
Seed Rust canon predicate pack

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -1,0 +1,60 @@
+# Rust Seed Predicate Pack
+
+This pack covers Rust crates and workspaces. It targets high-signal issues that are cheap to catch from changed source slices: accidental panics, undocumented unsafe code, blocking work in async functions, dependency-advisory drift, and public API contracts that callers can otherwise misuse.
+
+## Stack Assumptions
+
+- Rust source files use `.rs`; Cargo metadata uses `Cargo.toml` and `Cargo.lock`.
+- Production paths exclude `tests/`, `benches/`, and `examples/` fixtures or sample programs.
+- Deterministic predicates operate on changed file text until Harn Flow exposes a stable Rust AST query API.
+- Semantic predicates make one cheap judge call over changed Rust/Cargo files and use only evidence captured at authoring time.
+- The pack is advisory-first where regex matching has likely false positives. Blocking rules are reserved for unfinished code, bare production unwraps, undocumented unsafe blocks, obvious blocking calls inside `async fn`, and missing semantic dependency/FFI safety evidence.
+
+## Predicate Coverage
+
+| Predicate | Mode | Verdict | Purpose |
+|---|---|---|---|
+| `no_unwrap_in_prod` | deterministic | Block | Bare `unwrap`/`unwrap_err` in production Rust should not ship without explicit handling or a named invariant. |
+| `must_use_message_on_pub_result_option` | deterministic | Warn | Public `Result`/`Option`-returning functions should add a custom unused-value message when the default warning lacks domain context. |
+| `unsafe_requires_safety_comment` | deterministic | Block | Each unsafe block or impl needs a nearby `// SAFETY:` justification. |
+| `no_blocking_io_in_async` | deterministic | Block | `async fn` bodies should not call obvious blocking std APIs directly. |
+| `no_dbg_macro_in_prod` | deterministic | Warn | `dbg!` is a temporary debugging macro and should not be committed to production paths. |
+| `no_todo_or_unimplemented_in_prod` | deterministic | Block | `todo!` and `unimplemented!` mark unfinished production code. |
+| `no_wildcard_imports_in_prod` | deterministic | Warn | Module-level glob imports can obscure name provenance and produce surprising shadowing. |
+| `no_panic_in_result_fn` | deterministic | Warn | `Result`-returning functions should usually return `Err` or document panic behavior. |
+| `cargo_advisories_checked` | semantic | Block | Dependency changes should preserve or run RustSec/cargo-audit/cargo-deny-style advisory checks. |
+| `ffi_boundary_safety_contract` | semantic | Block | Public FFI and unsafe wrappers need explicit safety, ownership, nullability, and lifetime contracts. |
+
+## Evidence
+
+Evidence scanned on 2026-04-26.
+
+- Rust Clippy lint docs: `unwrap_used`, `must_use_candidate`, `undocumented_unsafe_blocks`, `dbg_macro`, `todo`, `unimplemented`, `wildcard_imports`, `panic_in_result_fn`, and `missing_panics_doc`.
+- Rust Reference and Edition Guide: `#[must_use]`, `unsafe` proof obligations, glob imports, and Rust 2024 unsafe extern blocks.
+- Rust By Example and standard library docs: `Option`/`Result` unwrap behavior and debugging/unfinished-code macros.
+- Tokio and Async Book docs: blocking work in async contexts, `spawn_blocking`, and async `sleep`.
+- RustSec, cargo-deny, and Cargo docs: advisory databases, dependency checks, and `Cargo.lock` reproducibility.
+
+## Known False Positives
+
+- Regex predicates do not parse Rust. Macro-generated functions, nested blocks, raw strings, comments, and multi-line signatures can confuse the deterministic checks.
+- `no_unwrap_in_prod` ignores test, bench, and example paths, but it can still catch intentional invariant unwraps in production code. Prefer `expect("why this is impossible")` or a local allow once the predicate runtime supports suppressions.
+- `must_use_message_on_pub_result_option` is intentionally narrower than "always add bare `#[must_use]`": `Result` and `Option` already warn when ignored, and Clippy flags redundant bare attributes.
+- `unsafe_requires_safety_comment` requires a direct `// SAFETY:` line before the unsafe block or impl. Wider module-level explanations may need to move closer to the operation.
+- `no_blocking_io_in_async` catches obvious std blocking APIs only. It will not detect synchronous third-party calls hidden behind helper functions.
+- `no_wildcard_imports_in_prod` is advisory because enum-variant globs and prelude imports can be reasonable in small scopes.
+- Semantic predicates depend on the judge recognizing concrete changed spans. They should stay high-threshold and cite exact dependency or FFI changes before blocking.
+
+## Fixtures
+
+Each fixture in `fixtures/` contains one blocked or warned example and one allowed example for the corresponding predicate. The fixture shape matches the current harn-canon convention:
+
+```json
+{
+  "predicate": "name",
+  "cases": [
+    {"expect": "Block", "files": [{"path": "src/lib.rs", "text": "..."}]},
+    {"expect": "Allow", "files": [{"path": "src/lib.rs", "text": "..."}]}
+  ]
+}
+```

--- a/rust/fixtures/cargo_advisories_checked.json
+++ b/rust/fixtures/cargo_advisories_checked.json
@@ -1,0 +1,29 @@
+{
+  "predicate": "cargo_advisories_checked",
+  "cases": [
+    {
+      "name": "blocks_dependency_change_without_advisory_check",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "Cargo.toml",
+          "text": "[package]\nname = \"service\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n[dependencies]\ntime = \"0.1\"\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_dependency_change_with_cargo_deny_ci",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "Cargo.toml",
+          "text": "[package]\nname = \"service\"\nversion = \"0.1.0\"\nedition = \"2024\"\n\n[dependencies]\ntime = \"0.3\"\n"
+        },
+        {
+          "path": ".github/workflows/security.yml",
+          "text": "name: security\non: [pull_request]\njobs:\n  cargo-deny:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v6\n      - uses: EmbarkStudios/cargo-deny-action@v2\n"
+        }
+      ]
+    }
+  ]
+}

--- a/rust/fixtures/ffi_boundary_safety_contract.json
+++ b/rust/fixtures/ffi_boundary_safety_contract.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "ffi_boundary_safety_contract",
+  "cases": [
+    {
+      "name": "blocks_public_ffi_without_contract",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/ffi.rs",
+          "text": "#[unsafe(no_mangle)]\npub extern \"C\" fn process(ptr: *const u8, len: usize) -> i32 {\n    0\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_ffi_with_safety_contract",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/ffi.rs",
+          "text": "/// # Safety\n/// `ptr` must be non-null and valid for `len` bytes for the duration of this call.\n#[unsafe(no_mangle)]\npub unsafe extern \"C\" fn process(ptr: *const u8, len: usize) -> i32 {\n    0\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/rust/fixtures/must_use_message_on_pub_result_option.json
+++ b/rust/fixtures/must_use_message_on_pub_result_option.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "must_use_message_on_pub_result_option",
+  "cases": [
+    {
+      "name": "warns_public_result_without_custom_must_use_message",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/lib.rs",
+          "text": "pub fn parse_port(raw: &str) -> Result<u16, std::num::ParseIntError> {\n    raw.parse()\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_custom_must_use_message",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/lib.rs",
+          "text": "#[must_use = \"callers must handle whether a configured port exists\"]\npub fn maybe_port(raw: &str) -> Option<u16> {\n    raw.parse().ok()\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/rust/fixtures/no_blocking_io_in_async.json
+++ b/rust/fixtures/no_blocking_io_in_async.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_blocking_io_in_async",
+  "cases": [
+    {
+      "name": "blocks_std_fs_in_async_fn",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/server.rs",
+          "text": "pub async fn load_config() -> std::io::Result<String> {\n    std::fs::read_to_string(\"config.toml\")\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_tokio_fs_in_async_fn",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/server.rs",
+          "text": "pub async fn load_config() -> std::io::Result<String> {\n    tokio::fs::read_to_string(\"config.toml\").await\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/rust/fixtures/no_dbg_macro_in_prod.json
+++ b/rust/fixtures/no_dbg_macro_in_prod.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_dbg_macro_in_prod",
+  "cases": [
+    {
+      "name": "warns_dbg_in_src",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/lib.rs",
+          "text": "pub fn normalize(value: u32) -> u32 {\n    dbg!(value) + 1\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_tracing",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/lib.rs",
+          "text": "pub fn normalize(value: u32) -> u32 {\n    tracing::debug!(value, \"normalizing\");\n    value + 1\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/rust/fixtures/no_panic_in_result_fn.json
+++ b/rust/fixtures/no_panic_in_result_fn.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_panic_in_result_fn",
+  "cases": [
+    {
+      "name": "warns_panic_in_result_fn",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/lib.rs",
+          "text": "pub fn parse(raw: &str) -> Result<u16, String> {\n    if raw.is_empty() {\n        panic!(\"empty port\")\n    }\n    raw.parse().map_err(|err| err.to_string())\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_err_return",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/lib.rs",
+          "text": "pub fn parse(raw: &str) -> Result<u16, String> {\n    if raw.is_empty() {\n        return Err(\"empty port\".to_string());\n    }\n    raw.parse().map_err(|err| err.to_string())\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/rust/fixtures/no_todo_or_unimplemented_in_prod.json
+++ b/rust/fixtures/no_todo_or_unimplemented_in_prod.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_todo_or_unimplemented_in_prod",
+  "cases": [
+    {
+      "name": "blocks_todo_in_src",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/lib.rs",
+          "text": "pub fn score() -> u32 {\n    todo!(\"wire scoring\")\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_todo_in_example",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "examples/sketch.rs",
+          "text": "fn main() {\n    todo!(\"demo coming soon\")\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/rust/fixtures/no_unwrap_in_prod.json
+++ b/rust/fixtures/no_unwrap_in_prod.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_unwrap_in_prod",
+  "cases": [
+    {
+      "name": "blocks_unwrap_in_src",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/config.rs",
+          "text": "pub fn port(raw: &str) -> u16 {\n    raw.parse::<u16>().unwrap()\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_error_propagation",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/config.rs",
+          "text": "pub fn port(raw: &str) -> Result<u16, std::num::ParseIntError> {\n    raw.parse::<u16>()\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/rust/fixtures/no_wildcard_imports_in_prod.json
+++ b/rust/fixtures/no_wildcard_imports_in_prod.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_wildcard_imports_in_prod",
+  "cases": [
+    {
+      "name": "warns_module_glob_import",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/lib.rs",
+          "text": "use crate::prelude::*;\n\npub fn run() {\n    execute();\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_explicit_import",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/lib.rs",
+          "text": "use crate::prelude::execute;\n\npub fn run() {\n    execute();\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/rust/fixtures/unsafe_requires_safety_comment.json
+++ b/rust/fixtures/unsafe_requires_safety_comment.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "unsafe_requires_safety_comment",
+  "cases": [
+    {
+      "name": "blocks_unsafe_without_comment",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/raw.rs",
+          "text": "pub fn read(ptr: *const u8) -> u8 {\n    unsafe { *ptr }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_safety_comment",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/raw.rs",
+          "text": "pub fn read(ptr: *const u8) -> u8 {\n    // SAFETY: caller validated that ptr is non-null and readable for one byte.\n    unsafe { *ptr }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/rust/invariants.harn
+++ b/rust/invariants.harn
@@ -1,0 +1,292 @@
+let _EVIDENCE_UNWRAP = [
+  "https://rust-lang.github.io/rust-clippy/beta/#unwrap_used",
+  "https://doc.rust-lang.org/rust-by-example/error/option_unwrap.html",
+]
+
+let _EVIDENCE_MUST_USE = [
+  "https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute",
+  "https://rust-lang.github.io/rust-clippy/beta/#must_use_candidate",
+  "https://rust-lang.github.io/rust-clippy/beta/#double_must_use",
+]
+
+let _EVIDENCE_UNSAFE_COMMENT = [
+  "https://rust-lang.github.io/rust-clippy/beta/#undocumented_unsafe_blocks",
+  "https://doc.rust-lang.org/stable/reference/unsafe-keyword.html",
+]
+
+let _EVIDENCE_ASYNC_BLOCKING = [
+  "https://docs.rs/tokio/latest/tokio/task/fn.spawn_blocking.html",
+  "https://docs.rs/tokio/latest/tokio/time/fn.sleep.html",
+  "https://rust-lang.github.io/async-book/part-guide/async-await.html",
+]
+
+let _EVIDENCE_DBG = [
+  "https://rust-lang.github.io/rust-clippy/beta/#dbg_macro",
+  "https://doc.rust-lang.org/std/macro.dbg.html",
+]
+
+let _EVIDENCE_TODO = [
+  "https://rust-lang.github.io/rust-clippy/beta/#todo",
+  "https://rust-lang.github.io/rust-clippy/beta/#unimplemented",
+  "https://doc.rust-lang.org/std/macro.todo.html",
+]
+
+let _EVIDENCE_WILDCARD_IMPORTS = [
+  "https://rust-lang.github.io/rust-clippy/beta/#wildcard_imports",
+  "https://doc.rust-lang.org/reference/items/use-declarations.html#glob-imports",
+]
+
+let _EVIDENCE_PANIC_RESULT = [
+  "https://rust-lang.github.io/rust-clippy/beta/#panic_in_result_fn",
+  "https://rust-lang.github.io/rust-clippy/beta/#missing_panics_doc",
+]
+
+let _EVIDENCE_CARGO_ADVISORIES = [
+  "https://rustsec.org/",
+  "https://embarkstudios.github.io/cargo-deny/checks/",
+  "https://doc.rust-lang.org/cargo/faq.html#why-have-cargolock-in-version-control",
+]
+
+let _EVIDENCE_FFI_SAFETY = [
+  "https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-extern.html",
+  "https://doc.rust-lang.org/reference/items/external-blocks.html",
+  "https://rust-lang.github.io/rust-clippy/beta/#missing_safety_doc",
+]
+
+fn is_rust_path(path) {
+  return path.ends_with(".rs")
+}
+
+fn is_prod_rust_path(path) {
+  return is_rust_path(path)
+    && !path.contains("tests/")
+    && !path.contains("/tests/")
+    && !path.contains("benches/")
+    && !path.contains("/benches/")
+    && !path.contains("examples/")
+    && !path.contains("/examples/")
+}
+
+fn is_rust_project_path(path) {
+  return is_rust_path(path)
+    || path.ends_with("Cargo.toml")
+    || path.ends_with("Cargo.lock")
+    || path.ends_with("deny.toml")
+    || path.contains(".github/workflows/")
+}
+
+fn rust_files(slice) {
+  return slice.files.filter({ file -> is_rust_path(file.path) })
+}
+
+fn prod_rust_files(slice) {
+  return slice.files.filter({ file -> is_prod_rust_path(file.path) })
+}
+
+fn rust_project_files(slice) {
+  return slice.files.filter({ file -> is_rust_project_path(file.path) })
+}
+
+fn scan_files(files, pattern) {
+  var findings = []
+  for file in files {
+    if regex_match(pattern, file.text, "s") != nil {
+      findings = findings
+        .push({path: file.path, pattern: pattern})
+    }
+  }
+  return findings
+}
+
+fn scan_prod(slice, pattern) {
+  return scan_files(prod_rust_files(slice), pattern)
+}
+
+fn scan_without_prod(slice, include_pattern, exclude_pattern) {
+  var findings = []
+  for file in prod_rust_files(slice) {
+    if regex_match(include_pattern, file.text, "s") != nil && regex_match(exclude_pattern, file.text, "s") == nil {
+      findings = findings
+        .push({path: file.path, pattern: include_pattern})
+    }
+  }
+  return findings
+}
+
+fn allow(rule) {
+  return {verdict: "Allow", rule: rule, findings: [], remediation: ""}
+}
+
+fn warn(rule, remediation, findings) {
+  return {verdict: "Warn", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block(rule, remediation, findings) {
+  return {verdict: "Block", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return block(rule, remediation, findings)
+}
+
+fn warn_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return warn(rule, remediation, findings)
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_UNWRAP, confidence: 0.82, source_date: "2026-04-26")
+/** Blocks bare unwrap calls in production Rust paths. */
+pub fn no_unwrap_in_prod(slice, _ctx, _repo_at_base) {
+  let findings = scan_prod(slice, r"\.(unwrap|unwrap_err)\s*\(")
+  return block_on_findings(
+    "no_unwrap_in_prod",
+    "Handle Result/Option explicitly, propagate with ?, or use expect with a specific invariant.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_MUST_USE, confidence: 0.7, source_date: "2026-04-26")
+/** Warns on public Result/Option-returning functions without a custom must_use message. */
+pub fn must_use_message_on_pub_result_option(slice, _ctx, _repo_at_base) {
+  let findings = scan_without_prod(
+    slice,
+    r"pub\s+(async\s+)?fn\s+\w+[^{;]*->\s*(Result|Option)\s*[<\(]",
+    r"#\s*\[\s*must_use\s*=",
+  )
+  return warn_on_findings(
+    "must_use_message_on_pub_result_option",
+    "Use #[must_use = \"...\"] when Result/Option's default unused warning needs domain context.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_UNSAFE_COMMENT, confidence: 0.78, source_date: "2026-04-26")
+/** Blocks unsafe blocks or impls without a preceding SAFETY comment. */
+pub fn unsafe_requires_safety_comment(slice, _ctx, _repo_at_base) {
+  let findings = scan_without_prod(
+    slice,
+    r"\bunsafe\s*(\{|impl\b)",
+    r"//\s*SAFETY:[^\n]*\n\s*unsafe\s*(\{|impl\b)",
+  )
+  return block_on_findings(
+    "unsafe_requires_safety_comment",
+    "Precede each unsafe block or unsafe impl with a // SAFETY: comment explaining the invariant.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_ASYNC_BLOCKING, confidence: 0.74, source_date: "2026-04-26")
+/** Blocks common blocking std calls inside async functions. */
+pub fn no_blocking_io_in_async(slice, _ctx, _repo_at_base) {
+  let findings = scan_prod(
+    slice,
+    r"async\s+fn\s+\w+[^{]*\{[^}]*\b(std::fs::|std::thread::sleep|std::process::Command|std::net::Tcp(Stream|Listener))",
+  )
+  return block_on_findings(
+    "no_blocking_io_in_async",
+    "Use async APIs or move blocking work to spawn_blocking/block_in_place with a bounded plan.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_DBG, confidence: 0.9, source_date: "2026-04-26")
+/** Warns when dbg! is committed to production Rust paths. */
+pub fn no_dbg_macro_in_prod(slice, _ctx, _repo_at_base) {
+  let findings = scan_prod(slice, r"\bdbg!\s*\(")
+  return warn_on_findings(
+    "no_dbg_macro_in_prod",
+    "Remove dbg! or replace it with structured tracing/logging before shipping.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_TODO, confidence: 0.88, source_date: "2026-04-26")
+/** Blocks unfinished-code macros in production Rust paths. */
+pub fn no_todo_or_unimplemented_in_prod(slice, _ctx, _repo_at_base) {
+  let findings = scan_prod(slice, r"\b(todo|unimplemented)!\s*\(")
+  return block_on_findings(
+    "no_todo_or_unimplemented_in_prod",
+    "Finish the implementation or isolate the stub to tests/examples before shipping.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_WILDCARD_IMPORTS, confidence: 0.68, source_date: "2026-04-26")
+/** Warns on module-level wildcard imports outside tests and examples. */
+pub fn no_wildcard_imports_in_prod(slice, _ctx, _repo_at_base) {
+  let findings = scan_prod(slice, r"(?m)^\s*use\s+[^;]*::\*\s*;")
+  return warn_on_findings(
+    "no_wildcard_imports_in_prod",
+    "Import the names you use explicitly, or keep wildcard imports local to tests/match-heavy code.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_PANIC_RESULT, confidence: 0.66, source_date: "2026-04-26")
+/** Warns when Result-returning functions contain direct panics. */
+pub fn no_panic_in_result_fn(slice, _ctx, _repo_at_base) {
+  let findings = scan_prod(
+    slice,
+    r"fn\s+\w+[^{;]*->\s*Result\s*[<\(][^{]*\{[^}]*\b(panic!|assert!|assert_eq!|assert_ne!)\s*\(",
+  )
+  return warn_on_findings(
+    "no_panic_in_result_fn",
+    "Return an Err or document the panic contract with a # Panics section.",
+    findings,
+  )
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_CARGO_ADVISORIES, confidence: 0.64, source_date: "2026-04-26")
+/** Blocks dependency changes that lack advisory or cargo-deny/audit evidence. */
+pub fn cargo_advisories_checked(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when Rust dependency metadata changed, such as Cargo.toml, Cargo.lock, deny.toml, or Rust CI, and the slice provides no evidence that cargo-deny, cargo-audit, RustSec, OSV, Dependabot, or equivalent advisory checks were considered. Allow pure source changes and dependency changes that add or preserve a clear advisory-check path."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: rust_project_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "cargo_advisories_checked",
+      "Run or configure cargo-deny/cargo-audit/RustSec advisory checks for dependency changes.",
+      judgement.findings,
+    )
+  }
+  return allow("cargo_advisories_checked")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_FFI_SAFETY, confidence: 0.6, source_date: "2026-04-26")
+/** Blocks unsafe public FFI boundaries that omit safety contracts. */
+pub fn ffi_boundary_safety_contract(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when a changed Rust file adds or modifies a public FFI boundary, extern block, no_mangle/export_name symbol, or public unsafe wrapper and the nearby docs/comments do not state caller safety obligations, ownership/nullability/lifetime requirements, or why the foreign signature is sound."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: rust_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "ffi_boundary_safety_contract",
+      "Document the FFI or unsafe public contract: safety, ownership, nullability, and lifetime assumptions.",
+      judgement.findings,
+    )
+  }
+  return allow("ffi_boundary_safety_contract")
+}


### PR DESCRIPTION
## Summary
- add a Rust seed predicate pack with 8 deterministic and 2 semantic invariants
- document stack assumptions, evidence sources, known false positives, and fixture conventions
- add one allow/block-or-warn fixture file for each predicate

## Validation
- jq empty rust/fixtures/*.json
- git diff --cached --check
- evidence URL check: all cited URLs returned HTTP 200
- self-review adjustment: refined the must_use predicate to require a custom must_use message because Result/Option already carry default must_use behavior

Closes #3