### PR TITLE
Add Ruby seed predicate pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ See the Harn Flow design docs for the full predicate language spec.
 - [Harn](./harn/) — v0 draft predicates for `.harn` scripts, Flow workflows, and agent-facing Harn modules.
 - [JavaScript](./javascript/) — v0 draft predicates for plain JavaScript source, async handling, dynamic-code hazards, and untrusted data boundaries.
 - [Python](./python/) — v0 draft predicates for Python application and library code.
+- [Ruby](./ruby/) — v0 draft predicates for Ruby application and library code.
 - [Rust](./rust/) — v0 draft predicates for Rust application and library code.
 - [SQL](./sql/) — v0 draft predicates for schema, migration, and query safety.
 - [Swift](./swift/) — v0 draft predicates for Swift application and UI code.

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -1,0 +1,60 @@
+# Ruby Seed Predicate Pack
+
+This pack covers general-purpose Ruby application and library code before framework-specific packs such as Rails add tighter defaults. It focuses on review-slice checks with clear correctness, maintenance, or security impact: explicit string literal mutability, global mutation, risky core-class changes, legacy options hashes, dynamic evaluation, unsafe deserialization, superclass initialization, RuboCop policy drift, hardcoded secrets, and sensitive logging.
+
+## Stack Assumptions
+
+- Files use `.rb`, `.rake`, `.gemspec`, `Gemfile`, or `Rakefile` Ruby source conventions.
+- Projects target modern Ruby with keyword arguments, Psych safe-loading APIs, and RuboCop available as the local style authority.
+- Deterministic predicates run over changed source text until Flow exposes a stable Ruby AST query API. Rules with meaningful false-positive risk warn rather than block.
+- Production-path checks exclude obvious `spec/`, `test/`, `tests/`, `bin/`, `script/`, `scripts/`, `Rakefile`, and `.rake` paths.
+- Semantic predicates use one cheap judge call and should block only when they can cite concrete changed spans.
+
+## Predicate Coverage
+
+| Predicate | Mode | Verdict | Purpose |
+|---|---|---|---|
+| `frozen_string_literal_magic_comment` | deterministic | Warn | Production Ruby files should opt into frozen string literals explicitly. |
+| `no_monkey_patch_stdlib` | deterministic | Block | Application code should not reopen high-risk Ruby core classes globally. |
+| `no_global_variables` | deterministic | Block | Application-defined `$globals` leak mutable state across the process. |
+| `no_class_variable_state` | deterministic | Block | Class variables are shared through inheritance and make state ownership unclear. |
+| `prefer_keyword_args` | deterministic | Warn | Modern Ruby APIs should prefer explicit keyword arguments over `options = {}`. |
+| `no_dynamic_eval` | deterministic | Block | Dynamic `eval`-style execution is hard to reason about and can become injection. |
+| `no_unsafe_deserialization` | deterministic | Block | YAML/Psych/Marshal object loading should use safe, explicit deserialization paths. |
+| `initialize_calls_super` | deterministic | Warn | Subclass constructors should call `super` unless skipping parent setup is intentional. |
+| `rubocop_style_compliance` | semantic | Block | Ruby changes should honor the repo's RuboCop configuration or justify narrow disables. |
+| `no_hardcoded_secrets` | semantic | Block | Credentials and tokens should come from secret managers or scoped environment. |
+| `no_sensitive_data_in_logs` | semantic | Block | Logs, telemetry, and raised messages should not expose secrets or sensitive user data. |
+
+## Evidence
+
+Evidence scanned on 2026-05-08.
+
+- Ruby 3.4 documentation and RubyGuides: magic comments, global variables, class variables, keyword arguments, `Kernel#eval`, inheritance, refinements, modules/classes, open classes, and `Psych.safe_load`.
+- RuboCop documentation: `Style/FrozenStringLiteralComment`, `Style/GlobalVars`, `Style/ClassVars`, `Style/OptionHash`, `Security/Eval`, `Security/YAMLLoad`, `Lint/MissingSuper`, configuration, and the RuboCop project overview.
+- OWASP cheat sheets and GitHub secret scanning documentation: deserialization, secrets management, logging, and hardcoded credential risk.
+
+## Known False Positives
+
+- Regex predicates are source-text checks. Comments, string literals, metaprogramming, and multiline formatting can fool them until AST-backed matching lands.
+- `frozen_string_literal_magic_comment` warns on production Ruby files that intentionally rely on mutable string literals.
+- `no_monkey_patch_stdlib` blocks direct reopening of selected core classes even when a project intentionally centralizes compatibility patches. Prefer refinements or an explicit patch module.
+- `no_global_variables` only targets lowercase application globals; special Ruby globals and uppercase builtin globals are left alone.
+- `no_dynamic_eval` allows literal-string eval calls but blocks dynamic arguments. It cannot prove whether a variable is trusted.
+- `no_unsafe_deserialization` blocks all `Marshal.load` and direct YAML/Psych load calls because source text cannot prove trust boundaries.
+- `initialize_calls_super` is conservative at the file level and may warn when `super` appears outside the target constructor or when a parent constructor is intentionally skipped.
+- Semantic predicates depend on a cheap judge and should stay high-threshold until Flow exposes structured Ruby data-flow and RuboCop results.
+
+## Fixtures
+
+Each fixture in `fixtures/` contains one blocked or warned example and one allowed example for the corresponding predicate. The fixture shape mirrors the existing seed packs:
+
+```json
+{
+  "predicate": "name",
+  "cases": [
+    {"expect": "Block", "files": [{"path": "app/service.rb", "text": "..."}]},
+    {"expect": "Allow", "files": [{"path": "app/service.rb", "text": "..."}]}
+  ]
+}
+```

