### PR TITLE
Add C# seed predicate pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ See the Harn Flow design docs for the full predicate language spec.
 
 ## Packs
 
+- [C#](./csharp/) — v0 draft predicates for plain C# and .NET library or application code.
 - [Harn](./harn/) — v0 draft predicates for `.harn` scripts, Flow workflows, and agent-facing Harn modules.
 - [Python](./python/) — v0 draft predicates for Python application and library code.
 

--- a/csharp/README.md
+++ b/csharp/README.md
@@ -1,0 +1,60 @@
+# C# Seed Predicate Pack
+
+This pack covers plain C# and .NET library or application code before framework-specific packs such as ASP.NET Core, MAUI, Unity, or Orleans add tighter local rules. It focuses on high-signal defaults for nullable safety, async correctness, analyzer hygiene, exception diagnostics, and security-sensitive data handling.
+
+## Stack Assumptions
+
+- Files use `.cs`; project checks target `.csproj`, `Directory.Build.props`, and `Directory.Build.targets`.
+- Projects use SDK-style .NET builds with nullable reference types enabled centrally or in each changed project file.
+- Deterministic predicates operate over changed source text until Flow exposes stable Roslyn symbols, analyzer configuration, and effective MSBuild property queries.
+- Semantic predicates may block only when the judge can cite a concrete changed span and the issue is not reliably expressible with simple syntax checks.
+
+## Predicate Coverage
+
+| Predicate | Mode | Verdict | Purpose |
+|---|---|---|---|
+| `nullable_reference_types_enabled` | deterministic | Block | Changed C# project defaults must enable nullable reference types. |
+| `async_method_naming` | deterministic | Warn | Async Task-returning methods should use an `Async` suffix unless a fixed contract prevents it. |
+| `no_task_wait` | deterministic | Block | Production C# paths must not synchronously block on `Task` completion. |
+| `configure_await_false_in_libraries` | deterministic | Warn | Library-looking code should make continuation capture explicit with `ConfigureAwait`. |
+| `no_unused_privates` | deterministic | Block | Changed analyzer configuration must not disable IDE0051 unused-private-member diagnostics. |
+| `no_throw_ex_resets_stack` | deterministic | Block | Catch blocks should use bare `throw;` instead of `throw ex;`. |
+| `no_valuetask_reuse` | deterministic | Warn | `ValueTask` instances should not be consumed more than once. |
+| `no_console_write_in_prod_path` | deterministic | Warn | Production code should use structured logging instead of ad hoc `Console` writes. |
+| `sql_commands_use_parameters` | semantic | Block | SQL commands must bind untrusted values instead of interpolating them into command text. |
+| `no_hardcoded_secrets` | semantic | Block | Credentials, tokens, private keys, and production connection strings must not live in source or config. |
+| `no_sensitive_data_in_logs` | semantic | Block | Logs and exception messages must not expose secrets or sensitive user data. |
+
+## Evidence
+
+Evidence scanned on 2026-05-08.
+
+- Microsoft Learn C# nullable reference type docs, nullable reference type reference, and exception-handling statement docs.
+- Microsoft Learn .NET analyzer docs for CA1849, CA2007, CA2012, CA2100, CA2200, IDE0051, code-style naming rules, and reliability rule indexes.
+- Microsoft Learn .NET logging guidance for structured `ILogger` usage and production log-level considerations.
+- OWASP cheat sheets for SQL injection prevention, logging, and secrets management.
+- GitHub secret scanning docs for hardcoded credential risk and remediation context.
+
+## Known False Positives
+
+- Regex predicates are intentionally conservative and file-scoped. A file containing both an offending pattern and an allowed pattern may be allowed until Roslyn-level matching lands.
+- `nullable_reference_types_enabled` only inspects changed project/default files. The intended runtime form should resolve the effective nullable context for each touched C# file.
+- `async_method_naming` warns on interface implementations and framework overrides when source text alone cannot see the inherited contract.
+- `configure_await_false_in_libraries` treats non-test files under `/src/` as library-looking unless their path suggests UI or MVC surface area.
+- `no_unused_privates` guards analyzer configuration rather than trying to identify unused private members from text alone.
+- `no_valuetask_reuse` only catches obvious repeated local consumption and should become a Roslyn dataflow predicate later.
+- The semantic predicates must cite concrete changed spans and should stay high-threshold to avoid blocking on speculative security concerns.
+
+## Fixtures
+
+Each fixture in `fixtures/` contains one blocked or warned example and one allowed example for the corresponding predicate. The fixture shape is deliberately simple until the Flow replay harness lands:
+
+```json
+{
+  "predicate": "name",
+  "cases": [
+    {"expect": "Block", "files": [{"path": "src/File.cs", "text": "..."}]},
+    {"expect": "Allow", "files": [{"path": "src/File.cs", "text": "..."}]}
+  ]
+}
+```

--- a/csharp/fixtures/async_method_naming.json
+++ b/csharp/fixtures/async_method_naming.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "async_method_naming",
+  "cases": [
+    {
+      "name": "warns_async_method_without_suffix",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/App/Worker.cs",
+          "text": "using System.Threading.Tasks;\n\npublic sealed class Worker\n{\n    public async Task Load()\n    {\n        await Task.Delay(1);\n    }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_async_suffix",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/App/Worker.cs",
+          "text": "using System.Threading.Tasks;\n\npublic sealed class Worker\n{\n    public async Task LoadAsync()\n    {\n        await Task.Delay(1);\n    }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/csharp/fixtures/configure_await_false_in_libraries.json
+++ b/csharp/fixtures/configure_await_false_in_libraries.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "configure_await_false_in_libraries",
+  "cases": [
+    {
+      "name": "warns_library_await_without_configure_await",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/Library/Client.cs",
+          "text": "using System.Threading.Tasks;\n\npublic sealed class Client\n{\n    public async Task ReadAsync(Task task)\n    {\n        await task;\n    }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_explicit_configure_await",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/Library/Client.cs",
+          "text": "using System.Threading.Tasks;\n\npublic sealed class Client\n{\n    public async Task ReadAsync(Task task)\n    {\n        await task.ConfigureAwait(false);\n    }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/csharp/fixtures/no_console_write_in_prod_path.json
+++ b/csharp/fixtures/no_console_write_in_prod_path.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_console_write_in_prod_path",
+  "cases": [
+    {
+      "name": "warns_console_write_in_prod",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/App/Processor.cs",
+          "text": "using System;\n\npublic sealed class Processor\n{\n    public void Run() => Console.WriteLine(\"processing\");\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_logger",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/App/Processor.cs",
+          "text": "using Microsoft.Extensions.Logging;\n\npublic sealed class Processor(ILogger<Processor> logger)\n{\n    public void Run() => logger.LogInformation(\"Processing item\");\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/csharp/fixtures/no_hardcoded_secrets.json
+++ b/csharp/fixtures/no_hardcoded_secrets.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_hardcoded_secrets",
+  "cases": [
+    {
+      "name": "blocks_hardcoded_api_key",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/App/PaymentClient.cs",
+          "text": "public sealed class PaymentClient\n{\n    private const string ApiKey = \"sk_live_1234567890abcdef\";\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_configuration_secret_lookup",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/App/PaymentClient.cs",
+          "text": "using Microsoft.Extensions.Configuration;\n\npublic sealed class PaymentClient(IConfiguration config)\n{\n    private string ApiKey => config[\"Payments:ApiKey\"] ?? throw new InvalidOperationException(\"Missing payment API key\");\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/csharp/fixtures/no_sensitive_data_in_logs.json
+++ b/csharp/fixtures/no_sensitive_data_in_logs.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_sensitive_data_in_logs",
+  "cases": [
+    {
+      "name": "blocks_logging_authorization_header",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/App/AuthHandler.cs",
+          "text": "using Microsoft.Extensions.Logging;\n\npublic sealed class AuthHandler(ILogger<AuthHandler> logger)\n{\n    public void Reject(string authorizationHeader)\n    {\n        logger.LogWarning(\"Rejected authorization header {AuthorizationHeader}\", authorizationHeader);\n    }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_stable_identifier_logging",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/App/AuthHandler.cs",
+          "text": "using Microsoft.Extensions.Logging;\n\npublic sealed class AuthHandler(ILogger<AuthHandler> logger)\n{\n    public void Reject(string userId)\n    {\n        logger.LogWarning(\"Rejected authentication for user {UserId}\", userId);\n    }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/csharp/fixtures/no_task_wait.json
+++ b/csharp/fixtures/no_task_wait.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_task_wait",
+  "cases": [
+    {
+      "name": "blocks_task_result",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/App/Client.cs",
+          "text": "using System.Threading.Tasks;\n\npublic sealed class Client\n{\n    public string Read(Task<string> task) => task.Result;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_await",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/App/Client.cs",
+          "text": "using System.Threading.Tasks;\n\npublic sealed class Client\n{\n    public async Task<string> ReadAsync(Task<string> task) => await task;\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/csharp/fixtures/no_throw_ex_resets_stack.json
+++ b/csharp/fixtures/no_throw_ex_resets_stack.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_throw_ex_resets_stack",
+  "cases": [
+    {
+      "name": "blocks_throw_exception_variable",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/App/Handler.cs",
+          "text": "using System;\n\npublic sealed class Handler\n{\n    public void Run()\n    {\n        try { Work(); }\n        catch (Exception ex) { throw ex; }\n    }\n\n    private static void Work() { }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_bare_throw",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/App/Handler.cs",
+          "text": "using System;\n\npublic sealed class Handler\n{\n    public void Run()\n    {\n        try { Work(); }\n        catch (Exception) { throw; }\n    }\n\n    private static void Work() { }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/csharp/fixtures/no_unused_privates.json
+++ b/csharp/fixtures/no_unused_privates.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_unused_privates",
+  "cases": [
+    {
+      "name": "blocks_disabling_unused_private_analyzer",
+      "expect": "Block",
+      "files": [
+        {
+          "path": ".editorconfig",
+          "text": "root = true\n\n[*.cs]\ndotnet_diagnostic.IDE0051.severity = none\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_enabled_unused_private_analyzer",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": ".editorconfig",
+          "text": "root = true\n\n[*.cs]\ndotnet_diagnostic.IDE0051.severity = warning\n"
+        }
+      ]
+    }
+  ]
+}

--- a/csharp/fixtures/no_valuetask_reuse.json
+++ b/csharp/fixtures/no_valuetask_reuse.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_valuetask_reuse",
+  "cases": [
+    {
+      "name": "warns_reused_valuetask",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/App/Cache.cs",
+          "text": "using System.Threading.Tasks;\n\npublic sealed class Cache\n{\n    public async ValueTask<int> LoadTwiceAsync()\n    {\n        ValueTask<int> value = ReadAsync();\n        int first = await value;\n        int second = await value;\n        return first + second;\n    }\n\n    private static ValueTask<int> ReadAsync() => ValueTask.FromResult(1);\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_direct_awaits",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/App/Cache.cs",
+          "text": "using System.Threading.Tasks;\n\npublic sealed class Cache\n{\n    public async ValueTask<int> LoadTwiceAsync()\n    {\n        int first = await ReadAsync();\n        int second = await ReadAsync();\n        return first + second;\n    }\n\n    private static ValueTask<int> ReadAsync() => ValueTask.FromResult(1);\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/csharp/fixtures/nullable_reference_types_enabled.json
+++ b/csharp/fixtures/nullable_reference_types_enabled.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "nullable_reference_types_enabled",
+  "cases": [
+    {
+      "name": "blocks_missing_nullable",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/App/App.csproj",
+          "text": "<Project Sdk=\"Microsoft.NET.Sdk\">\n  <PropertyGroup>\n    <TargetFramework>net10.0</TargetFramework>\n  </PropertyGroup>\n</Project>\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_nullable_enabled",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/App/App.csproj",
+          "text": "<Project Sdk=\"Microsoft.NET.Sdk\">\n  <PropertyGroup>\n    <TargetFramework>net10.0</TargetFramework>\n    <Nullable>enable</Nullable>\n  </PropertyGroup>\n</Project>\n"
+        }
+      ]
+    }
+  ]
+}

--- a/csharp/fixtures/sql_commands_use_parameters.json
+++ b/csharp/fixtures/sql_commands_use_parameters.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "sql_commands_use_parameters",
+  "cases": [
+    {
+      "name": "blocks_interpolated_user_sql",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/App/UserRepository.cs",
+          "text": "using Microsoft.Data.SqlClient;\n\npublic sealed class UserRepository\n{\n    public SqlCommand Find(string email) => new($\"SELECT * FROM Users WHERE Email = '{email}'\");\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_parameterized_sql",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/App/UserRepository.cs",
+          "text": "using Microsoft.Data.SqlClient;\n\npublic sealed class UserRepository\n{\n    public SqlCommand Find(string email)\n    {\n        var command = new SqlCommand(\"SELECT * FROM Users WHERE Email = @email\");\n        command.Parameters.AddWithValue(\"@email\", email);\n        return command;\n    }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/csharp/invariants.harn
+++ b/csharp/invariants.harn
@@ -1,0 +1,348 @@
+let _EVIDENCE_NULLABLE = [
+  "https://learn.microsoft.com/en-us/dotnet/csharp/nullable-references",
+  "https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/builtin-types/nullable-reference-types",
+]
+
+let _EVIDENCE_ASYNC_NAMING = [
+  "https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/naming-rules",
+  "https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/",
+]
+
+let _EVIDENCE_TASK_WAIT = [
+  "https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1849",
+  "https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2007",
+]
+
+let _EVIDENCE_CONFIGURE_AWAIT = [
+  "https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2007",
+  "https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/reliability-warnings",
+]
+
+let _EVIDENCE_UNUSED_PRIVATES = [
+  "https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/ide0051",
+  "https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/",
+]
+
+let _EVIDENCE_RETHROW = [
+  "https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2200",
+  "https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/statements/exception-handling-statements",
+]
+
+let _EVIDENCE_VALUETASK = [
+  "https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2012",
+  "https://learn.microsoft.com/en-us/dotnet/api/system.threading.tasks.valuetask",
+]
+
+let _EVIDENCE_CONSOLE_LOGGING = [
+  "https://learn.microsoft.com/en-us/dotnet/core/extensions/logging/overview",
+  "https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html",
+]
+
+let _EVIDENCE_SQL_PARAMETERS = [
+  "https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2100",
+  "https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html",
+]
+
+let _EVIDENCE_SECRETS = [
+  "https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html",
+  "https://docs.github.com/code-security/secret-scanning/about-secret-scanning",
+]
+
+let _EVIDENCE_SENSITIVE_LOGS = [
+  "https://learn.microsoft.com/en-us/dotnet/core/extensions/logging/overview",
+  "https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html",
+]
+
+fn csharp_files(slice) {
+  return slice.files.filter({ file -> file.path.ends_with(".cs") })
+}
+
+fn project_files(slice) {
+  return slice.files
+    .filter(
+    { file -> file.path.ends_with(".csproj")
+      || file.path.ends_with("Directory.Build.props")
+      || file.path.ends_with("Directory.Build.targets") },
+  )
+}
+
+fn analyzer_config_files(slice) {
+  return slice.files
+    .filter(
+    { file -> file.path.ends_with(".editorconfig")
+      || file.path.ends_with(".globalconfig")
+      || file.path.ends_with(".csproj")
+      || file.path.ends_with("Directory.Build.props") },
+  )
+}
+
+fn is_test_path(path) {
+  return contains(path, ".Tests/")
+    || contains(path, ".Test/")
+    || contains(path, "/Tests/")
+    || contains(path, "/Test/")
+    || contains(path, "/tests/")
+    || path.ends_with("Tests.cs")
+    || path.ends_with("Test.cs")
+}
+
+fn is_ui_path(path) {
+  return contains(path, "/Controllers/")
+    || contains(path, "/Pages/")
+    || contains(path, "/Views/")
+    || contains(path, "/Components/")
+    || contains(path, ".razor.cs")
+    || contains(path, "/Wpf/")
+    || contains(path, "/WinForms/")
+}
+
+fn production_csharp_files(slice) {
+  return csharp_files(slice).filter({ file -> !is_test_path(file.path) })
+}
+
+fn library_csharp_files(slice) {
+  return production_csharp_files(slice)
+    .filter(
+    { file -> contains(file.path, "/src/") && !is_ui_path(file.path) },
+  )
+}
+
+fn scan_files(files, pattern, flags) {
+  var findings = []
+  for file in files {
+    if regex_match(pattern, file.text, flags) != nil {
+      findings = findings.push({path: file.path, pattern: pattern})
+    }
+  }
+  return findings
+}
+
+fn scan_files_if(files, predicate) {
+  var findings = []
+  for file in files {
+    if predicate(file) {
+      findings = findings.push({path: file.path})
+    }
+  }
+  return findings
+}
+
+fn scan_files_without(files, include_pattern, exclude_pattern) {
+  return scan_files_if(
+    files,
+    { file -> regex_match(include_pattern, file.text, "s") != nil
+      && regex_match(exclude_pattern, file.text, "s") == nil },
+  )
+}
+
+fn allow(rule) {
+  return {verdict: "Allow", rule: rule, findings: [], remediation: ""}
+}
+
+fn warn(rule, remediation, findings) {
+  return {verdict: "Warn", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block(rule, remediation, findings) {
+  return {verdict: "Block", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return block(rule, remediation, findings)
+}
+
+fn warn_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return warn(rule, remediation, findings)
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_NULLABLE, confidence: 0.86, source_date: "2026-05-08")
+/** Blocks C# project files that disable or omit nullable reference types. */
+pub fn nullable_reference_types_enabled(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    project_files(slice),
+    { file -> regex_match(r"<Nullable>\s*enable\s*</Nullable>", file.text, "is") == nil },
+  )
+  return block_on_findings(
+    "nullable_reference_types_enabled",
+    "Set <Nullable>enable</Nullable> in C# project defaults or the changed project file.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_ASYNC_NAMING, confidence: 0.7, source_date: "2026-05-08")
+/** Warns when async Task-returning methods do not use an Async suffix. */
+pub fn async_method_naming(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    csharp_files(slice),
+    r"(?m)\b(public|internal|protected|private)?\s*(static\s+)?async\s+(Task|ValueTask)(<[^>\n]+>)?\s+(?![A-Za-z_][A-Za-z0-9_]*Async\b)[A-Za-z_][A-Za-z0-9_]*\s*\(",
+    "m",
+  )
+  return warn_on_findings(
+    "async_method_naming",
+    "Rename async Task-returning methods with an Async suffix unless they implement a fixed contract.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_TASK_WAIT, confidence: 0.84, source_date: "2026-05-08")
+/** Blocks synchronous waits on Task results in production C# paths. */
+pub fn no_task_wait(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_csharp_files(slice),
+    r"(\.Wait\s*\(|\.Result\b|\.GetAwaiter\s*\(\s*\)\s*\.GetResult\s*\()",
+    "s",
+  )
+  return block_on_findings(
+    "no_task_wait",
+    "Use await or expose an async API instead of synchronously blocking on Task completion.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_CONFIGURE_AWAIT, confidence: 0.68, source_date: "2026-05-08")
+/** Warns when library-looking code awaits tasks without an explicit ConfigureAwait choice. */
+pub fn configure_await_false_in_libraries(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_without(
+    library_csharp_files(slice),
+    r"\bawait\s+[^;\n]+;",
+    r"\.ConfigureAwait\s*\(\s*(false|true)\s*\)",
+  )
+  return warn_on_findings(
+    "configure_await_false_in_libraries",
+    "Use ConfigureAwait(false) in libraries, or ConfigureAwait(true) when context capture is intentional.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_UNUSED_PRIVATES, confidence: 0.72, source_date: "2026-05-08")
+/** Blocks disabling the unused-private-member analyzer for C# source. */
+pub fn no_unused_privates(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    analyzer_config_files(slice),
+    r"(dotnet_diagnostic\.IDE0051\.severity\s*=\s*(none|silent)|<NoWarn>[^<]*IDE0051)",
+    "is",
+  )
+  return block_on_findings(
+    "no_unused_privates",
+    "Keep IDE0051 enabled and delete unused private members instead of suppressing the analyzer.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_RETHROW, confidence: 0.82, source_date: "2026-05-08")
+/** Blocks `throw ex;` because it resets the original exception stack trace. */
+pub fn no_throw_ex_resets_stack(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    csharp_files(slice),
+    r"catch\s*\([^)]*\b([A-Za-z_][A-Za-z0-9_]*)\s*\)\s*\{[^}]*\bthrow\s+\1\s*;",
+    "s",
+  )
+  return block_on_findings(
+    "no_throw_ex_resets_stack",
+    "Use bare throw; inside catch blocks to preserve the original stack trace.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_VALUETASK, confidence: 0.66, source_date: "2026-05-08")
+/** Warns when a ValueTask local is awaited or read more than once in one method body. */
+pub fn no_valuetask_reuse(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    csharp_files(slice),
+    r"ValueTask(<[^>\n]+>)?\s+([A-Za-z_][A-Za-z0-9_]*)\s*=.*\b(await\s+\2|\2\.Result)\b.*\b(await\s+\2|\2\.Result)\b",
+    "s",
+  )
+  return warn_on_findings(
+    "no_valuetask_reuse",
+    "Await each ValueTask once, or convert to Task with AsTask() before multiple awaits.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_CONSOLE_LOGGING, confidence: 0.74, source_date: "2026-05-08")
+/** Warns on Console debug output in production C# paths. */
+pub fn no_console_write_in_prod_path(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_csharp_files(slice),
+    r"\bConsole\.(Write|WriteLine|Error\.Write|Error\.WriteLine)\s*\(",
+    "s",
+  )
+  return warn_on_findings(
+    "no_console_write_in_prod_path",
+    "Use Microsoft.Extensions.Logging or explicit CLI output paths instead of production Console writes.",
+    findings,
+  )
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_SQL_PARAMETERS, confidence: 0.68, source_date: "2026-05-08")
+/** Blocks SQL commands assembled with untrusted string interpolation or concatenation. */
+pub fn sql_commands_use_parameters(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed C# builds SQL command text by concatenating, interpolating, or formatting user-controlled values into the SQL string instead of using parameters, stored procedures, or a query builder that binds values."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: csharp_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "sql_commands_use_parameters",
+      "Use parameterized commands or a query builder that binds values instead of string-built SQL.",
+      judgement.findings,
+    )
+  }
+  return allow("sql_commands_use_parameters")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_SECRETS, confidence: 0.68, source_date: "2026-05-08")
+/** Blocks hardcoded credentials, tokens, private keys, and production connection strings. */
+pub fn no_hardcoded_secrets(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed C# source, appsettings JSON, csproj metadata, or test host configuration embeds a credential, API key, token, private key, signing secret, password, or production connection string instead of reading it from configuration or a managed secret source."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: slice.files})
+  if judgement.verdict == "Block" {
+    return block(
+      "no_hardcoded_secrets",
+      "Move credentials to a secret manager or scoped configuration source and rotate exposed values.",
+      judgement.findings,
+    )
+  }
+  return allow("no_hardcoded_secrets")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_SENSITIVE_LOGS, confidence: 0.64, source_date: "2026-05-08")
+/** Blocks logging of secrets, authorization material, or sensitive user data. */
+pub fn no_sensitive_data_in_logs(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed C# logs or throws messages containing secrets, credentials, session identifiers, authorization headers, access tokens, passwords, payment data, or sensitive personal data through ILogger, Console, diagnostics, telemetry, or exception text."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: csharp_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "no_sensitive_data_in_logs",
+      "Remove sensitive values from logs and exception messages; log stable identifiers or redacted fields.",
+      judgement.findings,
+    )
+  }
+  return allow("no_sensitive_data_in_logs")
+}


### PR DESCRIPTION
## Summary

- Add a C# seed predicate pack with 8 deterministic predicates and 3 semantic predicates.
- Document stack assumptions, evidence sources, known gaps, and fixture format.
- Add allow/block or allow/warn fixtures for every C# predicate.
- Add the C# pack to the root pack index.

Closes #10.

## Validation

- `harn fmt csharp/invariants.harn`
- `harn check csharp/invariants.harn`
- `harn lint csharp/invariants.harn`
- `for f in csharp/fixtures/*.json; do jq empty "$f" || exit 1; done`
- Custom metadata check: predicate/fixture parity, one `@archivist` per predicate, at least two evidence links per predicate, source date `2026-05-08`
- Evidence link check: all C# evidence URLs returned HTTP 200

## Note

- Repo-wide `harn check .` and `harn lint .` are currently blocked by pre-existing SQL pack syntax in `sql/invariants.harn`; this PR keeps scope to the C# stack per CONTRIBUTING.md.
