### PR TITLE
Seed Swift canon predicate pack

### DIFF
--- a/swift/README.md
+++ b/swift/README.md
@@ -1,0 +1,60 @@
+# Swift Seed Predicate Pack
+
+This pack covers Swift application and package code with an emphasis on crash prevention, UI responsiveness, ARC memory safety, and Swift 6 data-race safety. The v0 rules deliberately prefer simple source-text predicates where a failure mode is concrete, and semantic predicates where Swift syntax and framework lifetime rules are too contextual for regex alone.
+
+## Stack Assumptions
+
+- Files use the `.swift` extension and target Swift 5.10 through Swift 6.x.
+- Apple-platform code may use SwiftUI, UIKit, AppKit, Combine, Swift Testing, XCTest, Dispatch, and OSLog.
+- Deterministic predicates run over changed production Swift source text. `Tests`, `TestSupport`, and preview files are excluded from production-only rules.
+- Semantic predicates use `ctx.semantic_judge(...)` and must cite concrete changed spans before blocking.
+- The pack is a seed canon, not a replacement for SwiftSyntax, SwiftLint, the Swift compiler, Xcode diagnostics, or runtime profiling.
+
+## Predicate Coverage
+
+| Predicate | Mode | Verdict | Purpose |
+|---|---|---|---|
+| `no_force_unwrap` | deterministic | Block | Avoid production crashes from force-unwrapping optionals. |
+| `no_force_try` | deterministic | Block | Avoid runtime traps from `try!`. |
+| `no_force_cast` | deterministic | Block | Avoid runtime traps from `as!`. |
+| `no_dispatch_main_sync` | deterministic | Block | Prevent main-queue deadlocks and UI hangs. |
+| `prefer_structured_concurrency` | deterministic | Warn | Prefer Swift concurrency primitives over new low-level queue/thread work. |
+| `main_actor_on_ui_observable_state` | deterministic | Warn | UI-bound observable state should declare main-actor isolation. |
+| `unchecked_sendable_requires_rationale` | deterministic | Warn | `@unchecked Sendable` requires a local synchronization rationale. |
+| `no_top_level_mutable_state` | deterministic | Warn | Top-level mutable state is risky under Swift 6 concurrency. |
+| `no_print_in_production` | deterministic | Warn | Production diagnostics should use OSLog or project logging. |
+| `no_retain_cycle_in_escaping_closure` | semantic | Block | Escaping closures that capture `self` must avoid retain cycles. |
+| `ui_state_mutations_stay_main_actor` | semantic | Block | UI and observable state mutations must stay main-actor isolated. |
+| `sendable_cross_actor_boundaries_are_safe` | semantic | Block | Mutable non-Sendable state must not cross concurrency domains unsafely. |
+
+## Evidence
+
+Evidence scanned on 2026-04-26.
+
+- Swift book: optional chaining vs forced unwrapping, error handling, type casting, concurrency, Sendable, constants and variables, and ARC closure capture lists.
+- Swift.org: Swift 6 announcement and package ecosystem guidance for compile-time data-race safety.
+- Apple Developer Documentation: app responsiveness, DispatchQueue behavior, Sendable, and unified logging with `Logger`.
+- SwiftLint rule docs: `force_unwrapping`, `force_try`, `force_cast`, and `implicitly_unwrapped_optional` behavior as widely adopted ecosystem lint precedent.
+- Swift Forums: current discussion on accidental retain cycles from strong closure captures.
+
+## Known False Positives
+
+- `no_force_unwrap` is source-text based and can flag rare intentional force unwraps or implicitly unwrapped optional declarations outside recognized test/preview paths; it may miss unwraps at the end of a line until SwiftSyntax-backed matching exists.
+- `prefer_structured_concurrency` warns on any new Dispatch, OperationQueue, Thread, or pthread usage, including legitimate low-level adapters.
+- `main_actor_on_ui_observable_state` warns at file granularity when a UI-facing file has observable state but no `@MainActor`; helper-only files may need a local suppression once suppressions exist.
+- `no_top_level_mutable_state` treats unindented `var` declarations as top-level state; generated code should be excluded by repository policy.
+- The semantic predicates depend on a cheap judge and should block only when the changed span clearly introduces the risk.
+
+## Fixtures
+
+Each fixture in `fixtures/` contains at least one blocked or warned production example and one allowed example for the corresponding predicate:
+
+```json
+{
+  "predicate": "name",
+  "cases": [
+    {"expect": "Block", "files": [{"path": "Sources/App/File.swift", "text": "..."}]},
+    {"expect": "Allow", "files": [{"path": "Sources/App/File.swift", "text": "..."}]}
+  ]
+}
+```

