### PR TITLE
Add JavaScript seed predicate pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,12 @@ See the Harn Flow design docs for the full predicate language spec.
 ## Packs
 
 - [Harn](./harn/) — v0 draft predicates for `.harn` scripts, Flow workflows, and agent-facing Harn modules.
+- [JavaScript](./javascript/) — v0 draft predicates for plain JavaScript source, async handling, dynamic-code hazards, and untrusted data boundaries.
 - [Python](./python/) — v0 draft predicates for Python application and library code.
+- [Rust](./rust/) — v0 draft predicates for Rust application and library code.
+- [SQL](./sql/) — v0 draft predicates for schema, migration, and query safety.
+- [Swift](./swift/) — v0 draft predicates for Swift application and UI code.
+- [TypeScript](./typescript/) — v0 draft predicates for TypeScript and TSX code.
 
 ## Status
 

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -1,0 +1,58 @@
+# JavaScript Seed Predicate Pack
+
+This pack covers plain JavaScript before framework-specific packs such as React, Node services, browser extensions, or build tooling add narrower rules. It focuses on high-signal defaults for async correctness, dynamic-code hazards, production logging, global scope hygiene, and untrusted data handling.
+
+## Stack Assumptions
+
+- Files use `.js`, `.jsx`, `.mjs`, or `.cjs`.
+- Projects use modern JavaScript, strict mode or modules where practical, and linting compatible with current ESLint rule guidance.
+- Deterministic predicates operate over changed source text until Flow exposes stable JavaScript AST and module-resolution queries.
+- Semantic predicates may block only when the judge can cite a concrete changed span and the issue is not reliably expressible with simple syntax checks.
+
+## Predicate Coverage
+
+| Predicate | Mode | Verdict | Purpose |
+|---|---|---|---|
+| `no_floating_promises` | deterministic | Block | Obvious Promise-returning calls must be awaited, returned, explicitly void-marked, or handled with `.catch()`. |
+| `no_eval` | deterministic | Block | Direct `eval` use is blocked because it executes source text dynamically. |
+| `no_implied_eval` | deterministic | Block | Timer APIs must receive functions instead of strings of JavaScript source. |
+| `strict_equality` | deterministic | Block | Loose equality and inequality are blocked in favor of `===` and `!==`. |
+| `no_var_keyword` | deterministic | Block | `var` declarations are blocked in favor of block-scoped `let` or `const`. |
+| `no_console_in_prod_path` | deterministic | Block | Production JavaScript paths must not ship `console.log`, `debug`, `trace`, or `info`. |
+| `no_with_statement` | deterministic | Block | `with` statements are blocked because they are incompatible with strict mode and obscure name resolution. |
+| `no_implicit_globals` | deterministic | Warn | Browser-script-style top-level declarations should not leak names onto the global object. |
+| `runtime_validate_external_data` | semantic | Block | External data must be runtime-validated before being trusted as domain data. |
+| `no_hardcoded_secrets` | semantic | Block | Credentials, tokens, private keys, and production connection strings must not live in source. |
+| `no_sensitive_data_in_logs` | semantic | Block | Logs and error messages must not expose secrets or sensitive user data. |
+
+## Evidence
+
+Evidence scanned on 2026-05-08.
+
+- ESLint rules: `no-eval`, `no-implied-eval`, `eqeqeq`, `no-var`, `no-console`, `no-with`, and `no-implicit-globals`.
+- MDN JavaScript and Web API docs: `eval`, `Promise.prototype.catch`, `fetch`, `JSON.parse`, strict equality, strict mode, and `var`.
+- OWASP cheat sheets for input validation, logging, and secrets management.
+- GitHub secret scanning docs for hardcoded credential risk and remediation context.
+
+## Known False Positives
+
+- Regex predicates are intentionally conservative and file-scoped. A file containing both an offending pattern and an allowed pattern may be allowed until AST-level matching lands.
+- `no_floating_promises` only blocks obvious async surfaces such as `fetch`, `Promise.*`, `new Promise`, or `*Async` calls until promise-aware JavaScript analysis is available.
+- `strict_equality` is source-text based and does not inspect comments, strings, or project-specific `== null` conventions.
+- `no_implicit_globals` warns on top-level function declarations even inside CommonJS modules because source text alone cannot reliably distinguish browser script execution from module execution.
+- `no_console_in_prod_path` allows tests and CLI paths but does not yet understand custom generated-code or storybook directories.
+- The semantic predicates must cite concrete changed spans and should stay high-threshold to avoid blocking on speculative security concerns.
+
+## Fixtures
+
+Each fixture in `fixtures/` contains one blocked or warned example and one allowed example for the corresponding predicate. The fixture shape is deliberately simple until the Flow replay harness lands:
+
+```json
+{
+  "predicate": "name",
+  "cases": [
+    {"expect": "Block", "files": [{"path": "src/file.js", "text": "..."}]},
+    {"expect": "Allow", "files": [{"path": "src/file.js", "text": "..."}]}
+  ]
+}
+```

