### PR TITLE
Add Go seed predicate pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ See the Harn Flow design docs for the full predicate language spec.
 ## Packs
 
 - [C#](./csharp/) — v0 draft predicates for plain C# and .NET library or application code.
+- [Go](./go/) — v0 draft predicates for Go modules, command packages, and reusable libraries.
 - [Harn](./harn/) — v0 draft predicates for `.harn` scripts, Flow workflows, and agent-facing Harn modules.
 - [JavaScript](./javascript/) — v0 draft predicates for plain JavaScript source, async handling, dynamic-code hazards, and untrusted data boundaries.
 - [Python](./python/) — v0 draft predicates for Python application and library code.

--- a/go/README.md
+++ b/go/README.md
@@ -1,0 +1,63 @@
+# Go Seed Predicate Pack
+
+This pack covers Go modules, command packages, and reusable libraries. It targets high-signal review issues that changed source slices can catch cheaply: ignored errors, context propagation mistakes, library panics, overly broad exported APIs, lossy error wrapping, HTTP response leaks, weak randomness, goroutine lifetime leaks, and dependency vulnerability review.
+
+## Stack Assumptions
+
+- Go source files use `.go`; module metadata uses `go.mod` and `go.sum`.
+- Production paths exclude `_test.go`, `test/`, `tests/`, and `testdata/` files.
+- Generated Go files with the standard `// Code generated ... DO NOT EDIT.` marker are ignored by deterministic source predicates.
+- Deterministic predicates use file-text scans until Harn Flow exposes a stable Go AST query API.
+- Semantic predicates make one cheap judge call over changed Go/module files and use only evidence captured at authoring time.
+- Advisory rules return `Warn` when idiomatic exceptions are common. Blocking rules are reserved for ignored errors, library panics, likely response-body leaks, security-sensitive randomness, goroutine leaks, and missing dependency-vulnerability evidence.
+
+## Predicate Coverage
+
+| Predicate | Mode | Verdict | Purpose |
+|---|---|---|---|
+| `no_ignored_errors` | deterministic | Block | Obvious blank-identifier discards of call results should not hide errors in production Go. |
+| `context_first_arg` | deterministic | Warn | Exported APIs should place `context.Context` first unless an interface fixes the signature. |
+| `no_panic_in_library` | deterministic | Block | Non-main library packages should return errors instead of panicking from normal failure paths. |
+| `no_context_in_struct` | deterministic | Warn | Context values should be passed per call rather than stored in structs. |
+| `no_empty_interface_in_api` | deterministic | Warn | Exported APIs should avoid `interface{}` and `any` when concrete types, type parameters, or small interfaces fit. |
+| `wrap_errors_with_percent_w` | deterministic | Warn | Error context should preserve unwrap chains when callers may use `errors.Is` or `errors.As`. |
+| `error_strings_not_capitalized` | deterministic | Warn | Error strings should compose cleanly when callers add context. |
+| `http_response_body_closed` | deterministic | Block | Successful HTTP responses must have their bodies closed to release resources. |
+| `no_math_rand_for_keys` | deterministic | Block | Security-sensitive keys, tokens, nonces, and secrets require `crypto/rand`, not `math/rand`. |
+| `goroutine_leak_guard` | semantic | Block | Long-lived goroutines need credible cancellation, shutdown, or bounded-lifetime evidence. |
+| `go_dependency_vulns_checked` | semantic | Block | Dependency changes should preserve or run govulncheck, Dependabot, OSV, or equivalent checks. |
+
+## Evidence
+
+Evidence scanned on 2026-05-08.
+
+- Go docs and tutorials: Effective Go, Go error handling tutorial, Go 1.13 errors blog, package docs for `context`, `errors`, `fmt`, `io`, `net/http`, `crypto/rand`, and `math/rand`.
+- Go Wiki: Code Review Comments for contexts, interfaces, panic guidance, crypto randomness, and error strings.
+- Go Blog: pipeline cancellation patterns for goroutine shutdown.
+- Staticcheck docs: correctness checks that include ignored-result and suspicious-code signals.
+- Go vulnerability tooling and dependency docs: module dependency management and `govulncheck`.
+- GitHub Dependabot docs: dependency update and security automation paths.
+
+## Known False Positives
+
+- Regex predicates do not parse Go. Comments, raw strings, nested function literals, unusual formatting, and aliases can confuse deterministic checks.
+- `no_ignored_errors` intentionally catches obvious `_ = call()` and `value, _ := call()` shapes, but it cannot prove the discarded result has type `error`.
+- `context_first_arg` and `no_empty_interface_in_api` are advisory because generated bindings and required interface signatures may force non-idiomatic signatures.
+- `no_panic_in_library` ignores `package main` and tests, but it can still catch panics used for internal invariants. Prefer returning errors or documenting the public panic contract once suppressions exist.
+- `http_response_body_closed` is conservative and file-scoped. It can miss helper-based close patterns or flag files that close through a different response variable.
+- `no_math_rand_for_keys` is keyword-based. Non-security simulations with token-like names may need a local allow once the predicate runtime supports suppressions.
+- Semantic predicates depend on the judge recognizing concrete changed spans. They should stay high-threshold and cite exact goroutine or dependency changes before blocking.
+
+## Fixtures
+
+Each fixture in `fixtures/` contains one blocked or warned example and one allowed example for the corresponding predicate. The fixture shape matches the current harn-canon convention:
+
+```json
+{
+  "predicate": "name",
+  "cases": [
+    {"expect": "Block", "files": [{"path": "client.go", "text": "..."}]},
+    {"expect": "Allow", "files": [{"path": "client.go", "text": "..."}]}
+  ]
+}
+```

--- a/go/fixtures/context_first_arg.json
+++ b/go/fixtures/context_first_arg.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "context_first_arg",
+  "cases": [
+    {
+      "name": "warns_context_after_business_arg",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "api/users.go",
+          "text": "package api\n\nimport \"context\"\n\nfunc LoadUser(id string, ctx context.Context) error {\n\treturn nil\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_context_first",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "api/users.go",
+          "text": "package api\n\nimport \"context\"\n\nfunc LoadUser(ctx context.Context, id string) error {\n\treturn nil\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/go/fixtures/error_strings_not_capitalized.json
+++ b/go/fixtures/error_strings_not_capitalized.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "error_strings_not_capitalized",
+  "cases": [
+    {
+      "name": "warns_capitalized_error",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "store/load.go",
+          "text": "package store\n\nimport \"errors\"\n\nfunc Load(path string) error {\n\tif path == \"\" {\n\t\treturn errors.New(\"Missing path\")\n\t}\n\treturn nil\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_lowercase_error",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "store/load.go",
+          "text": "package store\n\nimport \"errors\"\n\nfunc Load(path string) error {\n\tif path == \"\" {\n\t\treturn errors.New(\"missing path\")\n\t}\n\treturn nil\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/go/fixtures/go_dependency_vulns_checked.json
+++ b/go/fixtures/go_dependency_vulns_checked.json
@@ -1,0 +1,29 @@
+{
+  "predicate": "go_dependency_vulns_checked",
+  "cases": [
+    {
+      "name": "blocks_dependency_change_without_vuln_check",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "go.mod",
+          "text": "module example.com/service\n\ngo 1.24\n\nrequire github.com/example/legacy v0.1.0\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_dependency_change_with_govulncheck_ci",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "go.mod",
+          "text": "module example.com/service\n\ngo 1.24\n\nrequire github.com/example/current v1.2.3\n"
+        },
+        {
+          "path": ".github/workflows/security.yml",
+          "text": "name: security\non: [pull_request]\njobs:\n  govulncheck:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v6\n      - uses: golang/govulncheck-action@v1\n"
+        }
+      ]
+    }
+  ]
+}

--- a/go/fixtures/goroutine_leak_guard.json
+++ b/go/fixtures/goroutine_leak_guard.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "goroutine_leak_guard",
+  "cases": [
+    {
+      "name": "blocks_unbounded_worker_without_shutdown",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "worker/pump.go",
+          "text": "package worker\n\nfunc Start(jobs <-chan Job) {\n\tgo func() {\n\t\tfor job := range jobs {\n\t\t\tprocess(job)\n\t\t}\n\t}()\n}\n\ntype Job struct{}\nfunc process(Job) {}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_ctx_done_shutdown",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "worker/pump.go",
+          "text": "package worker\n\nimport \"context\"\n\nfunc Start(ctx context.Context, jobs <-chan Job) {\n\tgo func() {\n\t\tfor {\n\t\t\tselect {\n\t\t\tcase <-ctx.Done():\n\t\t\t\treturn\n\t\t\tcase job := <-jobs:\n\t\t\t\tprocess(job)\n\t\t\t}\n\t\t}\n\t}()\n}\n\ntype Job struct{}\nfunc process(Job) {}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/go/fixtures/http_response_body_closed.json
+++ b/go/fixtures/http_response_body_closed.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "http_response_body_closed",
+  "cases": [
+    {
+      "name": "blocks_missing_body_close",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "client/fetch.go",
+          "text": "package client\n\nimport (\n\t\"io\"\n\t\"net/http\"\n)\n\nfunc Fetch(url string) ([]byte, error) {\n\tresp, err := http.Get(url)\n\tif err != nil {\n\t\treturn nil, err\n\t}\n\treturn io.ReadAll(resp.Body)\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_deferred_body_close",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "client/fetch.go",
+          "text": "package client\n\nimport (\n\t\"io\"\n\t\"net/http\"\n)\n\nfunc Fetch(url string) ([]byte, error) {\n\tresp, err := http.Get(url)\n\tif err != nil {\n\t\treturn nil, err\n\t}\n\tdefer resp.Body.Close()\n\treturn io.ReadAll(resp.Body)\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/go/fixtures/no_context_in_struct.json
+++ b/go/fixtures/no_context_in_struct.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_context_in_struct",
+  "cases": [
+    {
+      "name": "warns_context_field",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "worker/worker.go",
+          "text": "package worker\n\nimport \"context\"\n\ntype Worker struct {\n\tctx context.Context\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_context_parameter",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "worker/worker.go",
+          "text": "package worker\n\nimport \"context\"\n\ntype Worker struct{}\n\nfunc (w *Worker) Run(ctx context.Context) error {\n\treturn ctx.Err()\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/go/fixtures/no_empty_interface_in_api.json
+++ b/go/fixtures/no_empty_interface_in_api.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_empty_interface_in_api",
+  "cases": [
+    {
+      "name": "warns_any_in_exported_signature",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "api/events.go",
+          "text": "package api\n\nfunc Publish(topic string, payload any) error {\n\treturn nil\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_concrete_payload",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "api/events.go",
+          "text": "package api\n\ntype Event struct {\n\tTopic string\n\tBody  []byte\n}\n\nfunc Publish(event Event) error {\n\treturn nil\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/go/fixtures/no_ignored_errors.json
+++ b/go/fixtures/no_ignored_errors.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_ignored_errors",
+  "cases": [
+    {
+      "name": "blocks_blank_identifier_error_discard",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "service/write.go",
+          "text": "package service\n\nimport \"os\"\n\nfunc Save(path string, data []byte) {\n\t_ = os.WriteFile(path, data, 0o600)\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_checked_error",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "service/write.go",
+          "text": "package service\n\nimport \"os\"\n\nfunc Save(path string, data []byte) error {\n\tif err := os.WriteFile(path, data, 0o600); err != nil {\n\t\treturn err\n\t}\n\treturn nil\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/go/fixtures/no_math_rand_for_keys.json
+++ b/go/fixtures/no_math_rand_for_keys.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_math_rand_for_keys",
+  "cases": [
+    {
+      "name": "blocks_math_rand_token",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "auth/token.go",
+          "text": "package auth\n\nimport \"math/rand\"\n\nfunc SessionToken() int64 {\n\treturn rand.Int63()\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_crypto_rand_token",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "auth/token.go",
+          "text": "package auth\n\nimport \"crypto/rand\"\n\nfunc SessionToken() ([32]byte, error) {\n\tvar token [32]byte\n\t_, err := rand.Read(token[:])\n\treturn token, err\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/go/fixtures/no_panic_in_library.json
+++ b/go/fixtures/no_panic_in_library.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_panic_in_library",
+  "cases": [
+    {
+      "name": "blocks_panic_in_library_package",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "parser/config.go",
+          "text": "package parser\n\nfunc Parse(raw string) Config {\n\tif raw == \"\" {\n\t\tpanic(\"empty config\")\n\t}\n\treturn Config{}\n}\n\ntype Config struct{}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_error_return",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "parser/config.go",
+          "text": "package parser\n\nimport \"errors\"\n\nfunc Parse(raw string) (Config, error) {\n\tif raw == \"\" {\n\t\treturn Config{}, errors.New(\"empty config\")\n\t}\n\treturn Config{}, nil\n}\n\ntype Config struct{}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/go/fixtures/wrap_errors_with_percent_w.json
+++ b/go/fixtures/wrap_errors_with_percent_w.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "wrap_errors_with_percent_w",
+  "cases": [
+    {
+      "name": "warns_percent_v_error_context",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "store/load.go",
+          "text": "package store\n\nimport \"fmt\"\n\nfunc Load() error {\n\tif err := read(); err != nil {\n\t\treturn fmt.Errorf(\"read config: %v\", err)\n\t}\n\treturn nil\n}\n\nfunc read() error { return nil }\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_percent_w_error_context",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "store/load.go",
+          "text": "package store\n\nimport \"fmt\"\n\nfunc Load() error {\n\tif err := read(); err != nil {\n\t\treturn fmt.Errorf(\"read config: %w\", err)\n\t}\n\treturn nil\n}\n\nfunc read() error { return nil }\n"
+        }
+      ]
+    }
+  ]
+}

--- a/go/invariants.harn
+++ b/go/invariants.harn
@@ -1,0 +1,307 @@
+let _EVIDENCE_IGNORED_ERRORS = [
+  "https://go.dev/doc/effective_go#blank",
+  "https://go.dev/doc/tutorial/handle-errors",
+  "https://staticcheck.dev/docs/checks/",
+]
+
+let _EVIDENCE_CONTEXT_FIRST = ["https://go.dev/wiki/CodeReviewComments#contexts", "https://pkg.go.dev/context"]
+
+let _EVIDENCE_PANIC_LIBRARY = ["https://go.dev/doc/effective_go#panic", "https://go.dev/wiki/CodeReviewComments#dont-panic"]
+
+let _EVIDENCE_CONTEXT_STRUCT = ["https://go.dev/wiki/CodeReviewComments#contexts", "https://pkg.go.dev/context"]
+
+let _EVIDENCE_EMPTY_INTERFACE = [
+  "https://go.dev/wiki/CodeReviewComments#interfaces",
+  "https://go.dev/doc/effective_go#interfaces_and_types",
+]
+
+let _EVIDENCE_ERROR_WRAP = ["https://go.dev/blog/go1.13-errors", "https://pkg.go.dev/errors", "https://pkg.go.dev/fmt"]
+
+let _EVIDENCE_ERROR_STRINGS = ["https://go.dev/wiki/CodeReviewComments#error-strings", "https://go.dev/wiki/Errors"]
+
+let _EVIDENCE_HTTP_BODY_CLOSE = ["https://pkg.go.dev/net/http", "https://pkg.go.dev/io"]
+
+let _EVIDENCE_MATH_RAND_KEYS = [
+  "https://go.dev/wiki/CodeReviewComments#crypto-rand",
+  "https://pkg.go.dev/crypto/rand",
+  "https://pkg.go.dev/math/rand",
+]
+
+let _EVIDENCE_GOROUTINE_LEAKS = [
+  "https://pkg.go.dev/context",
+  "https://go.dev/blog/pipelines",
+  "https://pkg.go.dev/golang.org/x/sync/errgroup",
+]
+
+let _EVIDENCE_DEP_SECURITY = [
+  "https://go.dev/doc/modules/managing-dependencies",
+  "https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck",
+  "https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates",
+]
+
+fn is_go_path(path) {
+  return path.ends_with(".go")
+}
+
+fn is_test_path(path) {
+  return path.ends_with("_test.go")
+    || path.contains("/test/")
+    || path.contains("/tests/")
+    || path.contains("/testdata/")
+}
+
+fn is_generated_go(file) {
+  return regex_match(r"(?m)^// Code generated .* DO NOT EDIT\.$", file.text, "m") != nil
+}
+
+fn go_files(slice) {
+  return slice.files
+    .filter({ file -> is_go_path(file.path) && !is_generated_go(file) })
+}
+
+fn production_go_files(slice) {
+  return go_files(slice).filter({ file -> !is_test_path(file.path) })
+}
+
+fn library_go_files(slice) {
+  return production_go_files(slice)
+    .filter(
+    { file -> regex_match(r"(?m)^\s*package\s+main\s*$", file.text, "m") == nil },
+  )
+}
+
+fn go_project_files(slice) {
+  return slice.files
+    .filter(
+    { file -> is_go_path(file.path)
+      || file.path.ends_with("go.mod")
+      || file.path.ends_with("go.sum")
+      || file.path.ends_with("dependabot.yml")
+      || file.path.ends_with("dependabot.yaml")
+      || file.path.contains(".github/workflows/") },
+  )
+}
+
+fn scan_files(files, pattern, flags) {
+  var findings = []
+  for file in files {
+    if regex_match(pattern, file.text, flags) != nil {
+      findings = findings
+        .push({path: file.path, pattern: pattern})
+    }
+  }
+  return findings
+}
+
+fn scan_files_if(files, predicate) {
+  var findings = []
+  for file in files {
+    if predicate(file) {
+      findings = findings
+        .push({path: file.path})
+    }
+  }
+  return findings
+}
+
+fn allow(rule) {
+  return {verdict: "Allow", rule: rule, findings: [], remediation: ""}
+}
+
+fn warn(rule, remediation, findings) {
+  return {verdict: "Warn", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block(rule, remediation, findings) {
+  return {verdict: "Block", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return block(rule, remediation, findings)
+}
+
+fn warn_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return warn(rule, remediation, findings)
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_IGNORED_ERRORS, confidence: 0.7, source_date: "2026-05-08")
+/** Blocks obvious discarded error results in production Go files. */
+pub fn no_ignored_errors(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_go_files(slice),
+    r"(?m)(^\s*_\s*=\s*[A-Za-z_][A-Za-z0-9_\.]*\s*\([^;\n]*\)\s*$|^[^/\n]*,\s*_\s*(:=|=)\s*[A-Za-z_][A-Za-z0-9_\.]*\s*\([^;\n]*\))",
+    "m",
+  )
+  return block_on_findings(
+    "no_ignored_errors",
+    "Check the returned error or document a safe, intentional discard in a narrow local helper.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_CONTEXT_FIRST, confidence: 0.72, source_date: "2026-05-08")
+/** Warns when exported functions accept context.Context after another argument. */
+pub fn context_first_arg(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_go_files(slice),
+    r"(?m)^func\s+(?:\([^)]+\)\s*)?[A-Z][A-Za-z0-9_]*\s*\(\s*[^)\n]+,\s*([A-Za-z_][A-Za-z0-9_]*\s+)?context\.Context\b",
+    "m",
+  )
+  return warn_on_findings(
+    "context_first_arg",
+    "Put context.Context first in exported APIs unless an interface requires another signature.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_PANIC_LIBRARY, confidence: 0.78, source_date: "2026-05-08")
+/** Blocks direct panic calls in non-main, non-test Go files. */
+pub fn no_panic_in_library(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(library_go_files(slice), r"\bpanic\s*\(", "s")
+  return block_on_findings(
+    "no_panic_in_library",
+    "Return an error from library code; reserve panic for unrecoverable programmer bugs with clear contracts.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_CONTEXT_STRUCT, confidence: 0.74, source_date: "2026-05-08")
+/** Warns when structs store context.Context instead of taking it per call. */
+pub fn no_context_in_struct(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(production_go_files(slice), r"type\s+\w+\s+struct\s*\{[^}]*\bcontext\.Context\b", "s")
+  return warn_on_findings(
+    "no_context_in_struct",
+    "Pass context.Context to methods that need it instead of storing it in structs.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_EMPTY_INTERFACE, confidence: 0.66, source_date: "2026-05-08")
+/** Warns on interface{} or any in exported function and method signatures. */
+pub fn no_empty_interface_in_api(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_go_files(slice),
+    r"(?m)^func\s+(?:\([^)]+\)\s*)?[A-Z][A-Za-z0-9_]*\s*\([^)]*\b(interface\s*\{\s*\}|any)\b",
+    "m",
+  )
+  return warn_on_findings(
+    "no_empty_interface_in_api",
+    "Prefer a concrete type, type parameter, or small consumer-owned interface in exported APIs.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_ERROR_WRAP, confidence: 0.7, source_date: "2026-05-08")
+/** Warns when fmt.Errorf formats err with %v instead of wrapping with %w. */
+pub fn wrap_errors_with_percent_w(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(production_go_files(slice), r"fmt\.Errorf\s*\([^)]*%v[^)]*,\s*err\s*\)", "s")
+  return warn_on_findings(
+    "wrap_errors_with_percent_w",
+    "Use %w when adding context to an error that callers may inspect with errors.Is or errors.As.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_ERROR_STRINGS, confidence: 0.68, source_date: "2026-05-08")
+/** Warns on capitalized error strings in errors.New or fmt.Errorf. */
+pub fn error_strings_not_capitalized(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_go_files(slice),
+    "(errors\\.New|fmt\\.Errorf)\\s*\\(\\s*\\\"[A-Z][A-Za-z]",
+    "s",
+  )
+  return warn_on_findings(
+    "error_strings_not_capitalized",
+    "Start error strings with lowercase text unless the first token is a proper noun or acronym.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_HTTP_BODY_CLOSE, confidence: 0.64, source_date: "2026-05-08")
+/** Blocks obvious http response reads without a nearby Body.Close. */
+pub fn http_response_body_closed(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    production_go_files(slice),
+    { file -> regex_match(r"http\.(Get|Post|Do)\s*\(", file.text, "s") != nil
+      && regex_match(r"\.Body\b", file.text, "s") != nil
+      && regex_match(r"\bdefer\s+\w+\.Body\.Close\s*\(", file.text, "s") == nil },
+  )
+  return block_on_findings(
+    "http_response_body_closed",
+    "Close successful HTTP response bodies, usually with defer resp.Body.Close() after nil error checks.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_MATH_RAND_KEYS, confidence: 0.76, source_date: "2026-05-08")
+/** Blocks math/rand use in files that appear to generate keys, tokens, or secrets. */
+pub fn no_math_rand_for_keys(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    production_go_files(slice),
+    { file -> regex_match(r"math/rand", file.text, "s") != nil
+      && regex_match(r"(?i)(key|token|secret|password|nonce|session)", file.text, "s") != nil },
+  )
+  return block_on_findings(
+    "no_math_rand_for_keys",
+    "Use crypto/rand for keys, tokens, nonces, passwords, and other security-sensitive randomness.",
+    findings,
+  )
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_GOROUTINE_LEAKS, confidence: 0.62, source_date: "2026-05-08")
+/** Blocks long-lived goroutines that lack cancellation or shutdown evidence. */
+pub fn goroutine_leak_guard(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed production Go code starts a goroutine that can wait, loop, receive from a channel, tick, sleep, or perform repeated work, and the changed code lacks a credible shutdown path such as ctx.Done(), a closed channel, errgroup context, WaitGroup ownership with cancellation, or documented bounded lifetime. Allow short fire-and-forget goroutines whose work is clearly bounded."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: production_go_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "goroutine_leak_guard",
+      "Give long-lived goroutines a cancellation or shutdown path such as ctx.Done(), close, or errgroup.",
+      judgement.findings,
+    )
+  }
+  return allow("goroutine_leak_guard")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_DEP_SECURITY, confidence: 0.64, source_date: "2026-05-08")
+/** Blocks Go dependency changes that omit vulnerability-check evidence. */
+pub fn go_dependency_vulns_checked(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when Go dependency metadata changed, such as go.mod, go.sum, dependency update automation, or Go CI, and the slice provides no evidence that govulncheck, Dependabot, OSV, a module proxy vulnerability check, or equivalent dependency vulnerability review was considered. Allow pure source changes and dependency changes that add or preserve a clear vulnerability-check path."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: go_project_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "go_dependency_vulns_checked",
+      "Run or configure govulncheck, Dependabot, OSV, or equivalent vulnerability checks for Go dependency changes.",
+      judgement.findings,
+    )
+  }
+  return allow("go_dependency_vulns_checked")
+}


### PR DESCRIPTION
## Summary
- add a Go v0 seed predicate pack with 9 deterministic predicates and 2 semantic predicates
- document stack assumptions, evidence, known gaps, and fixture shape
- add allow/block or allow/warn fixtures for every predicate and list Go in the root pack index

## Verification
- harn check go
- harn lint go
- jq empty go/fixtures/*.json
- harn test go (no test pipelines found)
- deterministic fixture sanity script
- evidence link reachability check: 24 links ok

Closes #8