--- a/swift/fixtures/main_actor_on_ui_observable_state.json
+++ b/swift/fixtures/main_actor_on_ui_observable_state.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "main_actor_on_ui_observable_state",
+  "cases": [
+    {
+      "name": "warns_observable_view_model_without_main_actor",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "Sources/App/ProfileViewModel.swift",
+          "text": "import SwiftUI\n\nfinal class ProfileViewModel: ObservableObject {\n  @Published var name = \"\"\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_main_actor_view_model",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "Sources/App/ProfileViewModel.swift",
+          "text": "import SwiftUI\n\n@MainActor\nfinal class ProfileViewModel: ObservableObject {\n  @Published var name = \"\"\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/swift/fixtures/no_dispatch_main_sync.json
+++ b/swift/fixtures/no_dispatch_main_sync.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_dispatch_main_sync",
+  "cases": [
+    {
+      "name": "blocks_main_sync",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "Sources/App/ImageCache.swift",
+          "text": "func refreshBadge() {\n  DispatchQueue.main.sync {\n    badgeView.setNeedsDisplay()\n  }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_main_actor_run",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "Sources/App/ImageCache.swift",
+          "text": "func refreshBadge() async {\n  await MainActor.run {\n    badgeView.setNeedsDisplay()\n  }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/swift/fixtures/no_force_cast.json
+++ b/swift/fixtures/no_force_cast.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_force_cast",
+  "cases": [
+    {
+      "name": "blocks_force_cast",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "Sources/App/Router.swift",
+          "text": "func route(_ value: Any) {\n  let screen = value as! ProfileScreen\n  screen.open()\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_conditional_cast",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "Sources/App/Router.swift",
+          "text": "func route(_ value: Any) {\n  guard let screen = value as? ProfileScreen else { return }\n  screen.open()\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/swift/fixtures/no_force_try.json
+++ b/swift/fixtures/no_force_try.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_force_try",
+  "cases": [
+    {
+      "name": "blocks_force_try",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "Sources/App/Decoder.swift",
+          "text": "func loadProfile(_ data: Data) -> Profile {\n  return try! JSONDecoder().decode(Profile.self, from: data)\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_propagating_throws",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "Sources/App/Decoder.swift",
+          "text": "func loadProfile(_ data: Data) throws -> Profile {\n  return try JSONDecoder().decode(Profile.self, from: data)\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/swift/fixtures/no_force_unwrap.json
+++ b/swift/fixtures/no_force_unwrap.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_force_unwrap",
+  "cases": [
+    {
+      "name": "blocks_production_force_unwrap",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "Sources/App/ProfileViewModel.swift",
+          "text": "final class ProfileViewModel {\n  func title(for user: User?) -> String {\n    return user!.name\n  }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_optional_binding",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "Sources/App/ProfileViewModel.swift",
+          "text": "final class ProfileViewModel {\n  func title(for user: User?) -> String {\n    guard let user else { return \"Unknown\" }\n    return user.name\n  }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/swift/fixtures/no_print_in_production.json
+++ b/swift/fixtures/no_print_in_production.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_print_in_production",
+  "cases": [
+    {
+      "name": "warns_print",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "Sources/App/SyncService.swift",
+          "text": "func sync() {\n  print(\"starting sync\")\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_logger",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "Sources/App/SyncService.swift",
+          "text": "import OSLog\n\nprivate let logger = Logger(subsystem: \"com.example.app\", category: \"sync\")\n\nfunc sync() {\n  logger.info(\"starting sync\")\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/swift/fixtures/no_retain_cycle_in_escaping_closure.json
+++ b/swift/fixtures/no_retain_cycle_in_escaping_closure.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_retain_cycle_in_escaping_closure",
+  "cases": [
+    {
+      "name": "blocks_timer_closure_capturing_self",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "Sources/App/Poller.swift",
+          "text": "final class Poller {\n  private var timer: Timer?\n\n  func start() {\n    timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in\n      self.refresh()\n    }\n  }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_weak_self_capture",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "Sources/App/Poller.swift",
+          "text": "final class Poller {\n  private var timer: Timer?\n\n  func start() {\n    timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in\n      self?.refresh()\n    }\n  }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/swift/fixtures/no_top_level_mutable_state.json
+++ b/swift/fixtures/no_top_level_mutable_state.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_top_level_mutable_state",
+  "cases": [
+    {
+      "name": "warns_top_level_var",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "Sources/App/Environment.swift",
+          "text": "var currentEnvironment = Environment.production\n\nstruct Environment {\n  static let production = Environment()\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_let_constant",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "Sources/App/Environment.swift",
+          "text": "let currentEnvironment = Environment.production\n\nstruct Environment {\n  static let production = Environment()\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/swift/fixtures/prefer_structured_concurrency.json
+++ b/swift/fixtures/prefer_structured_concurrency.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "prefer_structured_concurrency",
+  "cases": [
+    {
+      "name": "warns_on_new_dispatch_queue",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "Sources/App/SearchService.swift",
+          "text": "func refresh() {\n  DispatchQueue.global().async {\n    self.fetch()\n  }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_task",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "Sources/App/SearchService.swift",
+          "text": "func refresh() {\n  Task {\n    await fetch()\n  }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/swift/fixtures/sendable_cross_actor_boundaries_are_safe.json
+++ b/swift/fixtures/sendable_cross_actor_boundaries_are_safe.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "sendable_cross_actor_boundaries_are_safe",
+  "cases": [
+    {
+      "name": "blocks_mutable_class_shared_into_detached_task",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "Sources/App/Accumulator.swift",
+          "text": "final class Accumulator {\n  var values: [Int] = []\n}\n\nfunc start(_ accumulator: Accumulator) {\n  Task.detached {\n    accumulator.values.append(1)\n  }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_actor_isolated_state",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "Sources/App/Accumulator.swift",
+          "text": "actor Accumulator {\n  private var values: [Int] = []\n\n  func append(_ value: Int) {\n    values.append(value)\n  }\n}\n\nfunc start(_ accumulator: Accumulator) {\n  Task {\n    await accumulator.append(1)\n  }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/swift/fixtures/ui_state_mutations_stay_main_actor.json
+++ b/swift/fixtures/ui_state_mutations_stay_main_actor.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "ui_state_mutations_stay_main_actor",
+  "cases": [
+    {
+      "name": "blocks_background_ui_mutation",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "Sources/App/ProfileViewModel.swift",
+          "text": "import SwiftUI\n\nfinal class ProfileViewModel: ObservableObject {\n  @Published var name = \"\"\n\n  func load() {\n    Task.detached {\n      self.name = await fetchName()\n    }\n  }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_main_actor_hop",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "Sources/App/ProfileViewModel.swift",
+          "text": "import SwiftUI\n\n@MainActor\nfinal class ProfileViewModel: ObservableObject {\n  @Published var name = \"\"\n\n  func load() {\n    Task {\n      let value = await fetchName()\n      self.name = value\n    }\n  }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/swift/fixtures/unchecked_sendable_requires_rationale.json
+++ b/swift/fixtures/unchecked_sendable_requires_rationale.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "unchecked_sendable_requires_rationale",
+  "cases": [
+    {
+      "name": "warns_unchecked_sendable_without_safety_comment",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "Sources/App/SharedCache.swift",
+          "text": "final class SharedCache: @unchecked Sendable {\n  private var values: [String: Data] = [:]\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_safety_rationale",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "Sources/App/SharedCache.swift",
+          "text": "final class SharedCache: @unchecked Sendable {\n  // SAFETY: all access to values is guarded by lock.\n  private let lock = NSLock()\n  private var values: [String: Data] = [:]\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/swift/invariants.harn
+++ b/swift/invariants.harn
@@ -1,0 +1,290 @@
+let _EVIDENCE_OPTIONAL_SAFETY = [
+  "https://github.com/swiftlang/swift-book/blob/main/TSPL.docc/LanguageGuide/OptionalChaining.md",
+  "https://realm.github.io/SwiftLint/force_unwrapping.html",
+  "https://realm.github.io/SwiftLint/implicitly_unwrapped_optional.html",
+]
+
+let _EVIDENCE_FORCE_ERROR_HANDLING = [
+  "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/errorhandling/",
+  "https://realm.github.io/SwiftLint/force_try.html",
+]
+
+let _EVIDENCE_FORCE_CASTING = [
+  "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/typecasting/",
+  "https://realm.github.io/SwiftLint/force_cast.html",
+]
+
+let _EVIDENCE_UI_MAIN_ACTOR = [
+  "https://developer.apple.com/documentation/xcode/improving-app-responsiveness",
+  "https://docs.swift.org/swift-book/documentation/the-swift-programming-language/concurrency/",
+]
+
+let _EVIDENCE_STRUCTURED_CONCURRENCY = [
+  "https://www.swift.org/blog/announcing-swift-6/",
+  "https://developer.apple.com/documentation/dispatch/dispatchqueue",
+  "https://developer.apple.com/documentation/xcode/improving-app-responsiveness",
+]
+
+let _EVIDENCE_SENDABLE = [
+  "https://developer.apple.com/documentation/Swift/Sendable",
+  "https://github.com/swiftlang/swift-book/blob/main/TSPL.docc/LanguageGuide/Concurrency.md",
+  "https://www.swift.org/blog/ready-for-swift-6/",
+]
+
+let _EVIDENCE_MUTABILITY = [
+  "https://github.com/swiftlang/swift-book/blob/main/TSPL.docc/LanguageGuide/TheBasics.md",
+  "https://developer.apple.com/documentation/Swift/Sendable",
+  "https://www.swift.org/blog/ready-for-swift-6/",
+]
+
+let _EVIDENCE_LOGGING = [
+  "https://developer.apple.com/documentation/os/logging",
+  "https://developer.apple.com/documentation/os/generating-log-messages-from-your-code",
+]
+
+let _EVIDENCE_ARC_CLOSURES = [
+  "https://github.com/swiftlang/swift-book/blob/main/TSPL.docc/LanguageGuide/AutomaticReferenceCounting.md",
+  "https://forums.swift.org/t/long-term-solution-for-accidental-retain-cycles-from-strong-references-in-closures/77201",
+]
+
+fn swift_files(slice) {
+  return slice.files.filter({ file -> file.path.ends_with(".swift") })
+}
+
+fn production_swift_files(slice) {
+  return swift_files(slice)
+    .filter(
+    { file -> !contains(file.path, "/Tests/")
+    && !contains(file.path, "/TestSupport/")
+    && !file.path.ends_with("Tests.swift")
+    && !file.path.ends_with("Preview.swift")
+    && !file.path.ends_with("Previews.swift") },
+  )
+}
+
+fn scan_swift(slice, pattern) {
+  var findings = []
+  for file in production_swift_files(slice) {
+    if regex_match(pattern, file.text, "s") != nil {
+      findings = findings.push({path: file.path, pattern: pattern})
+    }
+  }
+  return findings
+}
+
+fn scan_swift_if(slice, predicate) {
+  var findings = []
+  for file in production_swift_files(slice) {
+    if predicate(file.text) {
+      findings = findings.push({path: file.path})
+    }
+  }
+  return findings
+}
+
+fn allow(rule) {
+  return {verdict: "Allow", rule: rule, findings: [], remediation: ""}
+}
+
+fn warn(rule, remediation, findings) {
+  return {verdict: "Warn", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block(rule, remediation, findings) {
+  return {verdict: "Block", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return block(rule, remediation, findings)
+}
+
+fn warn_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return warn(rule, remediation, findings)
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_OPTIONAL_SAFETY, confidence: 0.78, source_date: "2026-04-26")
+/** Blocks force-unwrapping optionals in production Swift sources. */
+pub fn no_force_unwrap(slice, _ctx, _repo_at_base) {
+  let findings = scan_swift(slice, r"([A-Za-z_][A-Za-z0-9_]*\.)?[A-Za-z_][A-Za-z0-9_]*\s*![\.\[\)\]\}\,;]")
+  return block_on_findings(
+    "no_force_unwrap",
+    "Use optional binding, guard let, nil coalescing, or optional chaining instead of force unwrap.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_FORCE_ERROR_HANDLING, confidence: 0.9, source_date: "2026-04-26")
+/** Blocks force-try in production Swift sources. */
+pub fn no_force_try(slice, _ctx, _repo_at_base) {
+  let findings = scan_swift(slice, r"\btry\s*!")
+  return block_on_findings(
+    "no_force_try",
+    "Handle thrown errors with do/catch, try?, or by propagating throws.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_FORCE_CASTING, confidence: 0.88, source_date: "2026-04-26")
+/** Blocks force-casting in production Swift sources. */
+pub fn no_force_cast(slice, _ctx, _repo_at_base) {
+  let findings = scan_swift(slice, r"\bas\s*!")
+  return block_on_findings(
+    "no_force_cast",
+    "Use as?, pattern matching, or a typed API boundary instead of force cast.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_UI_MAIN_ACTOR, confidence: 0.83, source_date: "2026-04-26")
+/** Blocks synchronous dispatch to the main queue. */
+pub fn no_dispatch_main_sync(slice, _ctx, _repo_at_base) {
+  let findings = scan_swift(slice, r"DispatchQueue\s*\.\s*main\s*\.\s*sync\s*(\(|\{)")
+  return block_on_findings(
+    "no_dispatch_main_sync",
+    "Never call DispatchQueue.main.sync; use @MainActor, MainActor.run, or async dispatch.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_STRUCTURED_CONCURRENCY, confidence: 0.72, source_date: "2026-04-26")
+/** Warns on new low-level concurrency primitives in production Swift sources. */
+pub fn prefer_structured_concurrency(slice, _ctx, _repo_at_base) {
+  let findings = scan_swift(slice, r"\b(DispatchQueue|DispatchWorkItem|OperationQueue|Thread|pthread_)\b")
+  return warn_on_findings(
+    "prefer_structured_concurrency",
+    "Prefer async/await, Task, actors, or AsyncSequence unless low-level scheduling is required.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_UI_MAIN_ACTOR, confidence: 0.69, source_date: "2026-04-26")
+/** Warns when UI-facing observable state is not explicitly main-actor isolated. */
+pub fn main_actor_on_ui_observable_state(slice, _ctx, _repo_at_base) {
+  let findings = scan_swift_if(
+    slice,
+    { text -> (contains(text, "import SwiftUI") || contains(text, "import UIKit")
+    || contains(text, "import AppKit"))
+    && (contains(text, "ObservableObject") || contains(text, "@Observable")
+    || regex_match(r"class\s+\w*(ViewModel|Controller)\b", text, "s") != nil)
+    && !contains(text, "@MainActor") },
+  )
+  return warn_on_findings(
+    "main_actor_on_ui_observable_state",
+    "Mark UI-bound observable state @MainActor or document the non-main actor isolation.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_SENDABLE, confidence: 0.76, source_date: "2026-04-26")
+/** Warns when unchecked Sendable lacks a local safety rationale. */
+pub fn unchecked_sendable_requires_rationale(slice, _ctx, _repo_at_base) {
+  let findings = scan_swift_if(
+    slice,
+    { text -> contains(text, "@unchecked Sendable") && !contains(text, "SAFETY:") },
+  )
+  return warn_on_findings(
+    "unchecked_sendable_requires_rationale",
+    "Add a SAFETY comment explaining synchronization before using @unchecked Sendable.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_MUTABILITY, confidence: 0.67, source_date: "2026-04-26")
+/** Warns on top-level mutable state in production Swift sources. */
+pub fn no_top_level_mutable_state(slice, _ctx, _repo_at_base) {
+  let findings = scan_swift(
+    slice,
+    r"(?m)^(public\s+|internal\s+|private\s+|fileprivate\s+|open\s+)?(static\s+)?var\s+\w+\s*[:=]",
+  )
+  return warn_on_findings(
+    "no_top_level_mutable_state",
+    "Prefer let constants, actor-isolated state, or scoped mutable storage over top-level var.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_LOGGING, confidence: 0.71, source_date: "2026-04-26")
+/** Warns on ad hoc console output in production Swift sources. */
+pub fn no_print_in_production(slice, _ctx, _repo_at_base) {
+  let findings = scan_swift(slice, r"\b(print|debugPrint|dump)\s*\(")
+  return warn_on_findings(
+    "no_print_in_production",
+    "Use os.Logger or the project logger instead of print/debugPrint/dump in production code.",
+    findings,
+  )
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_ARC_CLOSURES, confidence: 0.66, source_date: "2026-04-26")
+/** Blocks likely retain cycles from escaping closures that capture self strongly. */
+pub fn no_retain_cycle_in_escaping_closure(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when production Swift adds a stored, escaping, notification, Combine, delegate, timer, task, or completion closure that captures self strongly and can outlive the caller, and the closure lacks an intentional weak/unowned capture or lifecycle invalidation."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: production_swift_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "no_retain_cycle_in_escaping_closure",
+      "Use [weak self] or [unowned self], or prove the closure cannot outlive self.",
+      judgement.findings,
+    )
+  }
+  return allow("no_retain_cycle_in_escaping_closure")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_UI_MAIN_ACTOR, confidence: 0.64, source_date: "2026-04-26")
+/** Blocks UI state mutation from non-main actor callbacks or tasks. */
+pub fn ui_state_mutations_stay_main_actor(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed Swift code mutates UIKit, AppKit, SwiftUI, @Published, @Observable, or view-model state from a background callback, detached task, completion handler, or nonisolated async context without @MainActor, MainActor.run, or another explicit main-actor hop."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: production_swift_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "ui_state_mutations_stay_main_actor",
+      "Move UI-bound mutation behind @MainActor or an explicit MainActor.run hop.",
+      judgement.findings,
+    )
+  }
+  return allow("ui_state_mutations_stay_main_actor")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_SENDABLE, confidence: 0.62, source_date: "2026-04-26")
+/** Blocks unsafe cross-concurrency sharing that Swift 6 sendability should protect. */
+pub fn sendable_cross_actor_boundaries_are_safe(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed Swift code sends mutable non-Sendable reference state across actor, Task, detached task, async let, or task-group boundaries without actor isolation, locking, value copying, or a justified Sendable conformance."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: production_swift_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "sendable_cross_actor_boundaries_are_safe",
+      "Isolate mutable state to an actor, copy values, synchronize access, or add justified Sendable conformance.",
+      judgement.findings,
+    )
+  }
+  return allow("sendable_cross_actor_boundaries_are_safe")
+}


### PR DESCRIPTION
## Summary
- add the Swift v0 seed predicate pack with 9 deterministic predicates and 3 semantic predicates
- document stack assumptions, evidence sources, known gaps, and fixture format
- add allow/block or allow/warn fixtures for every predicate

## Verification
- jq empty swift/fixtures/*.json
- harn fmt swift/invariants.harn
- harn check . (passes with existing design-stage @archivist unknown-attribute warnings)
- harn lint .
- deterministic fixture smoke scripts
- evidence URL HEAD checks

Closes #4