### PR TITLE
Add Python seed predicate pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ See the Harn Flow design docs for the full predicate language spec.
 ## Packs
 
 - [Harn](./harn/) — v0 draft predicates for `.harn` scripts, Flow workflows, and agent-facing Harn modules.
+- [Python](./python/) — v0 draft predicates for Python application and library code.
 
 ## Status
 

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,58 @@
+# Python Seed Predicate Pack
+
+This pack covers general-purpose Python application and library code. It is intentionally focused on mistakes that are cheap to detect in review slices and have a clear operational or security cost: swallowed exceptions, shared mutable defaults, leaked debug output, unsafe dynamic execution, unclosed files, shell injection, production asserts, SQL injection, and hardcoded secrets.
+
+## Stack Assumptions
+
+- Files use the `.py` extension and target modern Python 3.
+- Deterministic predicates run over changed Python source text. They are regex-backed until Flow exposes a stable Python AST query API, so lower-confidence checks warn instead of block.
+- Production-path checks exclude obvious tests, `cli/`, `script/` or `scripts/`, `cli.py`, `main.py`, and `__main__.py`.
+- Semantic predicates use one cheap judge call and should block only when they can cite a concrete changed span.
+- Existing project linters such as Ruff, mypy, pyright, Bandit, pytest, and framework-specific checks remain the primary local enforcement tools; this pack seeds portable defaults for Flow.
+
+## Predicate Coverage
+
+| Predicate | Mode | Verdict | Purpose |
+|---|---|---|---|
+| `no_bare_except` | deterministic | Block | Bare `except:` catches `BaseException`, including interpreter-exiting exceptions. |
+| `type_hints_on_pub_fn` | deterministic | Warn | Public top-level functions should expose useful parameter and return annotations. |
+| `no_print_in_prod_path` | deterministic | Warn | Production paths should use `logging`; `print` is reserved for tests and CLIs. |
+| `no_mutable_default_arg` | deterministic | Block | Mutable defaults share state across calls and cause surprising behavior. |
+| `context_mgr_for_files` | deterministic | Warn | File handles should normally be managed with `with open(...)` or `Path.open(...)`. |
+| `no_eval_exec` | deterministic | Block | Direct `eval()` and `exec()` calls create arbitrary-code-execution risk. |
+| `no_subprocess_shell_true` | deterministic | Block | `subprocess.*(..., shell=True)` raises shell-injection risk. |
+| `no_assert_in_prod_path` | deterministic | Warn | Production validation should not rely on asserts that optimized runs can remove. |
+| `sql_queries_use_parameters` | semantic | Block | SQL should use DB-API placeholders and bound parameters, not string-built queries. |
+| `secrets_not_hardcoded_in_source` | semantic | Block | Credentials and tokens should come from secret managers or scoped environment. |
+
+## Evidence
+
+Evidence scanned on 2026-04-30.
+
+- Python 3.14 documentation: exception handling, default argument values, `with`, `open`, `eval`, `exec`, `subprocess` security, assertions, `typing`, `sqlite3` placeholders, and `logging`.
+- Ruff rule documentation: E722 bare except, ANN201 public function annotations, T201 print, B006 mutable argument defaults, S307 eval, S102 exec, S101 assert, S602 subprocess shell, and hardcoded password rules.
+- OWASP, CWE-78, and CWE-798 guidance: SQL injection, OS command injection, credential hygiene, and hardcoded credentials.
+
+## Known False Positives
+
+- Regex predicates are syntax-aware only at the source-text level; comments, string literals, aliases, and multiline formatting can fool them.
+- `type_hints_on_pub_fn` only catches unannotated top-level functions on a single signature span. It does not fully validate every parameter annotation.
+- `context_mgr_for_files` warns on code that intentionally closes file handles elsewhere.
+- `no_print_in_prod_path` treats obvious CLI/script/test paths as exempt but cannot infer custom user-output modules.
+- `no_eval_exec` may flag intentionally shadowed helper names named `eval` or `exec`.
+- `no_subprocess_shell_true` flags all shell use as a block candidate. Rare justified shell usage should move behind a reviewed helper with sanitization.
+- The semantic predicates depend on a cheap judge and should stay high-threshold until Flow exposes structured Python taint or data-flow facts.
+
+## Fixtures
+
+Each fixture in `fixtures/` contains one blocked or warned example and one allowed example for the corresponding predicate. The fixture shape mirrors the existing seed packs:
+
+```json
+{
+  "predicate": "name",
+  "cases": [
+    {"expect": "Block", "files": [{"path": "app.py", "text": "..."}]},
+    {"expect": "Allow", "files": [{"path": "app.py", "text": "..."}]}
+  ]
+}
+```