--- a/javascript/fixtures/no_console_in_prod_path.json
+++ b/javascript/fixtures/no_console_in_prod_path.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_console_in_prod_path",
+  "cases": [
+    {
+      "name": "blocks_console_log_in_src",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/payment.js",
+          "text": "export function charge(id) {\n  console.log('charging', id);\n  return id;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_console_log_in_cli",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "bin/status.js",
+          "text": "export function printStatus(status) {\n  console.log(status);\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/javascript/fixtures/no_eval.json
+++ b/javascript/fixtures/no_eval.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_eval",
+  "cases": [
+    {
+      "name": "blocks_direct_eval",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/rules.js",
+          "text": "export function runRule(source) {\n  return eval(source);\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_lookup_table",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/rules.js",
+          "text": "const rules = { double: (value) => value * 2 };\nexport function runRule(name, value) {\n  return rules[name](value);\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/javascript/fixtures/no_floating_promises.json
+++ b/javascript/fixtures/no_floating_promises.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_floating_promises",
+  "cases": [
+    {
+      "name": "blocks_unhandled_fetch_statement",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/save.js",
+          "text": "export function save() {\n  fetch('/api/save', { method: 'POST' });\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_returned_fetch",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/save.js",
+          "text": "export function save() {\n  return fetch('/api/save', { method: 'POST' });\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/javascript/fixtures/no_hardcoded_secrets.json
+++ b/javascript/fixtures/no_hardcoded_secrets.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_hardcoded_secrets",
+  "cases": [
+    {
+      "name": "blocks_embedded_api_key",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/client.js",
+          "text": "export const paymentConfig = {\n  apiKey: 'sk_live_51NHardcodedSecretValue',\n};\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_environment_secret",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/client.js",
+          "text": "export const paymentConfig = {\n  apiKey: process.env.PAYMENT_API_KEY,\n};\n"
+        }
+      ]
+    }
+  ]
+}

--- a/javascript/fixtures/no_implicit_globals.json
+++ b/javascript/fixtures/no_implicit_globals.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_implicit_globals",
+  "cases": [
+    {
+      "name": "warns_top_level_function",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "public/analytics.js",
+          "text": "function trackPageView() {\n  sendBeacon('/analytics');\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_module_export",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/analytics.mjs",
+          "text": "export function trackPageView(sendBeacon) {\n  sendBeacon('/analytics');\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/javascript/fixtures/no_implied_eval.json
+++ b/javascript/fixtures/no_implied_eval.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_implied_eval",
+  "cases": [
+    {
+      "name": "blocks_timer_string",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/timer.js",
+          "text": "export function schedule() {\n  setTimeout(\"refreshSession()\", 1000);\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_timer_callback",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/timer.js",
+          "text": "export function schedule(refreshSession) {\n  setTimeout(() => refreshSession(), 1000);\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/javascript/fixtures/no_sensitive_data_in_logs.json
+++ b/javascript/fixtures/no_sensitive_data_in_logs.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_sensitive_data_in_logs",
+  "cases": [
+    {
+      "name": "blocks_token_logging",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/auth.js",
+          "text": "export function auditLogin(user, token) {\n  logger.info({ userId: user.id, token }, 'login succeeded');\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_redacted_logging",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/auth.js",
+          "text": "export function auditLogin(user) {\n  logger.info({ userId: user.id }, 'login succeeded');\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/javascript/fixtures/no_var_keyword.json
+++ b/javascript/fixtures/no_var_keyword.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_var_keyword",
+  "cases": [
+    {
+      "name": "blocks_var_declaration",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/count.js",
+          "text": "export function count(items) {\n  var total = items.length;\n  return total;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_const_declaration",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/count.js",
+          "text": "export function count(items) {\n  const total = items.length;\n  return total;\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/javascript/fixtures/no_with_statement.json
+++ b/javascript/fixtures/no_with_statement.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_with_statement",
+  "cases": [
+    {
+      "name": "blocks_with_statement",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/profile.js",
+          "text": "export function label(profile) {\n  with (profile) {\n    return name;\n  }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_destructuring",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/profile.js",
+          "text": "export function label(profile) {\n  const { name } = profile;\n  return name;\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/javascript/fixtures/runtime_validate_external_data.json
+++ b/javascript/fixtures/runtime_validate_external_data.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "runtime_validate_external_data",
+  "cases": [
+    {
+      "name": "blocks_unvalidated_json",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/profile.js",
+          "text": "export function parseProfile(raw) {\n  const profile = JSON.parse(raw);\n  return profile.email.toLowerCase();\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_schema_validation",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/profile.js",
+          "text": "import { ProfileSchema } from './schema.js';\nexport function parseProfile(raw) {\n  const profile = ProfileSchema.parse(JSON.parse(raw));\n  return profile.email.toLowerCase();\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/javascript/fixtures/strict_equality.json
+++ b/javascript/fixtures/strict_equality.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "strict_equality",
+  "cases": [
+    {
+      "name": "blocks_loose_equality",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/compare.js",
+          "text": "export function isActive(value) {\n  return value == true;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_strict_equality",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/compare.js",
+          "text": "export function isActive(value) {\n  return value === true;\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/javascript/invariants.harn
+++ b/javascript/invariants.harn
@@ -1,0 +1,307 @@
+let _EVIDENCE_FLOATING_PROMISES = [
+  "https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch",
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch",
+]
+
+let _EVIDENCE_EVAL = [
+  "https://eslint.org/docs/latest/rules/no-eval",
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval",
+]
+
+let _EVIDENCE_IMPLIED_EVAL = [
+  "https://eslint.org/docs/latest/rules/no-implied-eval",
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval",
+]
+
+let _EVIDENCE_STRICT_EQUALITY = [
+  "https://eslint.org/docs/latest/rules/eqeqeq",
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality",
+]
+
+let _EVIDENCE_NO_VAR = [
+  "https://eslint.org/docs/latest/rules/no-var",
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var",
+]
+
+let _EVIDENCE_NO_CONSOLE = [
+  "https://eslint.org/docs/latest/rules/no-console",
+  "https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html",
+]
+
+let _EVIDENCE_NO_WITH = [
+  "https://eslint.org/docs/latest/rules/no-with",
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode",
+]
+
+let _EVIDENCE_NO_IMPLICIT_GLOBALS = [
+  "https://eslint.org/docs/latest/rules/no-implicit-globals",
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode",
+]
+
+let _EVIDENCE_RUNTIME_VALIDATION = [
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse",
+  "https://cheatsheetseries.owasp.org/cheatsheets/Input_Validation_Cheat_Sheet.html",
+]
+
+let _EVIDENCE_SECRETS = [
+  "https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html",
+  "https://docs.github.com/en/code-security/concepts/secret-security/about-secret-scanning",
+]
+
+let _EVIDENCE_SENSITIVE_LOGS = [
+  "https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html",
+  "https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html",
+]
+
+fn javascript_files(slice) {
+  return slice.files
+    .filter(
+    { file -> file.path.ends_with(".js")
+      || file.path.ends_with(".jsx")
+      || file.path.ends_with(".mjs")
+      || file.path.ends_with(".cjs") },
+  )
+}
+
+fn is_test_path(path) {
+  return contains(path, ".test.")
+    || contains(path, ".spec.")
+    || path.starts_with("test/")
+    || path.starts_with("tests/")
+    || contains(path, "/test/")
+    || contains(path, "/tests/")
+    || contains(path, "__tests__")
+}
+
+fn is_cli_path(path) {
+  return path.starts_with("cli/")
+    || path.starts_with("bin/")
+    || contains(path, "/cli/")
+    || contains(path, "/bin/")
+    || path.ends_with(".cli.js")
+    || path.ends_with(".cli.mjs")
+    || path.ends_with(".cli.cjs")
+}
+
+fn production_javascript_files(slice) {
+  return javascript_files(slice).filter({ file -> !is_test_path(file.path) && !is_cli_path(file.path) })
+}
+
+fn scan_files(files, pattern) {
+  var findings = []
+  for file in files {
+    if regex_match(pattern, file.text, "s") != nil {
+      findings = findings.push({path: file.path, pattern: pattern})
+    }
+  }
+  return findings
+}
+
+fn scan_files_if(files, predicate) {
+  var findings = []
+  for file in files {
+    if predicate(file.text) {
+      findings = findings.push({path: file.path})
+    }
+  }
+  return findings
+}
+
+fn scan_files_without(files, include_pattern, exclude_pattern) {
+  return scan_files_if(
+    files,
+    { text -> regex_match(include_pattern, text, "s") != nil && regex_match(exclude_pattern, text, "s") == nil },
+  )
+}
+
+fn allow(rule) {
+  return {verdict: "Allow", rule: rule, findings: [], remediation: ""}
+}
+
+fn warn(rule, remediation, findings) {
+  return {verdict: "Warn", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block(rule, remediation, findings) {
+  return {verdict: "Block", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return block(rule, remediation, findings)
+}
+
+fn warn_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return warn(rule, remediation, findings)
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_FLOATING_PROMISES, confidence: 0.76, source_date: "2026-05-08")
+/**
+ * Blocks obvious Promise-returning calls that are started as bare statements without await, return, void, or catch.
+ */
+pub fn no_floating_promises(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_without(
+    javascript_files(slice),
+    r"(?m)^\s*((fetch|[A-Za-z_$][A-Za-z0-9_$]*Async|[A-Za-z_$][A-Za-z0-9_$]*\.[A-Za-z_$][A-Za-z0-9_$]*Async|Promise\.[A-Za-z_$][A-Za-z0-9_$]*)\s*\([^;\n]*\)|new\s+Promise\s*\([^;\n]*\))\s*;",
+    r"\b(await|return|void)\s+[A-Za-z_$]|\.\s*catch\s*\(",
+  )
+  return block_on_findings(
+    "no_floating_promises",
+    "Await, return, void-mark, or attach .catch() to obvious Promise-returning calls.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_EVAL, confidence: 0.86, source_date: "2026-05-08")
+/** Blocks direct eval calls in JavaScript source. */
+pub fn no_eval(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    javascript_files(slice),
+    r"(?m)(^|[^._A-Za-z0-9])(eval|globalThis\.eval|window\.eval|global\.eval)\s*\(",
+  )
+  return block_on_findings(
+    "no_eval",
+    "Replace eval with structured parsing, lookup tables, or a constrained interpreter.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_IMPLIED_EVAL, confidence: 0.82, source_date: "2026-05-08")
+/** Blocks string arguments to timer APIs that evaluate code. */
+pub fn no_implied_eval(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    javascript_files(slice),
+    r"(?m)\b(window\.)?(setTimeout|setInterval|execScript)\s*\(\s*['\x22]",
+  )
+  return block_on_findings(
+    "no_implied_eval",
+    "Pass a function to timer APIs instead of a string of JavaScript source.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_STRICT_EQUALITY, confidence: 0.8, source_date: "2026-05-08")
+/** Blocks loose equality and inequality operators. */
+pub fn strict_equality(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(javascript_files(slice), r"(?m)(^|[^=!])([!=]=)([^=]|$)")
+  return block_on_findings(
+    "strict_equality",
+    "Use === or !== so JavaScript does not coerce operands during comparison.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_NO_VAR, confidence: 0.9, source_date: "2026-05-08")
+/** Blocks var declarations in favor of block-scoped declarations. */
+pub fn no_var_keyword(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(javascript_files(slice), r"(?m)(^|[^\w$])var\s+[A-Za-z_$]")
+  return block_on_findings("no_var_keyword", "Use let or const so declarations have block scope.", findings)
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_NO_CONSOLE, confidence: 0.76, source_date: "2026-05-08")
+/** Blocks console debugging calls in production JavaScript paths. */
+pub fn no_console_in_prod_path(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(production_javascript_files(slice), r"\bconsole\.(log|debug|trace|info)\s*\(")
+  return block_on_findings(
+    "no_console_in_prod_path",
+    "Use the project logger or remove console debugging from production code.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_NO_WITH, confidence: 0.9, source_date: "2026-05-08")
+/** Blocks with statements, which are unavailable in strict mode and obscure name resolution. */
+pub fn no_with_statement(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(javascript_files(slice), r"(?m)(^|[^\w$])with\s*\(")
+  return block_on_findings(
+    "no_with_statement",
+    "Replace with with explicit property access or object destructuring.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_NO_IMPLICIT_GLOBALS, confidence: 0.72, source_date: "2026-05-08")
+/** Warns on top-level var declarations or function declarations in browser scripts. */
+pub fn no_implicit_globals(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    javascript_files(slice),
+    r"(?m)^(var\s+[A-Za-z_$]|function\s+[A-Za-z_$][A-Za-z0-9_$]*\s*\()",
+  )
+  return warn_on_findings(
+    "no_implicit_globals",
+    "Use modules, block-scoped declarations, or explicit global assignments.",
+    findings,
+  )
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_RUNTIME_VALIDATION, confidence: 0.64, source_date: "2026-05-08")
+/** Blocks external data being trusted as domain data without runtime validation. */
+pub fn runtime_validate_external_data(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed JavaScript trusts external data from JSON.parse, request bodies, process.env, fetch responses, localStorage, postMessage, or URL params without runtime validation, schema parsing, allow-listing, or explicit narrowing."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: javascript_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "runtime_validate_external_data",
+      "Validate external data at runtime before trusting it as domain data.",
+      judgement.findings,
+    )
+  }
+  return allow("runtime_validate_external_data")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_SECRETS, confidence: 0.69, source_date: "2026-05-08")
+/** Blocks hardcoded credentials, tokens, and private keys in JavaScript source. */
+pub fn no_hardcoded_secrets(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed JavaScript embeds a credential, API key, token, private key, signing secret, password, or production connection string instead of reading it from a managed secret source."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: javascript_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "no_hardcoded_secrets",
+      "Move credentials to a secret manager or scoped environment variable and rotate exposed values.",
+      judgement.findings,
+    )
+  }
+  return allow("no_hardcoded_secrets")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_SENSITIVE_LOGS, confidence: 0.64, source_date: "2026-05-08")
+/** Blocks logging of secrets, credentials, tokens, or sensitive user data. */
+pub fn no_sensitive_data_in_logs(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed JavaScript logs secrets, credentials, session identifiers, access tokens, authorization headers, passwords, or sensitive personal data to console, logger, telemetry, or thrown error messages."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: javascript_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "no_sensitive_data_in_logs",
+      "Remove sensitive values from logs and use redaction or stable identifiers.",
+      judgement.findings,
+    )
+  }
+  return allow("no_sensitive_data_in_logs")
+}


### PR DESCRIPTION
## Summary
- Add the plain JavaScript v0 seed predicate pack with 8 deterministic predicates and 3 semantic predicates.
- Include allow/block fixtures for every predicate.
- Document stack assumptions, evidence sources, known gaps, and add JavaScript to the root pack index.

Closes #7

## Validation
- `harn fmt --check javascript/invariants.harn`
- `harn check javascript/invariants.harn`
- `harn lint javascript/invariants.harn`
- `harn check harn javascript python rust swift typescript`
- `for f in javascript/fixtures/*.json; do python3 -m json.tool "$f" >/dev/null || exit 1; done`
- evidence URL HEAD check for all JavaScript pack `@archivist` links

Note: `harn check .` still stops on the pre-existing `sql/invariants.harn` draft syntax format at line 1, so the broad check was run over the Harn-syntax packs directly.
