### PR TITLE
Add TypeScript seed predicate pack

### DIFF
--- a/typescript/README.md
+++ b/typescript/README.md
@@ -1,0 +1,59 @@
+# TypeScript Seed Predicate Pack
+
+This pack covers plain TypeScript and TSX code before framework-specific packs such as React, Next.js, or Node services add tighter local rules. It focuses on high-signal defaults for type safety, async correctness, production logging, and untrusted boundary handling.
+
+## Stack Assumptions
+
+- Files use `.ts`, `.tsx`, `.mts`, or `.cts`; config checks target `tsconfig.json`.
+- Projects use TypeScript strict mode and type-aware linting where practical.
+- Deterministic predicates operate over changed source text until Flow exposes stable TypeScript AST and tsconfig-resolution queries.
+- Semantic predicates may block only when the judge can cite a concrete changed span and the issue is not reliably expressible with simple syntax checks.
+
+## Predicate Coverage
+
+| Predicate | Mode | Verdict | Purpose |
+|---|---|---|---|
+| `no_floating_promises` | deterministic | Block | Obvious Promise-returning calls must be awaited, returned, explicitly void-marked, or handled with `.catch()`. |
+| `no_any_without_comment` | deterministic | Block | Explicit `any` requires a targeted `no-explicit-any` disable comment with a reason. |
+| `strict_null_checks_required` | deterministic | Block | Changed tsconfig files must not disable `strict` or `strictNullChecks`. |
+| `no_console_in_prod_path` | deterministic | Block | Production TypeScript paths must not ship `console.log`, `debug`, `trace`, or `info`. |
+| `exhaustive_switch` | deterministic | Warn | Switches should include explicit exhaustiveness handling. |
+| `ts_comment_suppressions_have_description` | deterministic | Block | TypeScript suppression comments need a meaningful reason, and `@ts-nocheck` is blocked. |
+| `no_non_null_assertion_in_prod_path` | deterministic | Warn | Production code should narrow nullable values instead of using postfix `!`. |
+| `no_inline_type_only_imports` | deterministic | Warn | Inline-only type imports should use top-level `import type`. |
+| `runtime_validate_external_data` | semantic | Block | External data must be runtime-validated before being trusted as a domain type. |
+| `no_hardcoded_secrets` | semantic | Block | Credentials, tokens, private keys, and production connection strings must not live in source. |
+| `no_sensitive_data_in_logs` | semantic | Block | Logs and error messages must not expose secrets or sensitive user data. |
+
+## Evidence
+
+Evidence scanned on 2026-04-26.
+
+- typescript-eslint rules: `no-floating-promises`, `no-explicit-any`, `switch-exhaustiveness-check`, `ban-ts-comment`, `no-non-null-assertion`, `no-import-type-side-effects`, and `no-unsafe-assignment`.
+- TypeScript docs: `strict`, `strictNullChecks`, `unknown`, exhaustiveness checking with `never`, and `verbatimModuleSyntax`.
+- ESLint `no-console` rule and MDN Promise `.catch()` documentation.
+- OWASP cheat sheets for input validation, logging, and secrets management.
+- GitHub secret scanning docs for hardcoded credential risk and remediation context.
+
+## Known False Positives
+
+- Regex predicates are intentionally conservative and file-scoped. A file containing both an offending pattern and an allowed pattern may be allowed until AST-level matching lands.
+- `no_floating_promises` only blocks obvious async surfaces such as `fetch`, `Promise.*`, `new Promise`, or `*Async` calls until TypeScript type information is available.
+- `strict_null_checks_required` currently blocks changed `tsconfig.json` files that turn strictness off. The intended runtime form should resolve the effective tsconfig for each touched TypeScript file.
+- `exhaustive_switch` warns on non-union switches because source text alone cannot distinguish union/enumeration switches from scalar switches.
+- `no_inline_type_only_imports` warns on all inline type imports, including mixed value/type imports; projects that prefer inline style can downgrade this predicate locally.
+- The semantic predicates must cite concrete changed spans and should stay high-threshold to avoid blocking on speculative security concerns.
+
+## Fixtures
+
+Each fixture in `fixtures/` contains one blocked or warned example and one allowed example for the corresponding predicate. The fixture shape is deliberately simple until the Flow replay harness lands:
+
+```json
+{
+  "predicate": "name",
+  "cases": [
+    {"expect": "Block", "files": [{"path": "src/file.ts", "text": "..."}]},
+    {"expect": "Allow", "files": [{"path": "src/file.ts", "text": "..."}]}
+  ]
+}
+```