--- a/python/fixtures/context_mgr_for_files.json
+++ b/python/fixtures/context_mgr_for_files.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "context_mgr_for_files",
+  "cases": [
+    {
+      "name": "warns_unmanaged_open",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/io.py",
+          "text": "def read_config(path):\n    handle = open(path, encoding=\"utf-8\")\n    return handle.read()\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_with_open",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/io.py",
+          "text": "def read_config(path):\n    with open(path, encoding=\"utf-8\") as handle:\n        return handle.read()\n"
+        }
+      ]
+    }
+  ]
+}

--- a/python/fixtures/no_assert_in_prod_path.json
+++ b/python/fixtures/no_assert_in_prod_path.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_assert_in_prod_path",
+  "cases": [
+    {
+      "name": "warns_assert_in_service_code",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/api/validation.py",
+          "text": "def parse_limit(raw):\n    limit = int(raw)\n    assert limit > 0\n    return limit\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_assert_in_test",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "tests/test_validation.py",
+          "text": "def test_parse_limit():\n    assert parse_limit(\"2\") == 2\n"
+        }
+      ]
+    }
+  ]
+}

--- a/python/fixtures/no_bare_except.json
+++ b/python/fixtures/no_bare_except.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_bare_except",
+  "cases": [
+    {
+      "name": "blocks_bare_except",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/service.py",
+          "text": "def load_user(repo, user_id):\n    try:\n        return repo.get(user_id)\n    except:\n        return None\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_specific_exception",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/service.py",
+          "text": "def load_user(repo, user_id):\n    try:\n        return repo.get(user_id)\n    except LookupError:\n        return None\n"
+        }
+      ]
+    }
+  ]
+}

--- a/python/fixtures/no_eval_exec.json
+++ b/python/fixtures/no_eval_exec.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_eval_exec",
+  "cases": [
+    {
+      "name": "blocks_eval",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/rules.py",
+          "text": "def calculate(expr):\n    return eval(expr)\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_dispatch_table",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/rules.py",
+          "text": "OPS = {\"double\": lambda value: value * 2}\n\ndef calculate(op, value):\n    return OPS[op](value)\n"
+        }
+      ]
+    }
+  ]
+}

--- a/python/fixtures/no_mutable_default_arg.json
+++ b/python/fixtures/no_mutable_default_arg.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_mutable_default_arg",
+  "cases": [
+    {
+      "name": "blocks_list_default",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/cache.py",
+          "text": "def append_seen(item, seen=[]):\n    seen.append(item)\n    return seen\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_none_sentinel",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/cache.py",
+          "text": "def append_seen(item, seen=None):\n    if seen is None:\n        seen = []\n    seen.append(item)\n    return seen\n"
+        }
+      ]
+    }
+  ]
+}

--- a/python/fixtures/no_print_in_prod_path.json
+++ b/python/fixtures/no_print_in_prod_path.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_print_in_prod_path",
+  "cases": [
+    {
+      "name": "warns_print_in_service_code",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/payments/service.py",
+          "text": "def charge(invoice):\n    print(f\"charging {invoice.id}\")\n    return gateway.charge(invoice)\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_print_in_cli",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/payments/cli.py",
+          "text": "def main() -> None:\n    print(\"payments synced\")\n"
+        }
+      ]
+    }
+  ]
+}

--- a/python/fixtures/no_subprocess_shell_true.json
+++ b/python/fixtures/no_subprocess_shell_true.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_subprocess_shell_true",
+  "cases": [
+    {
+      "name": "blocks_shell_true",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/build.py",
+          "text": "import subprocess\n\ndef list_files(pattern):\n    return subprocess.run(f\"ls {pattern}\", shell=True, check=True)\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_argv_sequence",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/build.py",
+          "text": "import subprocess\n\ndef list_files(path):\n    return subprocess.run([\"ls\", path], check=True)\n"
+        }
+      ]
+    }
+  ]
+}

