### PR TITLE
Add Java seed predicate pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ See the Harn Flow design docs for the full predicate language spec.
 
 - [C#](./csharp/) — v0 draft predicates for plain C# and .NET library or application code.
 - [Harn](./harn/) — v0 draft predicates for `.harn` scripts, Flow workflows, and agent-facing Harn modules.
+- [Java](./java/) — v0 draft predicates for plain Java application and library code.
 - [JavaScript](./javascript/) — v0 draft predicates for plain JavaScript source, async handling, dynamic-code hazards, and untrusted data boundaries.
 - [Python](./python/) — v0 draft predicates for Python application and library code.
 - [Rust](./rust/) — v0 draft predicates for Rust application and library code.

--- a/java/README.md
+++ b/java/README.md
@@ -1,0 +1,61 @@
+# Java Seed Predicate Pack
+
+This pack covers plain Java application and library code before framework-specific packs such as Spring, Android, or Maven/Gradle policy packs add tighter rules. It focuses on high-signal defaults for generic type safety, nullness contracts, exception handling, logging, immutable data modeling, and untrusted input boundaries.
+
+## Stack Assumptions
+
+- Source checks target `.java` files; production checks exclude common test paths and `*Test.java`, `*Tests.java`, and `*IT.java`.
+- Projects are assumed to target Java 17 or newer, so records are available for simple immutable data carriers.
+- Projects may use JSpecify, NullAway, Checker Framework, SpotBugs, JetBrains, Jakarta, or project-level nullness defaults; the nullness predicate accepts common annotations and package defaults.
+- Deterministic predicates operate over changed source text until Flow exposes stable Java AST and build-tool queries.
+- Semantic predicates may block only when the judge can cite a concrete changed span and the issue is not reliably expressible with simple syntax checks.
+
+## Predicate Coverage
+
+| Predicate | Mode | Verdict | Purpose |
+|---|---|---|---|
+| `no_raw_collection_types` | deterministic | Block | Common generic containers such as `List`, `Map`, `Set`, and `Optional` must be parameterized. |
+| `null_safety_annotations` | deterministic | Warn | Public reference-returning APIs should have package-level or explicit nullness annotations. |
+| `immutable_value_objects` | deterministic | Warn | Simple final-field data carriers should usually be records on Java 17+. |
+| `no_swallowed_exceptions` | deterministic | Block | Empty production `catch` blocks must handle, log, rethrow, or explain ignored exceptions. |
+| `prefer_stream_over_loop` | deterministic | Warn | Index-based loops over collection `size()`/`get(i)` pairs should use enhanced loops or streams. |
+| `no_print_stack_trace` | deterministic | Block | Production code should log exceptions with context or rethrow rather than calling `printStackTrace()`. |
+| `no_system_out_in_prod` | deterministic | Warn | Production code should use the project logger instead of direct stdout/stderr writes. |
+| `optional_returns_are_not_null` | deterministic | Block | Methods returning `Optional<T>` must return an `Optional`, not `null`. |
+| `jdbc_queries_use_parameters` | semantic | Block | SQL values must be bound with parameters or safe query builders. |
+| `no_hardcoded_secrets` | semantic | Block | Credentials, tokens, private keys, and production connection strings must not live in source. |
+
+## Evidence
+
+Evidence scanned on 2026-05-08.
+
+- Oracle docs for Java SE 25 records, raw types in the Java Language Specification and Generics tutorial, `Collection.stream()`, `Stream`, `Optional`, `PreparedStatement`, and `java.util.logging.Logger`.
+- OpenJDK JEP 395 for record rationale and data-carrier semantics.
+- Error Prone bug patterns for empty catch blocks, catch-and-print-stack-trace handling, and null Optional use.
+- Checkstyle `EmptyCatchBlock` guidance.
+- JSpecify and NullAway nullness annotation documentation.
+- OWASP cheat sheets for logging, secrets management, and SQL injection prevention.
+- GitHub secret scanning documentation for hardcoded credential risk and remediation context.
+
+## Known False Positives
+
+- Regex predicates are intentionally conservative and file-scoped. A file containing both an offending pattern and a separate allowed pattern may be allowed or warned imprecisely until AST-level matching lands.
+- `no_raw_collection_types` focuses on common collection-like APIs and does not attempt full generic type parsing.
+- `null_safety_annotations` warns at file granularity when a public reference-returning method appears without a recognized nullness annotation or package default in the same changed file.
+- `immutable_value_objects` warns on simple final-field classes even when framework constraints, inheritance, serialization, or identity semantics make a class the right choice.
+- `prefer_stream_over_loop` only identifies the common `for (int i = 0; i < xs.size(); i++) { xs.get(i) }` shape and may miss equivalent loops.
+- The semantic predicates must cite concrete changed spans and should stay high-threshold to avoid blocking on speculative security concerns.
+
+## Fixtures
+
+Each fixture in `fixtures/` contains one blocked or warned example and one allowed example for the corresponding predicate. The fixture shape is deliberately simple until the Flow replay harness lands:
+
+```json
+{
+  "predicate": "name",
+  "cases": [
+    {"expect": "Block", "files": [{"path": "src/main/java/App.java", "text": "..."}]},
+    {"expect": "Allow", "files": [{"path": "src/main/java/App.java", "text": "..."}]}
+  ]
+}
+```

--- a/java/fixtures/immutable_value_objects.json
+++ b/java/fixtures/immutable_value_objects.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "immutable_value_objects",
+  "cases": [
+    {
+      "name": "warns_final_field_data_carrier",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/main/java/example/Money.java",
+          "text": "public final class Money {\n  private final long cents;\n  private final String currency;\n\n  public Money(long cents, String currency) {\n    this.cents = cents;\n    this.currency = currency;\n  }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_record_data_carrier",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/java/example/Money.java",
+          "text": "public record Money(long cents, String currency) {}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/java/fixtures/jdbc_queries_use_parameters.json
+++ b/java/fixtures/jdbc_queries_use_parameters.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "jdbc_queries_use_parameters",
+  "cases": [
+    {
+      "name": "blocks_concatenated_jdbc_sql",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/main/java/example/UserRepository.java",
+          "text": "import java.sql.Connection;\nimport java.sql.ResultSet;\nimport java.sql.Statement;\n\npublic class UserRepository {\n  ResultSet find(Connection connection, String email) throws Exception {\n    Statement statement = connection.createStatement();\n    return statement.executeQuery(\"select * from users where email = '\" + email + \"'\");\n  }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_prepared_statement_parameters",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/java/example/UserRepository.java",
+          "text": "import java.sql.Connection;\nimport java.sql.PreparedStatement;\nimport java.sql.ResultSet;\n\npublic class UserRepository {\n  ResultSet find(Connection connection, String email) throws Exception {\n    PreparedStatement statement = connection.prepareStatement(\"select * from users where email = ?\");\n    statement.setString(1, email);\n    return statement.executeQuery();\n  }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/java/fixtures/no_hardcoded_secrets.json
+++ b/java/fixtures/no_hardcoded_secrets.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_hardcoded_secrets",
+  "cases": [
+    {
+      "name": "blocks_hardcoded_token",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/main/java/example/Client.java",
+          "text": "public class Client {\n  private static final String API_TOKEN = \"prod_sk_live_1234567890abcdef\";\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_environment_secret_lookup",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/java/example/Client.java",
+          "text": "public class Client {\n  private static final String API_TOKEN = System.getenv(\"API_TOKEN\");\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/java/fixtures/no_print_stack_trace.json
+++ b/java/fixtures/no_print_stack_trace.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_print_stack_trace",
+  "cases": [
+    {
+      "name": "blocks_print_stack_trace",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/main/java/example/Importer.java",
+          "text": "import java.io.IOException;\n\npublic class Importer {\n  void run() {\n    try {\n      load();\n    } catch (IOException ex) {\n      ex.printStackTrace();\n    }\n  }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_logger_with_exception",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/java/example/Importer.java",
+          "text": "import java.io.IOException;\nimport java.util.logging.Level;\nimport java.util.logging.Logger;\n\npublic class Importer {\n  private static final Logger logger = Logger.getLogger(Importer.class.getName());\n\n  void run() {\n    try {\n      load();\n    } catch (IOException ex) {\n      logger.log(Level.WARNING, \"load failed\", ex);\n    }\n  }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/java/fixtures/no_raw_collection_types.json
+++ b/java/fixtures/no_raw_collection_types.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_raw_collection_types",
+  "cases": [
+    {
+      "name": "blocks_raw_list_field",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/main/java/example/Users.java",
+          "text": "import java.util.List;\n\npublic class Users {\n  private List names;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_parameterized_list_field",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/java/example/Users.java",
+          "text": "import java.util.List;\n\npublic class Users {\n  private List<String> names;\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/java/fixtures/no_swallowed_exceptions.json
+++ b/java/fixtures/no_swallowed_exceptions.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_swallowed_exceptions",
+  "cases": [
+    {
+      "name": "blocks_empty_catch",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/main/java/example/Importer.java",
+          "text": "import java.io.IOException;\n\npublic class Importer {\n  void run() {\n    try {\n      load();\n    } catch (IOException ex) {\n    }\n  }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_rethrowing_catch",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/java/example/Importer.java",
+          "text": "import java.io.IOException;\n\npublic class Importer {\n  void run() {\n    try {\n      load();\n    } catch (IOException ex) {\n      throw new IllegalStateException(\"load failed\", ex);\n    }\n  }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/java/fixtures/no_system_out_in_prod.json
+++ b/java/fixtures/no_system_out_in_prod.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_system_out_in_prod",
+  "cases": [
+    {
+      "name": "warns_stdout_in_production",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/main/java/example/Server.java",
+          "text": "public class Server {\n  void start() {\n    System.out.println(\"started\");\n  }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_stdout_in_test",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/test/java/example/ServerTest.java",
+          "text": "public class ServerTest {\n  void start() {\n    System.out.println(\"started\");\n  }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/java/fixtures/null_safety_annotations.json
+++ b/java/fixtures/null_safety_annotations.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "null_safety_annotations",
+  "cases": [
+    {
+      "name": "warns_public_reference_api_without_nullness",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/main/java/example/UserDirectory.java",
+          "text": "public class UserDirectory {\n  public String displayName(User user) {\n    return user.name();\n  }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_null_marked_api",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/java/example/UserDirectory.java",
+          "text": "import org.jspecify.annotations.NullMarked;\n\n@NullMarked\npublic class UserDirectory {\n  public String displayName(User user) {\n    return user.name();\n  }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/java/fixtures/optional_returns_are_not_null.json
+++ b/java/fixtures/optional_returns_are_not_null.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "optional_returns_are_not_null",
+  "cases": [
+    {
+      "name": "blocks_null_optional_return",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/main/java/example/Lookup.java",
+          "text": "import java.util.Optional;\n\npublic class Lookup {\n  Optional<String> find(String id) {\n    return null;\n  }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_empty_optional_return",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/java/example/Lookup.java",
+          "text": "import java.util.Optional;\n\npublic class Lookup {\n  Optional<String> find(String id) {\n    return Optional.empty();\n  }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/java/fixtures/prefer_stream_over_loop.json
+++ b/java/fixtures/prefer_stream_over_loop.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "prefer_stream_over_loop",
+  "cases": [
+    {
+      "name": "warns_index_loop_over_collection",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/main/java/example/Formatter.java",
+          "text": "import java.util.List;\n\npublic class Formatter {\n  String join(List<String> names) {\n    StringBuilder out = new StringBuilder();\n    for (int i = 0; i < names.size(); i++) {\n      out.append(names.get(i));\n    }\n    return out.toString();\n  }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_stream_join",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/java/example/Formatter.java",
+          "text": "import java.util.List;\nimport java.util.stream.Collectors;\n\npublic class Formatter {\n  String join(List<String> names) {\n    return names.stream().collect(Collectors.joining());\n  }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/java/invariants.harn
+++ b/java/invariants.harn
@@ -1,0 +1,277 @@
+let _EVIDENCE_RAW_TYPES = [
+  "https://docs.oracle.com/javase/specs/jls/se25/html/jls-4.html#jls-4.8",
+  "https://docs.oracle.com/javase/tutorial/java/generics/rawTypes.html",
+]
+
+let _EVIDENCE_NULLNESS = [
+  "https://jspecify.dev/docs/user-guide/",
+  "https://github.com/uber/NullAway/wiki/Supported-Annotations",
+]
+
+let _EVIDENCE_RECORDS = ["https://docs.oracle.com/en/java/javase/25/language/records.html", "https://openjdk.org/jeps/395"]
+
+let _EVIDENCE_EMPTY_CATCH = [
+  "https://errorprone.info/bugpattern/EmptyCatch",
+  "https://checkstyle.sourceforge.io/checks/blocks/emptycatchblock.html",
+]
+
+let _EVIDENCE_STREAMS = [
+  "https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/util/stream/Stream.html",
+  "https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/util/Collection.html#stream()",
+]
+
+let _EVIDENCE_EXCEPTION_LOGGING = [
+  "https://errorprone.info/bugpattern/CatchAndPrintStackTrace",
+  "https://docs.oracle.com/en/java/javase/25/docs/api/java.logging/java/util/logging/Logger.html",
+]
+
+let _EVIDENCE_PRODUCTION_LOGGING = [
+  "https://docs.oracle.com/en/java/javase/25/docs/api/java.logging/java/util/logging/Logger.html",
+  "https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html",
+]
+
+let _EVIDENCE_OPTIONAL = [
+  "https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/util/Optional.html",
+  "https://errorprone.info/bugpattern/NullOptional",
+]
+
+let _EVIDENCE_SQL = [
+  "https://docs.oracle.com/en/java/javase/25/docs/api/java.sql/java/sql/PreparedStatement.html",
+  "https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html",
+]
+
+let _EVIDENCE_SECRETS = [
+  "https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html",
+  "https://docs.github.com/code-security/secret-scanning/about-secret-scanning",
+]
+
+fn java_files(slice) {
+  return slice.files.filter({ file -> file.path.ends_with(".java") })
+}
+
+fn is_test_path(path) {
+  return contains(path, "/test/")
+    || contains(path, "/tests/")
+    || contains(path, "/src/test/")
+    || path.ends_with("Test.java")
+    || path.ends_with("Tests.java")
+    || path.ends_with("IT.java")
+}
+
+fn production_java_files(slice) {
+  return java_files(slice).filter({ file -> !is_test_path(file.path) })
+}
+
+fn scan_files(files, pattern) {
+  var findings = []
+  for file in files {
+    if regex_match(pattern, file.text, "s") != nil {
+      findings = findings.push({path: file.path, pattern: pattern})
+    }
+  }
+  return findings
+}
+
+fn scan_files_if(files, predicate) {
+  var findings = []
+  for file in files {
+    if predicate(file.text) {
+      findings = findings.push({path: file.path})
+    }
+  }
+  return findings
+}
+
+fn allow(rule) {
+  return {verdict: "Allow", rule: rule, findings: [], remediation: ""}
+}
+
+fn warn(rule, remediation, findings) {
+  return {verdict: "Warn", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block(rule, remediation, findings) {
+  return {verdict: "Block", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return block(rule, remediation, findings)
+}
+
+fn warn_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return warn(rule, remediation, findings)
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_RAW_TYPES, confidence: 0.78, source_date: "2026-05-08")
+/** Blocks raw common generic collection and Optional declarations in production Java. */
+pub fn no_raw_collection_types(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_java_files(slice),
+    r"\b(List|Map|Set|Collection|Iterator|Iterable|Optional)\s+[A-Za-z_][A-Za-z0-9_]*\b",
+  )
+  return block_on_findings(
+    "no_raw_collection_types",
+    "Parameterize Java collections and Optional with concrete type arguments or wildcards.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_NULLNESS, confidence: 0.64, source_date: "2026-05-08")
+/** Warns when public reference-returning methods lack local or package nullness annotations. */
+pub fn null_safety_annotations(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    production_java_files(slice),
+    { text -> regex_match(
+      r"(?m)^\s*public\s+(static\s+|final\s+|synchronized\s+|abstract\s+)*[A-Z][A-Za-z0-9_<>, ?\[\]]+\s+[a-zA-Z_][A-Za-z0-9_]*\s*\(",
+      text,
+      "s",
+    )
+      != nil
+      && regex_match(
+      r"@(NullMarked|NonNullApi|ParametersAreNonnullByDefault|Nullable|NonNull|Nonnull|CheckForNull)\b",
+      text,
+      "s",
+    )
+      == nil },
+  )
+  return warn_on_findings(
+    "null_safety_annotations",
+    "Mark public reference APIs with package defaults or explicit nullable/non-null annotations.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_RECORDS, confidence: 0.6, source_date: "2026-05-08")
+/** Warns when simple final-field value carriers are added as classes instead of records. */
+pub fn immutable_value_objects(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    production_java_files(slice),
+    { text -> regex_match(r"\b(class)\s+[A-Z][A-Za-z0-9_]*\b", text, "s") != nil
+      && regex_match(r"private\s+final\s+[A-Za-z0-9_<>, ?\[\]]+\s+[a-zA-Z_][A-Za-z0-9_]*\s*;", text, "s")
+      != nil
+      && regex_match(r"public\s+[A-Z][A-Za-z0-9_]*\s*\([^)]*\)\s*\{", text, "s") != nil
+      && regex_match(r"\brecord\s+[A-Z][A-Za-z0-9_]*\b", text, "s") == nil },
+  )
+  return warn_on_findings(
+    "immutable_value_objects",
+    "Use a record for plain immutable data carriers on Java 17+ unless class identity is required.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_EMPTY_CATCH, confidence: 0.9, source_date: "2026-05-08")
+/** Blocks empty catch blocks in production Java. */
+pub fn no_swallowed_exceptions(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(production_java_files(slice), r"catch\s*\([^)]*\)\s*\{\s*\}")
+  return block_on_findings(
+    "no_swallowed_exceptions",
+    "Handle, log, rethrow, or comment intentionally ignored exceptions.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_STREAMS, confidence: 0.56, source_date: "2026-05-08")
+/** Warns on index-based loops over collection size/get pairs. */
+pub fn prefer_stream_over_loop(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_java_files(slice),
+    r"for\s*\(\s*int\s+[A-Za-z_][A-Za-z0-9_]*\s*=\s*0\s*;\s*[A-Za-z_][A-Za-z0-9_]*\s*<\s*[A-Za-z_][A-Za-z0-9_]*\.size\(\)\s*;\s*[A-Za-z_][A-Za-z0-9_]*\+\+\s*\)\s*\{[^}]*\.get\(\s*[A-Za-z_][A-Za-z0-9_]*\s*\)",
+  )
+  return warn_on_findings(
+    "prefer_stream_over_loop",
+    "Prefer enhanced for-loops or Stream operations over index loops on collections.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_EXCEPTION_LOGGING, confidence: 0.84, source_date: "2026-05-08")
+/** Blocks catch-and-printStackTrace exception handling in production Java. */
+pub fn no_print_stack_trace(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(production_java_files(slice), r"\.printStackTrace\s*\(")
+  return block_on_findings(
+    "no_print_stack_trace",
+    "Log exceptions with context or rethrow them instead of calling printStackTrace().",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_PRODUCTION_LOGGING, confidence: 0.78, source_date: "2026-05-08")
+/** Warns on direct stdout/stderr writes in production Java. */
+pub fn no_system_out_in_prod(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(production_java_files(slice), r"\bSystem\.(out|err)\.(print|println|printf)\s*\(")
+  return warn_on_findings(
+    "no_system_out_in_prod",
+    "Use the project logger instead of System.out or System.err in production code.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_OPTIONAL, confidence: 0.82, source_date: "2026-05-08")
+/** Blocks returning null from Optional-returning methods. */
+pub fn optional_returns_are_not_null(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_java_files(slice),
+    r"Optional\s*<[^>]+>\s+[A-Za-z_][A-Za-z0-9_]*\s*\([^)]*\)\s*\{[^}]*return\s+null\s*;",
+  )
+  return block_on_findings(
+    "optional_returns_are_not_null",
+    "Return Optional.empty() or Optional.ofNullable(...) instead of null.",
+    findings,
+  )
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_SQL, confidence: 0.66, source_date: "2026-05-08")
+/** Blocks JDBC SQL built from untrusted string concatenation without bind parameters. */
+pub fn jdbc_queries_use_parameters(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed Java builds SQL for JDBC, JPA native queries, or Spring JDBC by concatenating or formatting user-controlled values into the query text instead of using PreparedStatement parameters, named parameters, or a query builder that binds values."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: java_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "jdbc_queries_use_parameters",
+      "Bind SQL values with PreparedStatement, named parameters, or a safe query builder.",
+      judgement.findings,
+    )
+  }
+  return allow("jdbc_queries_use_parameters")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_SECRETS, confidence: 0.68, source_date: "2026-05-08")
+/** Blocks hardcoded credentials, tokens, and private keys in Java source. */
+pub fn no_hardcoded_secrets(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed Java embeds a credential, API key, token, private key, signing secret, password, or production connection string instead of reading it from a managed secret source."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: java_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "no_hardcoded_secrets",
+      "Move credentials to a secret manager or scoped environment variable and rotate exposed values.",
+      judgement.findings,
+    )
+  }
+  return allow("no_hardcoded_secrets")
+}


### PR DESCRIPTION
## Summary

- Adds a Java v0 seed predicate pack with 8 deterministic predicates and 2 semantic predicates.
- Documents Java stack assumptions, evidence sources, known gaps, and fixture shape.
- Adds allow/block or allow/warn fixtures for every Java predicate and links the pack from the repo README.

Closes #9

## Verification

- `harn check harn/invariants.harn java/invariants.harn python/invariants.harn rust/invariants.harn swift/invariants.harn typescript/invariants.harn`
- `find java/fixtures -name '*.json' -print0 | xargs -0 -n1 jq empty`
- `git diff --check HEAD~1 HEAD`
- Deterministic Java fixture smoke replay with a local Node script
- Java evidence link HEAD check for every URL in `java/invariants.harn`

## Notes

A repo-wide `find . -name 'invariants.harn' -print0 | xargs -0 harn check` still fails on the existing SQL placeholder file (`sql/invariants.harn`), which is outside this Java pack change.
