### PR TITLE
[codex] Add Kotlin seed predicate pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ See the Harn Flow design docs for the full predicate language spec.
 - [C#](./csharp/) — v0 draft predicates for plain C# and .NET library or application code.
 - [Harn](./harn/) — v0 draft predicates for `.harn` scripts, Flow workflows, and agent-facing Harn modules.
 - [JavaScript](./javascript/) — v0 draft predicates for plain JavaScript source, async handling, dynamic-code hazards, and untrusted data boundaries.
+- [Kotlin](./kotlin/) — v0 draft predicates for Kotlin JVM, Android, and Multiplatform source.
 - [Python](./python/) — v0 draft predicates for Python application and library code.
 - [Rust](./rust/) — v0 draft predicates for Rust application and library code.
 - [SQL](./sql/) — v0 draft predicates for schema, migration, and query safety.

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -1,0 +1,62 @@
+# Kotlin Seed Predicate Pack
+
+This pack covers Kotlin JVM, Android, and Kotlin Multiplatform source with an emphasis on null-safety, coroutine structure, API clarity, and value-object idioms. The v0 rules favor simple source-text predicates for concrete failure modes and semantic predicates where platform types or async API design require code context.
+
+## Stack Assumptions
+
+- Files use `.kt` or `.kts` and target Kotlin 2.x-era language and coroutine practices.
+- JVM and Android projects may use Gradle, kotlinx.coroutines, Jetpack lifecycle scopes, Compose, Java interop, detekt, and ktlint-style formatting.
+- Deterministic predicates run over changed production Kotlin source text. Test, generated, Gradle build, and common platform test paths are excluded where appropriate.
+- Semantic predicates use `ctx.semantic_judge(...)` and must cite concrete changed spans before blocking.
+- The pack is a seed canon, not a replacement for the Kotlin compiler, explicit API mode, detekt, Android Lint, ktlint, or coroutine debug tooling.
+
+## Predicate Coverage
+
+| Predicate | Mode | Verdict | Purpose |
+|---|---|---|---|
+| `no_bang_bang` | deterministic | Block | Avoid production NPEs from non-null assertions. |
+| `immutable_by_default` | deterministic | Warn | Prefer `val` over mutable `var` declarations. |
+| `no_run_blocking_in_prod_path` | deterministic | Block | Keep blocking coroutine bridges out of production library code. |
+| `no_global_scope_launch` | deterministic | Block | Require lifecycle-owned or caller-owned coroutine scopes. |
+| `no_thread_sleep_in_suspend` | deterministic | Warn | Avoid blocking threads from suspending functions. |
+| `blocking_io_uses_io_dispatcher` | deterministic | Warn | Keep obvious blocking IO off default or main coroutine dispatchers. |
+| `explicit_visibility_for_top_level_api` | deterministic | Warn | Make top-level API visibility intentional. |
+| `data_class_for_value` | deterministic | Warn | Prefer `data class` for simple value carriers. |
+| `no_broad_detekt_suppressions` | deterministic | Warn | Keep static-analysis suppressions narrow and reviewable. |
+| `no_platform_types_in_public_api` | semantic | Block | Normalize Java interop platform types before public exposure. |
+| `suspend_for_async` | semantic | Block | Prefer suspend or Flow for new Kotlin async APIs. |
+| `no_main_thread_blocking_work` | semantic | Block | Keep blocking work out of Android and UI main-thread paths. |
+
+## Evidence
+
+Evidence scanned on 2026-05-08.
+
+- Kotlin documentation: null safety, type system, basic syntax, properties, visibility modifiers, coding conventions, data classes, coroutines basics, cancellation, and coroutine channels.
+- Kotlin API guidelines: explicit API mode and public API simplicity.
+- Android Developers: Kotlin coroutine usage and coroutine best practices for main-safety.
+- Android Open Source Project API guidelines: asynchronous and non-blocking Kotlin API design.
+- detekt documentation: style rules and suppression behavior used as ecosystem lint precedent.
+
+## Known False Positives
+
+- `no_bang_bang` is source-text based and can flag rare intentional assertions. Test paths are excluded, but production assertions should usually be replaced or localized with `requireNotNull`.
+- `immutable_by_default` warns on any `var`, including stateful UI and persistence models where mutation is intentional.
+- `no_run_blocking_in_prod_path` allows `Main.kt` and scripts as entry-point conventions, but other legitimate process entry filenames may need a suppression once suppressions exist.
+- `blocking_io_uses_io_dispatcher` looks for common blocking APIs in coroutine bodies and may miss project-specific wrappers or flag code already confined by an injected dispatcher.
+- `explicit_visibility_for_top_level_api` warns at source-text level and does not inspect Gradle explicit API mode.
+- `data_class_for_value` catches only simple constructor-property classes with hand-rolled equality, and semantic review is still needed for identity-sensitive types.
+- The semantic predicates depend on a cheap judge and should block only when the changed span clearly introduces the risk.
+
+## Fixtures
+
+Each fixture in `fixtures/` contains at least one blocked or warned production example and one allowed example for the corresponding predicate:
+
+```json
+{
+  "predicate": "name",
+  "cases": [
+    {"expect": "Block", "files": [{"path": "src/main/kotlin/App.kt", "text": "..."}]},
+    {"expect": "Allow", "files": [{"path": "src/main/kotlin/App.kt", "text": "..."}]}
+  ]
+}
+```

--- a/kotlin/fixtures/blocking_io_uses_io_dispatcher.json
+++ b/kotlin/fixtures/blocking_io_uses_io_dispatcher.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "blocking_io_uses_io_dispatcher",
+  "cases": [
+    {
+      "name": "warns_blocking_io_without_io_dispatcher",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/main/kotlin/AvatarStore.kt",
+          "text": "class AvatarStore(private val scope: CoroutineScope) {\n    fun save(bytes: ByteArray) = scope.launch {\n        FileOutputStream(\"avatar.bin\").use { it.write(bytes) }\n    }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_io_dispatcher",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/kotlin/AvatarStore.kt",
+          "text": "class AvatarStore(private val scope: CoroutineScope) {\n    fun save(bytes: ByteArray) = scope.launch {\n        withContext(Dispatchers.IO) {\n            FileOutputStream(\"avatar.bin\").use { it.write(bytes) }\n        }\n    }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/kotlin/fixtures/data_class_for_value.json
+++ b/kotlin/fixtures/data_class_for_value.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "data_class_for_value",
+  "cases": [
+    {
+      "name": "warns_value_class_with_manual_equality",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/main/kotlin/Money.kt",
+          "text": "class Money(val cents: Int, val currency: String) {\n    override fun equals(other: Any?): Boolean = other is Money && cents == other.cents\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_data_class",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/kotlin/Money.kt",
+          "text": "data class Money(val cents: Int, val currency: String)\n"
+        }
+      ]
+    }
+  ]
+}

