### PR TITLE
Added SQL seed predicate pack

### DIFF
--- a/sql/README.md
+++ b/sql/README.md
@@ -1,0 +1,20 @@
+SQL Seed Predicate Pack (v0)
+
+This pack defines basic SQL safety and style rules.
+
+## RULES
+- AVOID SELECT * for clarity and performance
+- USE EXPLICIT JOINS instead of COMMA JOINS
+- Prevent SQL injection via parameterized queries
+- Index foreign key columns
+
+## Fixtures
+- fixtures/allow.sql -> example that should pass
+- fixtures/block.sql -> example that should blocked
+
+## Why
+Improves performance, security, and maintainability
+
+## Sources (evidence)
+- postgre SQL documentation (SELECT, JOINS, Indexes)
+- OWASP SQL Injection Prevention cheat sheet

--- a/sql/fixtures/allow.sql
+++ b/sql/fixtures/allow.sql
@@ -1,0 +1,5 @@
+SELECT id,name FROM users;
+
+SELECT o.id,u.name
+FROM orders o 
+INNER JOIN users u ON o.user_id = u.user_id

--- a/sql/fixtures/block.sql
+++ b/sql/fixtures/block.sql
@@ -1,0 +1,3 @@
+SELECT * FROM users;
+
+SELECT * FROM u,o WHERE u.user_id = o.user_id

--- a/sql/invariants.harn
+++ b/sql/invariants.harn
@@ -1,0 +1,11 @@
+no_select_star:
+  description: Avoid using SELECT * for better performance and clarity.
+
+explicit_join_type:
+  description: Use explicit JOIN syntax instead of comma joins.
+
+parameterized_queries_only:
+  description: Prevent SQL injection by using parameterized queries.
+
+index_on_fk:
+  description: Foreign key columns should be indexed.


### PR DESCRIPTION
## What
- Added initial SQL seed predicate pack under `sql/`
- Included 4 predicates:
  - no_select_star
  - explicit_join_type
  - parameterized_queries_only
  - index_on_fk
- Added fixtures:
  - allow.sql (valid queries)
  - block.sql (invalid queries)
- Added README with rationale and sources

## Why
- Provides a minimal v0 SQL pack aligned with CONTRIBUTING guidelines
- Demonstrates SQL safety, clarity, and best practices

## Notes
- Kept scope small and focused
- Examples are simple and easy to understand