### PR TITLE
Add CI status rollup gate to satisfy org rule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,17 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Placeholder
         run: echo "Fixture allow/block replay will run once the Harn Flow runtime ships."
+
+  ci-status:
+    name: CI status
+    if: always()
+    needs: [evidence-links, fmt, fixture-replay]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for failures
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo "One or more CI jobs failed"
+            exit 1
+          fi
+          echo "All CI jobs passed or were skipped"


### PR DESCRIPTION
Adds a rollup job named `CI status` (needs `[evidence-links, fmt, fixture-replay]`) to satisfy the `burin-labs/main protection` org ruleset which requires that exact context name.