--- a/typescript/fixtures/exhaustive_switch.json
+++ b/typescript/fixtures/exhaustive_switch.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "exhaustive_switch",
+  "cases": [
+    {
+      "name": "warns_switch_without_exhaustiveness_guard",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/state.ts",
+          "text": "type State = { kind: 'ready' } | { kind: 'failed' };\nexport function label(state: State) {\n  switch (state.kind) {\n    case 'ready':\n      return 'Ready';\n  }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_never_guard",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/state.ts",
+          "text": "type State = { kind: 'ready' } | { kind: 'failed' };\nexport function label(state: State) {\n  switch (state.kind) {\n    case 'ready':\n      return 'Ready';\n    case 'failed':\n      return 'Failed';\n    default: {\n      const _exhaustive: never = state;\n      return _exhaustive;\n    }\n  }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/typescript/fixtures/no_any_without_comment.json
+++ b/typescript/fixtures/no_any_without_comment.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_any_without_comment",
+  "cases": [
+    {
+      "name": "blocks_unexplained_any",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/parser.ts",
+          "text": "export function parse(raw: string): any {\n  return JSON.parse(raw);\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_targeted_disable_with_reason",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/vendor.ts",
+          "text": "// eslint-disable-next-line @typescript-eslint/no-explicit-any: legacy vendor callback type is not published\nexport type VendorCallback = (...args: any[]) => void;\n"
+        }
+      ]
+    }
+  ]
+}

--- a/typescript/fixtures/no_console_in_prod_path.json
+++ b/typescript/fixtures/no_console_in_prod_path.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_console_in_prod_path",
+  "cases": [
+    {
+      "name": "blocks_console_log_in_src",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/server/account.ts",
+          "text": "export function loadAccount(id: string) {\n  console.log('loading account', id);\n  return id;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_console_in_cli_path",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/cli/report.ts",
+          "text": "export function printReport(text: string) {\n  console.log(text);\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/typescript/fixtures/no_floating_promises.json
+++ b/typescript/fixtures/no_floating_promises.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_floating_promises",
+  "cases": [
+    {
+      "name": "blocks_unhandled_promise_statement",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/save.ts",
+          "text": "async function saveUserAsync() {\n  return writeUser();\n}\n\nsaveUserAsync();\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_awaited_promise",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/save.ts",
+          "text": "async function run() {\n  await saveUserAsync();\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/typescript/fixtures/no_hardcoded_secrets.json
+++ b/typescript/fixtures/no_hardcoded_secrets.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_hardcoded_secrets",
+  "cases": [
+    {
+      "name": "blocks_embedded_api_token",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/config.ts",
+          "text": "export const billingApiToken = 'HARDCODED_PROVIDER_TOKEN_DO_NOT_USE_12345';\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_secret_from_environment",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/config.ts",
+          "text": "export const billingApiToken = requiredEnv('BILLING_API_TOKEN');\n"
+        }
+      ]
+    }
+  ]
+}

--- a/typescript/fixtures/no_inline_type_only_imports.json
+++ b/typescript/fixtures/no_inline_type_only_imports.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_inline_type_only_imports",
+  "cases": [
+    {
+      "name": "warns_inline_only_type_import",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/types.ts",
+          "text": "import { type Account } from './models';\nexport type View = Account;\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_top_level_type_import",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/types.ts",
+          "text": "import type { Account } from './models';\nexport type View = Account;\n"
+        }
+      ]
+    }
+  ]
+}