--- a/kotlin/fixtures/explicit_visibility_for_top_level_api.json
+++ b/kotlin/fixtures/explicit_visibility_for_top_level_api.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "explicit_visibility_for_top_level_api",
+  "cases": [
+    {
+      "name": "warns_implicit_public_top_level_class",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/main/kotlin/Gateway.kt",
+          "text": "class Gateway(private val client: Client)\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_explicit_internal_top_level_class",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/kotlin/Gateway.kt",
+          "text": "internal class Gateway(private val client: Client)\n"
+        }
+      ]
+    }
+  ]
+}

--- a/kotlin/fixtures/immutable_by_default.json
+++ b/kotlin/fixtures/immutable_by_default.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "immutable_by_default",
+  "cases": [
+    {
+      "name": "warns_var_declaration",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/main/kotlin/Cart.kt",
+          "text": "class Cart {\n    var totalCents: Int = 0\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_val_declaration",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/kotlin/Cart.kt",
+          "text": "class Cart(private val items: List<Item>) {\n    val totalCents: Int = items.sumOf { it.priceCents }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/kotlin/fixtures/no_bang_bang.json
+++ b/kotlin/fixtures/no_bang_bang.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_bang_bang",
+  "cases": [
+    {
+      "name": "blocks_non_null_assertion",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/main/kotlin/Profile.kt",
+          "text": "fun displayName(user: User?): String {\n    return user!!.name\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_safe_call",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/kotlin/Profile.kt",
+          "text": "fun displayName(user: User?): String {\n    return user?.name ?: \"Anonymous\"\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/kotlin/fixtures/no_broad_detekt_suppressions.json
+++ b/kotlin/fixtures/no_broad_detekt_suppressions.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_broad_detekt_suppressions",
+  "cases": [
+    {
+      "name": "warns_broad_detekt_suppression",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/main/kotlin/Parser.kt",
+          "text": "@Suppress(\"style\")\nclass Parser\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_narrow_rule_suppression",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/kotlin/Parser.kt",
+          "text": "@Suppress(\"detekt:MagicNumber\")\nclass Parser\n"
+        }
+      ]
+    }
+  ]
+}

--- a/kotlin/fixtures/no_global_scope_launch.json
+++ b/kotlin/fixtures/no_global_scope_launch.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_global_scope_launch",
+  "cases": [
+    {
+      "name": "blocks_global_scope_launch",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/main/kotlin/SyncService.kt",
+          "text": "class SyncService {\n    fun refresh() {\n        GlobalScope.launch { syncNow() }\n    }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_injected_scope",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/kotlin/SyncService.kt",
+          "text": "class SyncService(private val scope: CoroutineScope) {\n    fun refresh() {\n        scope.launch { syncNow() }\n    }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/kotlin/fixtures/no_main_thread_blocking_work.json
+++ b/kotlin/fixtures/no_main_thread_blocking_work.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_main_thread_blocking_work",
+  "cases": [
+    {
+      "name": "blocks_blocking_disk_read_in_view_model",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/main/kotlin/ProfileViewModel.kt",
+          "text": "class ProfileViewModel : ViewModel() {\n    fun loadAvatar() {\n        viewModelScope.launch {\n            val bytes = FileInputStream(\"avatar.bin\").readBytes()\n            render(bytes)\n        }\n    }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_io_dispatcher_for_disk_read",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/kotlin/ProfileViewModel.kt",
+          "text": "class ProfileViewModel : ViewModel() {\n    fun loadAvatar() {\n        viewModelScope.launch {\n            val bytes = withContext(Dispatchers.IO) { FileInputStream(\"avatar.bin\").readBytes() }\n            render(bytes)\n        }\n    }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/kotlin/fixtures/no_platform_types_in_public_api.json
+++ b/kotlin/fixtures/no_platform_types_in_public_api.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_platform_types_in_public_api",
+  "cases": [
+    {
+      "name": "blocks_java_platform_type_at_public_boundary",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/main/kotlin/UserGateway.kt",
+          "text": "import java.sql.ResultSet\n\npublic class UserGateway {\n    public fun displayName(row: ResultSet) = row.getString(\"display_name\")\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_normalized_nullability",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/kotlin/UserGateway.kt",
+          "text": "import java.sql.ResultSet\n\npublic class UserGateway {\n    public fun displayName(row: ResultSet): String? = row.getString(\"display_name\")\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/kotlin/fixtures/no_run_blocking_in_prod_path.json
+++ b/kotlin/fixtures/no_run_blocking_in_prod_path.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_run_blocking_in_prod_path",
+  "cases": [
+    {
+      "name": "blocks_run_blocking_in_library_code",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/main/kotlin/UserRepository.kt",
+          "text": "class UserRepository(private val api: Api) {\n    fun loadUser(id: String): User = runBlocking { api.loadUser(id) }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_suspend_api",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/kotlin/UserRepository.kt",
+          "text": "class UserRepository(private val api: Api) {\n    suspend fun loadUser(id: String): User = api.loadUser(id)\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/kotlin/fixtures/no_thread_sleep_in_suspend.json
+++ b/kotlin/fixtures/no_thread_sleep_in_suspend.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_thread_sleep_in_suspend",
+  "cases": [
+    {
+      "name": "warns_thread_sleep_in_suspend_function",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/main/kotlin/Retry.kt",
+          "text": "suspend fun retryLater() {\n    Thread.sleep(1000)\n    fetchAgain()\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_delay_in_suspend_function",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/kotlin/Retry.kt",
+          "text": "suspend fun retryLater() {\n    delay(1000)\n    fetchAgain()\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/kotlin/fixtures/suspend_for_async.json
+++ b/kotlin/fixtures/suspend_for_async.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "suspend_for_async",
+  "cases": [
+    {
+      "name": "blocks_new_callback_async_api",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/main/kotlin/ProfileClient.kt",
+          "text": "class ProfileClient {\n    fun loadProfile(id: String, callback: (Profile) -> Unit) {\n        executor.execute { callback(fetchProfile(id)) }\n    }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_suspend_api",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/kotlin/ProfileClient.kt",
+          "text": "class ProfileClient {\n    suspend fun loadProfile(id: String): Profile = fetchProfile(id)\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/kotlin/invariants.harn
+++ b/kotlin/invariants.harn
@@ -1,0 +1,319 @@
+let _EVIDENCE_NULL_SAFETY = ["https://kotlinlang.org/docs/null-safety.html", "https://kotlinlang.org/spec/type-system.html"]
+
+let _EVIDENCE_MUTABILITY = [
+  "https://kotlinlang.org/docs/basic-syntax.html",
+  "https://kotlinlang.org/docs/properties.html",
+  "https://kotlinlang.org/docs/coding-conventions.html",
+]
+
+let _EVIDENCE_COROUTINES = [
+  "https://kotlinlang.org/docs/coroutines-basics.html",
+  "https://kotlinlang.org/docs/coroutines-and-channels.html",
+  "https://kotlinlang.org/docs/cancellation-and-timeouts.html",
+]
+
+let _EVIDENCE_ANDROID_COROUTINES = [
+  "https://developer.android.com/kotlin/coroutines",
+  "https://developer.android.com/kotlin/coroutines/coroutines-best-practices",
+  "https://android.googlesource.com/platform/developers/docs/+/refs/heads/main/api-guidelines/async.md",
+]
+
+let _EVIDENCE_DATA_CLASSES = [
+  "https://kotlinlang.org/docs/data-classes.html",
+  "https://kotlinlang.org/docs/coding-conventions.html",
+]
+
+let _EVIDENCE_VISIBILITY = [
+  "https://kotlinlang.org/docs/visibility-modifiers.html",
+  "https://kotlinlang.org/docs/api-guidelines-simplicity.html",
+]
+
+let _EVIDENCE_DETEKT_STYLE = ["https://detekt.dev/docs/rules/style", "https://detekt.dev/docs/introduction/suppressing-rules/"]
+
+fn kotlin_files(slice) {
+  return slice.files.filter({ file -> file.path.ends_with(".kt") || file.path.ends_with(".kts") })
+}
+
+fn is_test_path(path) {
+  return contains(path, "/test/")
+    || contains(path, "/tests/")
+    || contains(path, "/androidTest/")
+    || contains(path, "/commonTest/")
+    || contains(path, "/jvmTest/")
+    || contains(path, "/iosTest/")
+    || contains(path, "/Test/")
+    || path.ends_with("Test.kt")
+    || path.ends_with("Tests.kt")
+    || path.ends_with("Spec.kt")
+}
+
+fn is_generated_path(path) {
+  return contains(path, "/build/")
+    || contains(path, "/generated/")
+    || contains(path, "/.gradle/")
+    || path.ends_with(".generated.kt")
+}
+
+fn is_build_script_path(path) {
+  return path.ends_with("build.gradle.kts")
+    || path.ends_with("settings.gradle.kts")
+}
+
+fn production_kotlin_files(slice) {
+  return kotlin_files(slice)
+    .filter(
+    { file -> !is_test_path(file.path)
+      && !is_generated_path(file.path)
+      && !is_build_script_path(file.path) },
+  )
+}
+
+fn scan_files(files, pattern, flags) {
+  var findings = []
+  for file in files {
+    if regex_match(pattern, file.text, flags) != nil {
+      findings = findings.push({path: file.path, pattern: pattern})
+    }
+  }
+  return findings
+}
+
+fn scan_files_if(files, predicate) {
+  var findings = []
+  for file in files {
+    if predicate(file) {
+      findings = findings.push({path: file.path})
+    }
+  }
+  return findings
+}
+
+fn allow(rule) {
+  return {verdict: "Allow", rule: rule, findings: [], remediation: ""}
+}
+
+fn warn(rule, remediation, findings) {
+  return {verdict: "Warn", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block(rule, remediation, findings) {
+  return {verdict: "Block", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return block(rule, remediation, findings)
+}
+
+fn warn_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return warn(rule, remediation, findings)
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_NULL_SAFETY, confidence: 0.86, source_date: "2026-05-08")
+/** Blocks non-null assertions in production Kotlin source. */
+pub fn no_bang_bang(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(production_kotlin_files(slice), r"!!(?!\s*(=|//|[*]/))", "s")
+  return block_on_findings(
+    "no_bang_bang",
+    "Replace !! with safe calls, Elvis handling, requireNotNull, or explicit null checks.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_MUTABILITY, confidence: 0.7, source_date: "2026-05-08")
+/** Warns on mutable local or member variables in production Kotlin source. */
+pub fn immutable_by_default(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_kotlin_files(slice),
+    r"(?m)^\s*(private\s+|internal\s+|protected\s+|public\s+|override\s+|lateinit\s+)*var\s+\w+\s*[:=]",
+    "m",
+  )
+  return warn_on_findings(
+    "immutable_by_default",
+    "Prefer val; use var only when reassignment is part of the object's contract.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_COROUTINES, confidence: 0.82, source_date: "2026-05-08")
+/** Blocks runBlocking outside tests, scripts, and main entry points. */
+pub fn no_run_blocking_in_prod_path(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_kotlin_files(slice)
+      .filter(
+      { file -> !file.path.ends_with(".kts") && !file.path.ends_with("Main.kt") },
+    ),
+    r"\brunBlocking\s*\{",
+    "s",
+  )
+  return block_on_findings(
+    "no_run_blocking_in_prod_path",
+    "Keep runBlocking in tests or process entry points; expose suspend APIs instead.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_COROUTINES, confidence: 0.78, source_date: "2026-05-08")
+/** Blocks GlobalScope coroutine launches in production Kotlin source. */
+pub fn no_global_scope_launch(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(production_kotlin_files(slice), r"\bGlobalScope\s*\.\s*(launch|async)\s*\{", "s")
+  return block_on_findings(
+    "no_global_scope_launch",
+    "Launch work in a lifecycle-owned or caller-provided CoroutineScope.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_COROUTINES, confidence: 0.74, source_date: "2026-05-08")
+/** Warns when suspending code blocks threads directly. */
+pub fn no_thread_sleep_in_suspend(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_kotlin_files(slice),
+    r"(?s)\bsuspend\s+fun\b[^{]*\{[^}]*\bThread\s*\.\s*sleep\s*\(",
+    "s",
+  )
+  return warn_on_findings(
+    "no_thread_sleep_in_suspend",
+    "Use delay, runInterruptible, or move blocking work to an appropriate dispatcher.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_ANDROID_COROUTINES, confidence: 0.68, source_date: "2026-05-08")
+/** Warns when blocking IO appears inside coroutine bodies without an IO dispatcher hint. */
+pub fn blocking_io_uses_io_dispatcher(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    production_kotlin_files(slice),
+    { file -> regex_match(
+      r"\b(launch|async|withContext)\s*(\([^)]*\))?\s*\{[^}]*\b(FileInputStream|FileOutputStream|Socket|URL\s*\([^)]*\)\s*\.\s*openConnection|execute\s*\()",
+      file.text,
+      "s",
+    )
+      != nil
+      && !contains(file.text, "Dispatchers.IO") },
+  )
+  return warn_on_findings(
+    "blocking_io_uses_io_dispatcher",
+    "Run blocking IO on Dispatchers.IO or expose a suspending non-blocking API.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_VISIBILITY, confidence: 0.7, source_date: "2026-05-08")
+/** Warns on implicit public top-level declarations in production Kotlin source. */
+pub fn explicit_visibility_for_top_level_api(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_kotlin_files(slice),
+    r"(?m)^(?!\s*(private|internal|public)\b)\s*(data\s+)?(class|interface|object|fun|val|var)\s+[A-Z_a-z]",
+    "m",
+  )
+  return warn_on_findings(
+    "explicit_visibility_for_top_level_api",
+    "Add explicit public/internal/private visibility to top-level API declarations.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_DATA_CLASSES, confidence: 0.67, source_date: "2026-05-08")
+/** Warns when value-looking classes hand-roll equality instead of using data class. */
+pub fn data_class_for_value(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_kotlin_files(slice),
+    r"(?ms)^(?!\s*data\s+)\s*class\s+\w+\s*\([^)]*\bval\s+\w+[^)]*\)\s*\{[^}]*\boverride\s+fun\s+(equals|hashCode|toString)\s*\(",
+    "s",
+  )
+  return warn_on_findings(
+    "data_class_for_value",
+    "Use data class for value carriers unless identity or custom equality is intentional.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_DETEKT_STYLE, confidence: 0.66, source_date: "2026-05-08")
+/** Warns when broad detekt suppressions disable an entire rule category. */
+pub fn no_broad_detekt_suppressions(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_kotlin_files(slice),
+    "@Suppress\\s*\\(\\s*\"(detekt:)?(style|complexity|potential-bugs|performance)\"\\s*\\)",
+    "s",
+  )
+  return warn_on_findings(
+    "no_broad_detekt_suppressions",
+    "Suppress the narrow detekt rule with a reason instead of disabling a whole category.",
+    findings,
+  )
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_NULL_SAFETY, confidence: 0.64, source_date: "2026-05-08")
+/** Blocks public Kotlin APIs that expose Java platform types without a nullability contract. */
+pub fn no_platform_types_in_public_api(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed production Kotlin exposes a public or protected API whose parameter, return, property, or generic type comes from Java or Android interop and has unspecified nullability, and the code does not wrap it, annotate it, or convert it to an explicit nullable/non-null Kotlin type at the boundary."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: production_kotlin_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "no_platform_types_in_public_api",
+      "Normalize Java interop values to explicit nullable or non-null Kotlin types at public boundaries.",
+      judgement.findings,
+    )
+  }
+  return allow("no_platform_types_in_public_api")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_ANDROID_COROUTINES, confidence: 0.62, source_date: "2026-05-08")
+/** Blocks new async APIs that should be suspend-first. */
+pub fn suspend_for_async(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed Kotlin introduces a new production asynchronous API using callbacks, Future, CompletableFuture, Thread, Executor, or blocking wait patterns where a suspend function or Flow would provide the same caller-facing contract more safely, and no Java interop adapter requirement is shown."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: production_kotlin_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "suspend_for_async",
+      "Expose suspend or Flow for Kotlin async APIs; keep callbacks or futures at interop edges.",
+      judgement.findings,
+    )
+  }
+  return allow("suspend_for_async")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_ANDROID_COROUTINES, confidence: 0.6, source_date: "2026-05-08")
+/** Blocks main-thread blocking work in Android or UI-adjacent Kotlin code. */
+pub fn no_main_thread_blocking_work(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed production Kotlin that is Android UI, ViewModel, Compose, lifecycle, or main-dispatcher code performs blocking network, disk, database, sleep, lock, or wait work on the main thread without withContext(Dispatchers.IO), runInterruptible, or a documented non-blocking API."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: production_kotlin_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "no_main_thread_blocking_work",
+      "Move blocking work off the main thread with Dispatchers.IO or a non-blocking suspend API.",
+      judgement.findings,
+    )
+  }
+  return allow("no_main_thread_blocking_work")
+}


### PR DESCRIPTION
## Summary

- Adds a Kotlin seed predicate pack with 9 deterministic predicates and 3 semantic predicates covering null-safety, mutability, coroutine structure, API visibility, value classes, detekt suppressions, platform types, async API design, and main-thread blocking work.
- Adds allow/block or allow/warn fixtures for every Kotlin predicate.
- Documents Kotlin stack assumptions, evidence sources, known gaps, and updates the root pack index to include all existing packs.

Closes #12.

## Verification

- `harn fmt --check kotlin/invariants.harn`
- `harn check kotlin`
- `harn lint kotlin`
- JSON validation for every `kotlin/fixtures/*.json`
- Predicate/fixture coverage script: 12 predicates, 12 fixtures
- Lightweight deterministic fixture replay for all deterministic Kotlin predicates
- Evidence link check: all URLs in `kotlin/invariants.harn` returned HTTP 200