--- a/ruby/fixtures/frozen_string_literal_magic_comment.json
+++ b/ruby/fixtures/frozen_string_literal_magic_comment.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "frozen_string_literal_magic_comment",
+  "cases": [
+    {
+      "name": "warns_when_production_file_lacks_magic_comment",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "app/models/invoice.rb",
+          "text": "class Invoice\n  CURRENCY = \"USD\"\nend\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_magic_comment_after_shebang",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "app/models/invoice.rb",
+          "text": "#!/usr/bin/env ruby\n# frozen_string_literal: true\n\nclass Invoice\n  CURRENCY = \"USD\"\nend\n"
+        }
+      ]
+    }
+  ]
+}

--- a/ruby/fixtures/initialize_calls_super.json
+++ b/ruby/fixtures/initialize_calls_super.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "initialize_calls_super",
+  "cases": [
+    {
+      "name": "warns_when_subclass_initialize_skips_super",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "app/jobs/send_email_job.rb",
+          "text": "# frozen_string_literal: true\n\nclass SendEmailJob < ApplicationJob\n  def initialize(mailbox)\n    @mailbox = mailbox\n  end\nend\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_super_call",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "app/jobs/send_email_job.rb",
+          "text": "# frozen_string_literal: true\n\nclass SendEmailJob < ApplicationJob\n  def initialize(mailbox)\n    super()\n    @mailbox = mailbox\n  end\nend\n"
+        }
+      ]
+    }
+  ]
+}

--- a/ruby/fixtures/no_class_variable_state.json
+++ b/ruby/fixtures/no_class_variable_state.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_class_variable_state",
+  "cases": [
+    {
+      "name": "blocks_class_variable_assignment",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "app/models/account.rb",
+          "text": "# frozen_string_literal: true\n\nclass Account\n  @@cache = {}\nend\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_class_instance_variable",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "app/models/account.rb",
+          "text": "# frozen_string_literal: true\n\nclass Account\n  @cache = {}\nend\n"
+        }
+      ]
+    }
+  ]
+}

--- a/ruby/fixtures/no_dynamic_eval.json
+++ b/ruby/fixtures/no_dynamic_eval.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_dynamic_eval",
+  "cases": [
+    {
+      "name": "blocks_variable_eval",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "app/services/rule_runner.rb",
+          "text": "# frozen_string_literal: true\n\nclass RuleRunner\n  def run(source)\n    eval(source)\n  end\nend\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_explicit_dispatch",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "app/services/rule_runner.rb",
+          "text": "# frozen_string_literal: true\n\nclass RuleRunner\n  HANDLERS = { notify: :notify }.freeze\n\n  def run(name)\n    public_send(HANDLERS.fetch(name))\n  end\nend\n"
+        }
+      ]
+    }
+  ]
+}