--- a/python/fixtures/secrets_not_hardcoded_in_source.json
+++ b/python/fixtures/secrets_not_hardcoded_in_source.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "secrets_not_hardcoded_in_source",
+  "cases": [
+    {
+      "name": "blocks_hardcoded_token",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/deploy.py",
+          "text": "DEPLOY_TOKEN = \"sk-live-abc123\"\n\ndef deploy(client):\n    return client.deploy(token=DEPLOY_TOKEN)\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_environment_lookup",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/deploy.py",
+          "text": "import os\n\ndef deploy(client):\n    return client.deploy(token=os.environ[\"DEPLOY_TOKEN\"])\n"
+        }
+      ]
+    }
+  ]
+}

--- a/python/fixtures/sql_queries_use_parameters.json
+++ b/python/fixtures/sql_queries_use_parameters.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "sql_queries_use_parameters",
+  "cases": [
+    {
+      "name": "blocks_f_string_sql",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/users.py",
+          "text": "def find_user(conn, email):\n    return conn.execute(f\"SELECT * FROM users WHERE email = '{email}'\").fetchone()\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_bound_parameter",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/users.py",
+          "text": "def find_user(conn, email):\n    return conn.execute(\"SELECT * FROM users WHERE email = ?\", (email,)).fetchone()\n"
+        }
+      ]
+    }
+  ]
+}

--- a/python/fixtures/type_hints_on_pub_fn.json
+++ b/python/fixtures/type_hints_on_pub_fn.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "type_hints_on_pub_fn",
+  "cases": [
+    {
+      "name": "warns_unannotated_public_function",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/mathlib.py",
+          "text": "def add(a, b):\n    return a + b\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_return_annotated_function",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/mathlib.py",
+          "text": "def add(a: int, b: int) -> int:\n    return a + b\n"
+        }
+      ]
+    }
+  ]
+}