--- a/typescript/fixtures/no_non_null_assertion_in_prod_path.json
+++ b/typescript/fixtures/no_non_null_assertion_in_prod_path.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_non_null_assertion_in_prod_path",
+  "cases": [
+    {
+      "name": "warns_non_null_assertion_in_src",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/profile.ts",
+          "text": "export function displayName(user?: { name?: string }) {\n  return user!.name!;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_optional_chaining",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/profile.ts",
+          "text": "export function displayName(user?: { name?: string }) {\n  return user?.name ?? 'Anonymous';\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/typescript/fixtures/no_sensitive_data_in_logs.json
+++ b/typescript/fixtures/no_sensitive_data_in_logs.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_sensitive_data_in_logs",
+  "cases": [
+    {
+      "name": "blocks_logging_authorization_header",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/server/auth.ts",
+          "text": "export function audit(req: Request, logger: Logger) {\n  logger.info({ authorization: req.headers.get('authorization') }, 'request auth header');\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_redacted_logging",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/server/auth.ts",
+          "text": "export function audit(req: Request, logger: Logger) {\n  logger.info({ hasAuthorization: req.headers.has('authorization') }, 'request auth header present');\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/typescript/fixtures/runtime_validate_external_data.json
+++ b/typescript/fixtures/runtime_validate_external_data.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "runtime_validate_external_data",
+  "cases": [
+    {
+      "name": "blocks_unvalidated_json_cast",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/api/profile.ts",
+          "text": "type Profile = { id: string; email: string };\nexport function parseProfile(raw: string): Profile {\n  return JSON.parse(raw) as Profile;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_schema_parse",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/api/profile.ts",
+          "text": "import { ProfileSchema } from './schema';\nexport function parseProfile(raw: string) {\n  return ProfileSchema.parse(JSON.parse(raw));\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/typescript/fixtures/strict_null_checks_required.json
+++ b/typescript/fixtures/strict_null_checks_required.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "strict_null_checks_required",
+  "cases": [
+    {
+      "name": "blocks_strict_null_checks_disabled",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "tsconfig.json",
+          "text": "{\n  \"compilerOptions\": {\n    \"strictNullChecks\": false\n  }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_strict_enabled",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "tsconfig.json",
+          "text": "{\n  \"compilerOptions\": {\n    \"strict\": true\n  }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/typescript/fixtures/ts_comment_suppressions_have_description.json
+++ b/typescript/fixtures/ts_comment_suppressions_have_description.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "ts_comment_suppressions_have_description",
+  "cases": [
+    {
+      "name": "blocks_bare_ts_ignore",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/interop.ts",
+          "text": "// @ts-ignore\nlegacyCall(42);\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_described_expect_error",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/interop.ts",
+          "text": "// @ts-expect-error: upstream package omits the overload until v3 ships\nlegacyCall(42);\n"
+        }
+      ]
+    }
+  ]
+}

--- a/typescript/invariants.harn
+++ b/typescript/invariants.harn
@@ -1,0 +1,315 @@
+let _EVIDENCE_FLOATING_PROMISES = [
+  "https://typescript-eslint.io/rules/no-floating-promises/",
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch",
+]
+
+let _EVIDENCE_NO_ANY = [
+  "https://typescript-eslint.io/rules/no-explicit-any/",
+  "https://www.typescriptlang.org/docs/handbook/2/functions.html#unknown",
+]
+
+let _EVIDENCE_STRICT_NULL = [
+  "https://www.typescriptlang.org/tsconfig/strict.html",
+  "https://www.typescriptlang.org/tsconfig/strictNullChecks.html",
+]
+
+let _EVIDENCE_NO_CONSOLE = [
+  "https://eslint.org/docs/latest/rules/no-console",
+  "https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html",
+]
+
+let _EVIDENCE_EXHAUSTIVE_SWITCH = [
+  "https://typescript-eslint.io/rules/switch-exhaustiveness-check/",
+  "https://www.typescriptlang.org/docs/handbook/2/narrowing.html#exhaustiveness-checking",
+]
+
+let _EVIDENCE_TS_COMMENTS = [
+  "https://typescript-eslint.io/rules/ban-ts-comment/",
+  "https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-9.html#ts-expect-error-comments",
+]
+
+let _EVIDENCE_NON_NULL = [
+  "https://typescript-eslint.io/rules/no-non-null-assertion/",
+  "https://www.typescriptlang.org/tsconfig/strictNullChecks.html",
+]
+
+let _EVIDENCE_TYPE_IMPORTS = [
+  "https://typescript-eslint.io/rules/no-import-type-side-effects/",
+  "https://www.typescriptlang.org/tsconfig/verbatimModuleSyntax.html",
+]
+
+let _EVIDENCE_RUNTIME_VALIDATION = [
+  "https://typescript-eslint.io/rules/no-unsafe-assignment/",
+  "https://cheatsheetseries.owasp.org/cheatsheets/Input_Validation_Cheat_Sheet.html",
+]
+
+let _EVIDENCE_SECRETS = [
+  "https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html",
+  "https://docs.github.com/code-security/secret-scanning/about-secret-scanning",
+]
+
+let _EVIDENCE_SENSITIVE_LOGS = [
+  "https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html",
+  "https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html",
+]
+
+fn typescript_files(slice) {
+  return slice.files
+    .filter(
+    { file -> file.path.ends_with(".ts")
+    || file.path.ends_with(".tsx")
+    || file.path.ends_with(".mts")
+    || file.path.ends_with(".cts") },
+  )
+}
+
+fn tsconfig_files(slice) {
+  return slice.files.filter({ file -> file.path.ends_with("tsconfig.json") })
+}
+
+fn is_test_path(path) {
+  return contains(path, ".test.")
+    || contains(path, ".spec.")
+    || contains(path, "/test/")
+    || contains(path, "/tests/")
+    || contains(path, "__tests__")
+}
+
+fn is_cli_path(path) {
+  return contains(path, "/cli/")
+    || contains(path, "/bin/")
+    || path.ends_with(".cli.ts")
+    || path.ends_with(".cli.tsx")
+}
+
+fn production_ts_files(slice) {
+  return typescript_files(slice).filter({ file -> !is_test_path(file.path) && !is_cli_path(file.path) })
+}
+
+fn scan_files(files, pattern) {
+  var findings = []
+  for file in files {
+    if regex_match(pattern, file.text, "s") != nil {
+      findings = findings.push({path: file.path, pattern: pattern})
+    }
+  }
+  return findings
+}
+
+fn scan_files_if(files, predicate) {
+  var findings = []
+  for file in files {
+    if predicate(file.text) {
+      findings = findings.push({path: file.path})
+    }
+  }
+  return findings
+}
+
+fn scan_files_without(files, include_pattern, exclude_pattern) {
+  return scan_files_if(
+    files,
+    { text -> regex_match(include_pattern, text, "s") != nil && regex_match(exclude_pattern, text, "s") == nil },
+  )
+}
+
+fn allow(rule) {
+  return {verdict: "Allow", rule: rule, findings: [], remediation: ""}
+}
+
+fn warn(rule, remediation, findings) {
+  return {verdict: "Warn", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block(rule, remediation, findings) {
+  return {verdict: "Block", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return block(rule, remediation, findings)
+}
+
+fn warn_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return warn(rule, remediation, findings)
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_FLOATING_PROMISES, confidence: 0.82, source_date: "2026-04-26")
+/**
+ * Blocks Promise-returning calls that are started as bare statements without await, return, void, or catch.
+ */
+pub fn no_floating_promises(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_without(
+    typescript_files(slice),
+    r"(?m)^\s*((fetch|[A-Za-z_$][A-Za-z0-9_$]*Async|[A-Za-z_$][A-Za-z0-9_$]*\.[A-Za-z_$][A-Za-z0-9_$]*Async|Promise\.[A-Za-z_$][A-Za-z0-9_$]*)\s*\([^;\n]*\)|new\s+Promise\s*\([^;\n]*\))\s*;",
+    r"\b(await|return|void)\s+[A-Za-z_$]|\.\s*catch\s*\(",
+  )
+  return block_on_findings(
+    "no_floating_promises",
+    "Await, return, void-mark, or attach .catch() to obvious Promise-returning calls.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_NO_ANY, confidence: 0.8, source_date: "2026-04-26")
+/** Blocks explicit any unless an adjacent eslint disable comment explains why it is needed. */
+pub fn no_any_without_comment(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_without(
+    typescript_files(slice),
+    r"(:\s*any\b|<\s*any\s*>|\bas\s+any\b|Array\s*<\s*any\s*>)",
+    r"@typescript-eslint/no-explicit-any:\s*.{10,}",
+  )
+  return block_on_findings(
+    "no_any_without_comment",
+    "Replace any with unknown or add a targeted no-explicit-any disable comment with a reason.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_STRICT_NULL, confidence: 0.86, source_date: "2026-04-26")
+/** Blocks tsconfig edits that disable strict mode or strict null checking. */
+pub fn strict_null_checks_required(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(tsconfig_files(slice), "\"(strict|strictNullChecks)\"\\s*:\\s*false")
+  return block_on_findings(
+    "strict_null_checks_required",
+    "Keep strict and strictNullChecks enabled for TypeScript code.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_NO_CONSOLE, confidence: 0.78, source_date: "2026-04-26")
+/** Blocks console debugging calls in production TypeScript paths. */
+pub fn no_console_in_prod_path(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(production_ts_files(slice), r"\bconsole\.(log|debug|trace|info)\s*\(")
+  return block_on_findings(
+    "no_console_in_prod_path",
+    "Use the project logger or remove console debugging from production code.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_EXHAUSTIVE_SWITCH, confidence: 0.72, source_date: "2026-04-26")
+/**
+ * Warns when switch statements lack a default, assertNever, or satisfies-never exhaustiveness guard.
+ */
+pub fn exhaustive_switch(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_without(
+    typescript_files(slice),
+    r"switch\s*\([^)]+\)\s*\{",
+    r"(default\s*:|assertNever\s*\(|satisfies\s+never|:\s*never\s*=)",
+  )
+  return warn_on_findings(
+    "exhaustive_switch",
+    "Handle every union member explicitly or add an assertNever/satisfies never exhaustiveness guard.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_TS_COMMENTS, confidence: 0.84, source_date: "2026-04-26")
+/** Blocks TypeScript suppression comments that omit a meaningful description. */
+pub fn ts_comment_suppressions_have_description(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_without(
+    typescript_files(slice),
+    r"@ts-(ignore|expect-error|nocheck)",
+    r"@ts-(ignore|expect-error):\s*.{10,}",
+  )
+  return block_on_findings(
+    "ts_comment_suppressions_have_description",
+    "Prefer fixing the type; if suppression is required, use @ts-expect-error with a clear reason.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_NON_NULL, confidence: 0.76, source_date: "2026-04-26")
+/** Warns on non-null assertions in production TypeScript paths. */
+pub fn no_non_null_assertion_in_prod_path(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(production_ts_files(slice), r"[A-Za-z_$][A-Za-z0-9_$]*!\.")
+  return warn_on_findings(
+    "no_non_null_assertion_in_prod_path",
+    "Narrow nullable values with guards, optional chaining, or explicit error handling instead of !.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_TYPE_IMPORTS, confidence: 0.74, source_date: "2026-04-26")
+/** Warns on inline-only type imports that may leave runtime side-effect imports. */
+pub fn no_inline_type_only_imports(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(typescript_files(slice), r"import\s*\{\s*type\s+[A-Za-z_$][^}]*\}\s*from")
+  return warn_on_findings(
+    "no_inline_type_only_imports",
+    "Use top-level import type for imports that only bring in types.",
+    findings,
+  )
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_RUNTIME_VALIDATION, confidence: 0.66, source_date: "2026-04-26")
+/** Blocks external data being trusted as domain types without runtime validation. */
+pub fn runtime_validate_external_data(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed TypeScript treats untrusted external data from JSON.parse, request bodies, process.env, fetch responses, localStorage, or message events as a specific domain type without runtime validation, schema parsing, or explicit narrowing."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: typescript_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "runtime_validate_external_data",
+      "Validate external data at runtime before trusting it as a TypeScript domain type.",
+      judgement.findings,
+    )
+  }
+  return allow("runtime_validate_external_data")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_SECRETS, confidence: 0.69, source_date: "2026-04-26")
+/** Blocks hardcoded credentials, tokens, and private keys in TypeScript source. */
+pub fn no_hardcoded_secrets(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed TypeScript embeds a credential, API key, token, private key, signing secret, password, or production connection string instead of reading it from a managed secret source."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: typescript_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "no_hardcoded_secrets",
+      "Move credentials to a secret manager or scoped environment variable and rotate exposed values.",
+      judgement.findings,
+    )
+  }
+  return allow("no_hardcoded_secrets")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_SENSITIVE_LOGS, confidence: 0.64, source_date: "2026-04-26")
+/** Blocks logging of secrets, credentials, tokens, or sensitive user data. */
+pub fn no_sensitive_data_in_logs(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed TypeScript logs secrets, credentials, session identifiers, access tokens, authorization headers, passwords, or sensitive personal data to console, logger, telemetry, or thrown error messages."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: typescript_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "no_sensitive_data_in_logs",
+      "Remove sensitive values from logs and use redaction or stable identifiers.",
+      judgement.findings,
+    )
+  }
+  return allow("no_sensitive_data_in_logs")
+}


### PR DESCRIPTION
## Summary
- Adds `typescript/invariants.harn` with 8 deterministic predicates and 3 semantic predicates for the TypeScript v0 seed pack.
- Adds TypeScript pack README covering rationale, stack assumptions, evidence, fixture format, and known gaps.
- Adds one allow/block-or-warn fixture JSON file per predicate.

## Verification
- `/Users/ksinder/projects/harn/target/release/harn fmt --check typescript/invariants.harn`
- `/Users/ksinder/projects/harn/target/release/harn check typescript/invariants.harn`
- `jq -s -e ... typescript/fixtures/*.json` fixture shape check
- Evidence URL check: all `@archivist` URLs returned HTTP 200

Closes #5