--- a/ruby/fixtures/no_global_variables.json
+++ b/ruby/fixtures/no_global_variables.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_global_variables",
+  "cases": [
+    {
+      "name": "blocks_application_global_assignment",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "lib/current_tenant.rb",
+          "text": "# frozen_string_literal: true\n\n$current_tenant = nil\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_constant_state",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "lib/current_tenant.rb",
+          "text": "# frozen_string_literal: true\n\nDEFAULT_TENANT = \"public\"\n"
+        }
+      ]
+    }
+  ]
+}

--- a/ruby/fixtures/no_hardcoded_secrets.json
+++ b/ruby/fixtures/no_hardcoded_secrets.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_hardcoded_secrets",
+  "cases": [
+    {
+      "name": "blocks_embedded_api_token",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "app/clients/billing_client.rb",
+          "text": "# frozen_string_literal: true\n\nclass BillingClient\n  TOKEN = \"example_live_token_do_not_use_0123456789abcdef\"\nend\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_environment_secret_lookup",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "app/clients/billing_client.rb",
+          "text": "# frozen_string_literal: true\n\nclass BillingClient\n  def token\n    ENV.fetch(\"BILLING_API_TOKEN\")\n  end\nend\n"
+        }
+      ]
+    }
+  ]
+}

--- a/ruby/fixtures/no_monkey_patch_stdlib.json
+++ b/ruby/fixtures/no_monkey_patch_stdlib.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_monkey_patch_stdlib",
+  "cases": [
+    {
+      "name": "blocks_reopening_core_class",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "app/core_ext/string.rb",
+          "text": "# frozen_string_literal: true\n\nclass String\n  def to_slug\n    downcase.tr(\" \", \"-\")\n  end\nend\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_scoped_refinement",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "app/refinements/string_slug.rb",
+          "text": "# frozen_string_literal: true\n\nmodule StringSlug\n  refine String do\n    def to_slug\n      downcase.tr(\" \", \"-\")\n    end\n  end\nend\n"
+        }
+      ]
+    }
+  ]
+}

--- a/ruby/fixtures/no_sensitive_data_in_logs.json
+++ b/ruby/fixtures/no_sensitive_data_in_logs.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_sensitive_data_in_logs",
+  "cases": [
+    {
+      "name": "blocks_token_logging",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "app/controllers/sessions_controller.rb",
+          "text": "# frozen_string_literal: true\n\nclass SessionsController\n  def create(user, token)\n    Rails.logger.info(\"login token=#{token} user=#{user.email}\")\n  end\nend\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_redacted_logging",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "app/controllers/sessions_controller.rb",
+          "text": "# frozen_string_literal: true\n\nclass SessionsController\n  def create(user, _token)\n    Rails.logger.info(\"login user_id=#{user.id} token=[REDACTED]\")\n  end\nend\n"
+        }
+      ]
+    }
+  ]
+}

--- a/ruby/fixtures/no_unsafe_deserialization.json
+++ b/ruby/fixtures/no_unsafe_deserialization.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_unsafe_deserialization",
+  "cases": [
+    {
+      "name": "blocks_yaml_load",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "app/config_loader.rb",
+          "text": "# frozen_string_literal: true\n\nrequire \"yaml\"\n\nclass ConfigLoader\n  def load(text)\n    YAML.load(text)\n  end\nend\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_safe_load",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "app/config_loader.rb",
+          "text": "# frozen_string_literal: true\n\nrequire \"psych\"\n\nclass ConfigLoader\n  def load(text)\n    Psych.safe_load(text, permitted_classes: [], aliases: false)\n  end\nend\n"
+        }
+      ]
+    }
+  ]
+}

--- a/ruby/fixtures/prefer_keyword_args.json
+++ b/ruby/fixtures/prefer_keyword_args.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "prefer_keyword_args",
+  "cases": [
+    {
+      "name": "warns_on_options_hash_parameter",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "lib/report.rb",
+          "text": "# frozen_string_literal: true\n\ndef build_report(options = {})\n  limit = options.fetch(:limit, 100)\n  limit\nend\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_keyword_arguments",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "lib/report.rb",
+          "text": "# frozen_string_literal: true\n\ndef build_report(limit: 100)\n  limit\nend\n"
+        }
+      ]
+    }
+  ]
+}