--- a/python/invariants.harn
+++ b/python/invariants.harn
@@ -1,0 +1,274 @@
+let _EVIDENCE_BARE_EXCEPT = [
+  "https://docs.python.org/3.14/reference/compound_stmts.html#except-clause",
+  "https://docs.astral.sh/ruff/rules/bare-except/",
+]
+
+let _EVIDENCE_TYPE_HINTS = [
+  "https://docs.python.org/3.14/library/typing.html",
+  "https://docs.astral.sh/ruff/rules/missing-return-type-undocumented-public-function/",
+]
+
+let _EVIDENCE_PRINT_LOGGING = ["https://docs.python.org/3/howto/logging.html", "https://docs.astral.sh/ruff/rules/print/"]
+
+let _EVIDENCE_MUTABLE_DEFAULTS = [
+  "https://docs.python.org/3.14/tutorial/controlflow.html#default-argument-values",
+  "https://docs.astral.sh/ruff/rules/mutable-argument-default/",
+]
+
+let _EVIDENCE_FILE_HANDLES = [
+  "https://docs.python.org/3.14/reference/compound_stmts.html#the-with-statement",
+  "https://docs.python.org/3.14/library/functions.html#open",
+]
+
+let _EVIDENCE_EVAL_EXEC = [
+  "https://docs.python.org/3.14/library/functions.html#eval",
+  "https://docs.python.org/3.14/library/functions.html#exec",
+  "https://docs.astral.sh/ruff/rules/suspicious-eval-usage/",
+  "https://docs.astral.sh/ruff/rules/exec-builtin/",
+]
+
+let _EVIDENCE_SUBPROCESS_SHELL = [
+  "https://docs.python.org/3.14/library/subprocess.html#security-considerations",
+  "https://docs.astral.sh/ruff/rules/subprocess-popen-with-shell-equals-true/",
+  "https://cwe.mitre.org/data/definitions/78.html",
+]
+
+let _EVIDENCE_ASSERTS = [
+  "https://docs.python.org/3.14/reference/simple_stmts.html#the-assert-statement",
+  "https://docs.astral.sh/ruff/rules/assert/",
+]
+
+let _EVIDENCE_SQL_PARAMETERS = [
+  "https://docs.python.org/3.14/library/sqlite3.html#how-to-use-placeholders-to-bind-values-in-sql-queries",
+  "https://owasp.org/www-community/attacks/SQL_Injection",
+]
+
+let _EVIDENCE_SOURCE_SECRETS = [
+  "https://docs.astral.sh/ruff/rules/hardcoded-password-string/",
+  "https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-06-Insufficient-Credential-Hygiene",
+  "https://cwe.mitre.org/data/definitions/798.html",
+]
+
+fn python_files(slice) {
+  return slice.files.filter({ file -> file.path.ends_with(".py") })
+}
+
+fn is_test_path(path) {
+  return regex_match(r"(^|/)(tests?|test_[^/]*|[^/]*_test)\.py$", path, "") != nil
+    || regex_match(r"(^|/)tests?/", path, "") != nil
+}
+
+fn is_cli_path(path) {
+  return path.ends_with("__main__.py")
+    || regex_match(r"(^|/)(cli|scripts?)/", path, "") != nil
+    || regex_match(r"(^|/)(cli|main)\.py$", path, "") != nil
+}
+
+fn production_python_files(slice) {
+  return python_files(slice)
+    .filter({ file -> !is_test_path(file.path) && !is_cli_path(file.path) })
+}
+
+fn scan_files(files, pattern, flags) {
+  var findings = []
+  for file in files {
+    if regex_match(pattern, file.text, flags) != nil {
+      findings = findings
+        .push({path: file.path, pattern: pattern})
+    }
+  }
+  return findings
+}
+
+fn scan_files_if(files, predicate) {
+  var findings = []
+  for file in files {
+    if predicate(file) {
+      findings = findings
+        .push({path: file.path})
+    }
+  }
+  return findings
+}
+
+fn allow(rule) {
+  return {verdict: "Allow", rule: rule, findings: [], remediation: ""}
+}
+
+fn warn(rule, remediation, findings) {
+  return {verdict: "Warn", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block(rule, remediation, findings) {
+  return {verdict: "Block", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return block(rule, remediation, findings)
+}
+
+fn warn_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return warn(rule, remediation, findings)
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_BARE_EXCEPT, confidence: 0.92, source_date: "2026-04-30")
+/** Blocks bare except clauses that catch BaseException. */
+pub fn no_bare_except(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(python_files(slice), r"(?m)^\s*except\s*:\s*(#.*)?$", "m")
+  return block_on_findings(
+    "no_bare_except",
+    "Catch a specific exception class, or Exception if system-exiting exceptions must propagate.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_TYPE_HINTS, confidence: 0.7, source_date: "2026-04-30")
+/** Warns on public top-level functions without parameter or return annotations. */
+pub fn type_hints_on_pub_fn(slice, _ctx, _repo_at_base) {
+  let missing_return = r"(?m)^(async\s+)?def\s+[A-Za-z][A-Za-z0-9_]*\s*\([^)]*\)\s*:"
+  let missing_params = r"(?m)^(async\s+)?def\s+[A-Za-z][A-Za-z0-9_]*\s*\((?![^)]*:)[^)]*[A-Za-z_][^)]*\)\s*->"
+  let findings = scan_files_if(
+    python_files(slice),
+    { file -> regex_match(missing_return, file.text, "m") != nil
+      || regex_match(missing_params, file.text, "m") != nil },
+  )
+  return warn_on_findings(
+    "type_hints_on_pub_fn",
+    "Add parameter and return annotations to public top-level functions.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_PRINT_LOGGING, confidence: 0.74, source_date: "2026-04-30")
+/** Warns on print calls in non-test, non-CLI Python paths. */
+pub fn no_print_in_prod_path(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(production_python_files(slice), r"(^|[^._A-Za-z0-9])print\s*\(", "s")
+  return warn_on_findings(
+    "no_print_in_prod_path",
+    "Use logging in production paths; keep print for tests, CLIs, or explicit user output.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_MUTABLE_DEFAULTS, confidence: 0.86, source_date: "2026-04-30")
+/** Blocks mutable literal or constructor defaults in function signatures. */
+pub fn no_mutable_default_arg(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    python_files(slice),
+    r"(?s)\b(async\s+)?def\s+\w+\s*\([^)]*=\s*(\[\]|\{\}|set\s*\(|dict\s*\(|list\s*\()[^)]*\)\s*:",
+    "s",
+  )
+  return block_on_findings(
+    "no_mutable_default_arg",
+    "Use None or an immutable sentinel default, then create a new mutable value inside the function.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_FILE_HANDLES, confidence: 0.72, source_date: "2026-04-30")
+/** Warns when builtin open() appears outside a with statement. */
+pub fn context_mgr_for_files(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    python_files(slice),
+    r"(?m)^(?![^\n]*\bwith\s+open\s*\()[^\n]*[^._A-Za-z0-9]open\s*\(",
+    "m",
+  )
+  return warn_on_findings(
+    "context_mgr_for_files",
+    "Use with open(...) or Path.open(...) so file handles are closed promptly.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_EVAL_EXEC, confidence: 0.82, source_date: "2026-04-30")
+/** Blocks direct eval() or exec() calls in Python source. */
+pub fn no_eval_exec(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(python_files(slice), r"(?m)(^|[^._A-Za-z0-9])(eval|exec)\s*\(", "m")
+  return block_on_findings(
+    "no_eval_exec",
+    "Replace eval/exec with a parser, dispatch table, or constrained interpreter.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_SUBPROCESS_SHELL, confidence: 0.8, source_date: "2026-04-30")
+/** Blocks subprocess calls that opt into shell=True. */
+pub fn no_subprocess_shell_true(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    python_files(slice),
+    r"(?s)\bsubprocess\.(run|Popen|call|check_call|check_output)\s*\([^)]*shell\s*=\s*True",
+    "s",
+  )
+  return block_on_findings(
+    "no_subprocess_shell_true",
+    "Pass argv as a sequence with shell=False; document and sanitize rare shell=True cases.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_ASSERTS, confidence: 0.68, source_date: "2026-04-30")
+/** Warns on assert statements in non-test Python paths. */
+pub fn no_assert_in_prod_path(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(production_python_files(slice), r"(?m)^\s*assert\s+", "m")
+  return warn_on_findings(
+    "no_assert_in_prod_path",
+    "Raise explicit exceptions for runtime validation; asserts can be removed by optimized runs.",
+    findings,
+  )
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_SQL_PARAMETERS, confidence: 0.66, source_date: "2026-04-30")
+/** Blocks SQL assembled with user-controlled string interpolation. */
+pub fn sql_queries_use_parameters(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when Python code builds a SQL query by interpolating, formatting, concatenating, or f-stringing user-controlled values into the SQL text instead of binding parameters/placeholders."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: python_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "sql_queries_use_parameters",
+      "Use DB-API placeholders and bound parameters instead of string-built SQL.",
+      judgement.findings,
+    )
+  }
+  return allow("sql_queries_use_parameters")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_SOURCE_SECRETS, confidence: 0.64, source_date: "2026-04-30")
+/** Blocks hardcoded credentials and high-risk secrets in Python source. */
+pub fn secrets_not_hardcoded_in_source(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when Python source hardcodes credentials, API tokens, private keys, database passwords, signing secrets, or production service credentials instead of loading them from a secret manager or environment."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: python_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "secrets_not_hardcoded_in_source",
+      "Load secrets from a secret manager or scoped environment variable instead of source literals.",
+      judgement.findings,
+    )
+  }
+  return allow("secrets_not_hardcoded_in_source")
+}


### PR DESCRIPTION
## Summary
- Add a v0 Python seed predicate pack with 8 deterministic predicates and 2 semantic predicates
- Add allow/block or allow/warn fixtures for every predicate
- Document stack assumptions, evidence sources, known gaps, and list Python in the root pack index

## Verification
- harn fmt python/invariants.harn
- harn check python/invariants.harn
- harn lint python/invariants.harn
- jq validation for python/fixtures/*.json
- custom deterministic fixture replay for 16 cases
- evidence URL HEAD/GET link check for every @archivist URL
- self-review of staged diff for false positives, coverage gaps, and metadata consistency

Closes #6