--- a/ruby/fixtures/rubocop_style_compliance.json
+++ b/ruby/fixtures/rubocop_style_compliance.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "rubocop_style_compliance",
+  "cases": [
+    {
+      "name": "blocks_broad_rubocop_disable",
+      "expect": "Block",
+      "files": [
+        {
+          "path": ".rubocop.yml",
+          "text": "Style/FrozenStringLiteralComment:\n  Enabled: false\nSecurity/Eval:\n  Enabled: false\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_narrow_documented_disable",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": ".rubocop.yml",
+          "text": "Style/Documentation:\n  Exclude:\n    - \"db/migrate/**/*\"\n"
+        }
+      ]
+    }
+  ]
+}

--- a/ruby/invariants.harn
+++ b/ruby/invariants.harn
@@ -1,0 +1,327 @@
+let _EVIDENCE_FROZEN_STRING_LITERAL = [
+  "https://docs.ruby-lang.org/en/3.4/syntax/comments_rdoc.html",
+  "https://docs.rubocop.org/rubocop/latest/cops_style.html#stylefrozenstringliteralcomment",
+]
+
+let _EVIDENCE_MONKEY_PATCH = [
+  "https://docs.ruby-lang.org/en/3.4/syntax/refinements_rdoc.html",
+  "https://docs.ruby-lang.org/en/3.4/syntax/modules_and_classes_rdoc.html",
+  "https://rubyguides.dev/guides/ruby-open-classes/",
+]
+
+let _EVIDENCE_GLOBAL_VARIABLES = [
+  "https://docs.ruby-lang.org/en/3.4/syntax/assignment_rdoc.html#label-Global+Variables",
+  "https://docs.rubocop.org/rubocop/latest/cops_style.html#styleglobalvars",
+]
+
+let _EVIDENCE_CLASS_VARIABLES = [
+  "https://docs.ruby-lang.org/en/3.4/syntax/assignment_rdoc.html#label-Class+Variables",
+  "https://docs.rubocop.org/rubocop/latest/cops_style.html#styleclassvars",
+]
+
+let _EVIDENCE_KEYWORD_ARGS = [
+  "https://docs.ruby-lang.org/en/3.4/syntax/methods_rdoc.html#label-Keyword+Arguments",
+  "https://docs.rubocop.org/rubocop/latest/cops_style.html#styleoptionhash",
+]
+
+let _EVIDENCE_DYNAMIC_EVAL = [
+  "https://docs.ruby-lang.org/en/3.4/Kernel.html#method-i-eval",
+  "https://docs.rubocop.org/rubocop/latest/cops_security.html#securityeval",
+]
+
+let _EVIDENCE_UNSAFE_DESERIALIZATION = [
+  "https://docs.ruby-lang.org/en/3.4/Psych.html#method-c-safe_load",
+  "https://docs.rubocop.org/rubocop/latest/cops_security.html#securityyamlload",
+  "https://cheatsheetseries.owasp.org/cheatsheets/Deserialization_Cheat_Sheet.html",
+]
+
+let _EVIDENCE_MISSING_SUPER = [
+  "https://docs.rubocop.org/rubocop/latest/cops_lint.html#lintmissingsuper",
+  "https://docs.ruby-lang.org/en/3.4/syntax/modules_and_classes_rdoc.html#label-Inheritance",
+]
+
+let _EVIDENCE_RUBOCOP = [
+  "https://docs.rubocop.org/rubocop/latest/index.html",
+  "https://docs.rubocop.org/rubocop/latest/configuration.html",
+]
+
+let _EVIDENCE_SECRETS = [
+  "https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html",
+  "https://docs.github.com/code-security/secret-scanning/about-secret-scanning",
+]
+
+let _EVIDENCE_SENSITIVE_LOGS = [
+  "https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html",
+  "https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html",
+]
+
+fn ruby_files(slice) {
+  return slice.files
+    .filter(
+    { file -> file.path.ends_with(".rb")
+    || file.path.ends_with(".rake")
+    || file.path.ends_with(".gemspec")
+    || file.path.ends_with("Gemfile")
+    || file.path.ends_with("Rakefile") },
+  )
+}
+
+fn is_test_path(path) {
+  return contains(path, "_spec.rb")
+    || contains(path, "_test.rb")
+    || contains(path, "/spec/")
+    || contains(path, "/test/")
+    || contains(path, "/tests/")
+}
+
+fn is_script_path(path) {
+  return contains(path, "/bin/")
+    || contains(path, "/script/")
+    || contains(path, "/scripts/")
+    || path.ends_with("Rakefile")
+    || path.ends_with(".rake")
+}
+
+fn production_ruby_files(slice) {
+  return ruby_files(slice)
+    .filter({ file -> !is_test_path(file.path) && !is_script_path(file.path) })
+}
+
+fn scan_files(files, pattern, flags) {
+  var findings = []
+  for file in files {
+    if regex_match(pattern, file.text, flags) != nil {
+      findings = findings
+        .push({path: file.path, pattern: pattern})
+    }
+  }
+  return findings
+}
+
+fn scan_files_if(files, predicate) {
+  var findings = []
+  for file in files {
+    if predicate(file) {
+      findings = findings
+        .push({path: file.path})
+    }
+  }
+  return findings
+}
+
+fn scan_files_without(files, include_pattern, exclude_pattern) {
+  return scan_files_if(
+    files,
+    { file -> regex_match(include_pattern, file.text, "s") != nil
+      && regex_match(exclude_pattern, file.text, "s") == nil },
+  )
+}
+
+fn allow(rule) {
+  return {verdict: "Allow", rule: rule, findings: [], remediation: ""}
+}
+
+fn warn(rule, remediation, findings) {
+  return {verdict: "Warn", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block(rule, remediation, findings) {
+  return {verdict: "Block", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return block(rule, remediation, findings)
+}
+
+fn warn_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return warn(rule, remediation, findings)
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_FROZEN_STRING_LITERAL, confidence: 0.74, source_date: "2026-05-08")
+/** Warns on Ruby source files without an explicit frozen string literal magic comment. */
+pub fn frozen_string_literal_magic_comment(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_without(
+    production_ruby_files(slice),
+    r"(?s)\A(?:#![^\n]*\n)?(?:#\s*encoding:[^\n]*\n)?",
+    r"(?m)\A(?:#![^\n]*\n)?(?:#\s*encoding:[^\n]*\n)?#\s*frozen_string_literal:\s*true\b",
+  )
+  return warn_on_findings(
+    "frozen_string_literal_magic_comment",
+    "Add # frozen_string_literal: true near the top of production Ruby files.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_MONKEY_PATCH, confidence: 0.7, source_date: "2026-05-08")
+/** Blocks reopening high-risk Ruby core classes in production application code. */
+pub fn no_monkey_patch_stdlib(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_ruby_files(slice),
+    r"(?m)^\s*class\s+(String|Array|Hash|Integer|Float|Numeric|Symbol|Object|Kernel|Module|Class|Regexp|Time|Date)\b",
+    "m",
+  )
+  return block_on_findings(
+    "no_monkey_patch_stdlib",
+    "Use a wrapper, explicit module, or scoped refinement instead of reopening Ruby core classes.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_GLOBAL_VARIABLES, confidence: 0.78, source_date: "2026-05-08")
+/** Blocks assignment to application-defined global variables. */
+pub fn no_global_variables(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    ruby_files(slice),
+    r"(?m)(^|[^$])\$[a-z_][A-Za-z0-9_]*\s*=",
+    "m",
+  )
+  return block_on_findings(
+    "no_global_variables",
+    "Replace application globals with injected dependencies, constants, or object state.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_CLASS_VARIABLES, confidence: 0.82, source_date: "2026-05-08")
+/** Blocks writes to class variables because they are shared through inheritance. */
+pub fn no_class_variable_state(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(ruby_files(slice), r"(?m)@@[A-Za-z_][A-Za-z0-9_]*\s*=", "m")
+  return block_on_findings(
+    "no_class_variable_state",
+    "Use class instance variables or explicit shared state instead of class variables.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_KEYWORD_ARGS, confidence: 0.72, source_date: "2026-05-08")
+/** Warns on options-hash parameters where modern keyword arguments are clearer. */
+pub fn prefer_keyword_args(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    ruby_files(slice),
+    r"(?m)^\s*def\s+[A-Za-z_][A-Za-z0-9_!?=]*\s*\([^)]*\b(options|opts|params)\s*=\s*\{\s*\}",
+    "m",
+  )
+  return warn_on_findings(
+    "prefer_keyword_args",
+    "Prefer explicit keyword arguments over open-ended options hashes.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_DYNAMIC_EVAL, confidence: 0.8, source_date: "2026-05-08")
+/** Blocks dynamic eval-style execution from changed Ruby source. */
+pub fn no_dynamic_eval(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_without(
+    ruby_files(slice),
+    r"(?m)(^|[^A-Za-z0-9_])(eval|instance_eval|class_eval|module_eval)\s*\(",
+    r"(eval|instance_eval|class_eval|module_eval)\s*\(\s*['\"]",
+  )
+  return block_on_findings(
+    "no_dynamic_eval",
+    "Use explicit dispatch or public_send; avoid evaluating dynamic Ruby strings.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_UNSAFE_DESERIALIZATION, confidence: 0.78, source_date: "2026-05-08")
+/** Blocks unsafe object deserialization APIs in Ruby source. */
+pub fn no_unsafe_deserialization(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    ruby_files(slice),
+    r"(?m)\b(YAML|Psych)\.(load_file|unsafe_load|unsafe_load_file|load)\s*\(|\bMarshal\.load\s*\(",
+    "m",
+  )
+  return block_on_findings(
+    "no_unsafe_deserialization",
+    "Use Psych.safe_load/safe_load_file with explicit permitted classes for untrusted data.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_MISSING_SUPER, confidence: 0.68, source_date: "2026-05-08")
+/** Warns when subclass constructors override initialize without calling super. */
+pub fn initialize_calls_super(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_without(
+    ruby_files(slice),
+    r"(?s)class\s+[A-Za-z_:][A-Za-z0-9_:]*\s*<\s*[A-Za-z_:][A-Za-z0-9_:]*.*?def\s+initialize\b",
+    r"(?s)def\s+initialize\b.*?\bsuper\b",
+  )
+  return warn_on_findings(
+    "initialize_calls_super",
+    "Call super from subclass initialize methods, or document why parent initialization is intentionally skipped.",
+    findings,
+  )
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_RUBOCOP, confidence: 0.66, source_date: "2026-05-08")
+/** Blocks changes that bypass or weaken the repo's RuboCop policy without justification. */
+pub fn rubocop_style_compliance(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed Ruby code or .rubocop.yml clearly violates an enabled RuboCop rule, disables broad departments or cops without a narrow reason, or adds style drift that RuboCop would report under the repository configuration."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: slice.files})
+  if judgement.verdict == "Block" {
+    return block(
+      "rubocop_style_compliance",
+      "Keep Ruby style aligned with the repository RuboCop configuration or justify a narrow disable.",
+      judgement.findings,
+    )
+  }
+  return allow("rubocop_style_compliance")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_SECRETS, confidence: 0.68, source_date: "2026-05-08")
+/** Blocks hardcoded credentials and high-risk secrets in Ruby source. */
+pub fn no_hardcoded_secrets(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed Ruby source embeds credentials, API tokens, private keys, signing secrets, database passwords, production connection strings, or long-lived service credentials instead of reading them from a secret manager or scoped environment."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: ruby_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "no_hardcoded_secrets",
+      "Move secrets to a secret manager or scoped environment variable and rotate exposed values.",
+      judgement.findings,
+    )
+  }
+  return allow("no_hardcoded_secrets")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_SENSITIVE_LOGS, confidence: 0.63, source_date: "2026-05-08")
+/** Blocks logs and errors that expose secrets or sensitive user data. */
+pub fn no_sensitive_data_in_logs(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed Ruby source logs, reports, or raises messages containing secrets, credentials, authorization headers, session identifiers, tokens, passwords, or sensitive personal data without redaction."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: ruby_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "no_sensitive_data_in_logs",
+      "Redact sensitive values from logs and errors; use stable identifiers instead.",
+      judgement.findings,
+    )
+  }
+  return allow("no_sensitive_data_in_logs")
+}


### PR DESCRIPTION
## Summary
- add a v0 Ruby seed predicate pack with 8 deterministic predicates and 3 semantic predicates
- document Ruby stack assumptions, evidence sources, known false positives, and fixture shape
- add allow/block or allow/warn fixtures for every Ruby predicate and list Ruby in the root pack index

Closes #11

## Validation
- `jq empty ruby/fixtures/*.json`
- `git diff --check HEAD~1..HEAD`
- deterministic fixture smoke replay against the Ruby predicate regex intent
- evidence URL HEAD checks returned HTTP 200
