### PR TITLE
Add XML seed predicate pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ See the Harn Flow design docs for the full predicate language spec.
 - [SQL](./sql/) — v0 draft predicates for schema, migration, and query safety.
 - [Swift](./swift/) — v0 draft predicates for Swift application and UI code.
 - [TypeScript](./typescript/) — v0 draft predicates for TypeScript and TSX code.
+- [XML](./xml/) — v0 draft predicates for XML payloads, XSD schemas, XSLT stylesheets, and related XML-shaped formats.
 
 ## Status
 

--- a/xml/README.md
+++ b/xml/README.md
@@ -1,0 +1,61 @@
+# XML Seed Predicate Pack
+
+This pack covers raw XML payloads, schemas (XSD), stylesheets (XSLT), and related XML-shaped formats (WSDL, SVG, RSS, Atom). XML has a smaller surface area than a full programming language, so the pack focuses on the few defaults that consistently catch real shipping incidents: external entity injection, encoding ambiguity, namespace discipline, schema hygiene, stylesheet resource loading, and credential leaks in config files.
+
+## Stack Assumptions
+
+- Source checks target `.xml`, `.xsd`, `.xsl`, `.xslt`, `.wsdl`, `.svg`, `.rss`, and `.atom` files.
+- Payload-only checks (DOCTYPE block) exclude `.xsd`, `.xsl`, and `.xslt` because schemas and stylesheets routinely declare types the parser never needs to expand.
+- Deterministic predicates operate on changed source text. Until Flow exposes an XML AST and parser-configuration query, parser-side defenses (`FEATURE_SECURE_PROCESSING`, `XMLConstants.ACCESS_EXTERNAL_DTD`, `defusedxml`, etc.) live in language packs rather than this format pack.
+- Semantic predicates may block only when the judge can cite a concrete changed span and the issue is not reliably expressible with simple syntax checks.
+
+## Predicate Coverage
+
+| Predicate | Mode | Verdict | Purpose |
+|---|---|---|---|
+| `no_inline_doctype` | deterministic | Block | XML payloads must not declare an inline DOCTYPE; the entity subset is the primary XXE vector. |
+| `no_external_entity_references` | deterministic | Block | `<!ENTITY ... SYSTEM>` and `<!ENTITY ... PUBLIC>` declarations must not appear in any XML file. |
+| `xml_declares_utf8` | deterministic | Warn | XML files should pin `encoding="UTF-8"` in the XML declaration for stable interop. |
+| `xml_namespace_prefixes_declared` | deterministic | Warn | Files that use namespace-prefixed elements must declare at least one `xmlns:prefix=` binding. |
+| `xsd_has_target_namespace` | deterministic | Warn | XSD schemas should declare a `targetNamespace` so consumers can disambiguate types. |
+| `xslt_no_external_documents` | deterministic | Block | XSLT `xsl:include`, `xsl:import`, and `document()` must not load absolute `http(s)`, `ftp`, or `file` URIs. |
+| `no_hardcoded_secrets` | semantic | Block | XML config and payload files must not embed credentials, tokens, or production connection strings. |
+| `xsd_constrains_user_input` | semantic | Block | Schema changes must not weaken validation on attacker-reachable fields. |
+
+## Evidence
+
+Evidence scanned on 2026-05-09.
+
+- W3C XML 1.0 specification (encoding declaration, DOCTYPE definition, external entity rules) and W3C Namespaces in XML 1.0.
+- W3C XML Schema 1.1 Structures specification and XML Schema Primer for `targetNamespace` semantics.
+- W3C XSLT 3.0 specification for stable URI collection rules around `document()`, `xsl:include`, and `xsl:import`.
+- IETF RFC 7303 (XML Media Types) for default encoding and charset behavior.
+- OWASP cheat sheets: XML External Entity Prevention, XML Security, and Secrets Management.
+- OWASP community page on XSLT Injection for stylesheet resource-loading risk.
+- MITRE CWE-611 (Improper Restriction of XML External Entity Reference) and CWE-776 (Recursive Entity Expansion).
+- GitHub secret scanning documentation for hardcoded credential risk and remediation context.
+
+## Known False Positives
+
+- Regex predicates are intentionally conservative and file-scoped. Files containing both an offending pattern and an allowed one may be allowed or warned imprecisely until AST-level matching lands.
+- `no_inline_doctype` blocks every DOCTYPE in payload files, including legitimate uses such as XHTML documents that intentionally reference a public DTD. Move to an external schema or a XHTML-specific override pack if needed.
+- `no_external_entity_references` blocks all SYSTEM/PUBLIC entity declarations, including ones whose targets the project controls; the safe path is still to load such fragments through application code.
+- `xml_declares_utf8` only inspects the literal XML declaration. Files relying on a UTF-8 BOM with no declaration will warn.
+- `xml_namespace_prefixes_declared` warns at file granularity when any prefix appears without a corresponding `xmlns:` binding in the same document, even when the binding is inherited from an enclosing document at runtime.
+- `xsd_has_target_namespace` does not detect chameleon schemas that intentionally omit `targetNamespace` to be re-included.
+- `xslt_no_external_documents` only catches absolute URIs in literal `href` and `document()` arguments; computed URIs slip through and should be reviewed at the call site.
+- The semantic predicates must cite concrete changed spans and should stay high-threshold to avoid blocking on speculative concerns.
+
+## Fixtures
+
+Each fixture in `fixtures/` contains one blocked or warned example and one allowed example for the corresponding predicate. The fixture shape mirrors the existing seed packs:
+
+```json
+{
+  "predicate": "name",
+  "cases": [
+    {"expect": "Block", "files": [{"path": "config/app.xml", "text": "..."}]},
+    {"expect": "Allow", "files": [{"path": "config/app.xml", "text": "..."}]}
+  ]
+}
+```

--- a/xml/fixtures/no_external_entity_references.json
+++ b/xml/fixtures/no_external_entity_references.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_external_entity_references",
+  "cases": [
+    {
+      "name": "blocks_external_system_entity",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "fixtures/payload.xml",
+          "text": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE foo [\n  <!ENTITY xxe SYSTEM \"file:///etc/passwd\">\n]>\n<foo>&xxe;</foo>\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_inline_internal_entity_free_payload",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "fixtures/payload.xml",
+          "text": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<foo xmlns=\"https://example.com/foo/v1\">\n  <bar>baz</bar>\n</foo>\n"
+        }
+      ]
+    }
+  ]
+}

--- a/xml/fixtures/no_hardcoded_secrets.json
+++ b/xml/fixtures/no_hardcoded_secrets.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_hardcoded_secrets",
+  "cases": [
+    {
+      "name": "blocks_inline_database_password",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "config/datasource.xml",
+          "text": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<datasource>\n  <jdbc-url>jdbc:postgresql://prod-db.example.com:5432/app</jdbc-url>\n  <username>app_writer</username>\n  <password>S3cret!ProdToken_2026</password>\n</datasource>\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_secret_referenced_by_env_var",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "config/datasource.xml",
+          "text": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<datasource>\n  <jdbc-url>${DB_URL}</jdbc-url>\n  <username>${DB_USERNAME}</username>\n  <password>${DB_PASSWORD}</password>\n</datasource>\n"
+        }
+      ]
+    }
+  ]
+}

--- a/xml/fixtures/no_inline_doctype.json
+++ b/xml/fixtures/no_inline_doctype.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_inline_doctype",
+  "cases": [
+    {
+      "name": "blocks_inline_doctype_in_payload",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "config/users.xml",
+          "text": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE users [\n  <!ELEMENT users ANY>\n]>\n<users>\n  <user id=\"1\">alice</user>\n</users>\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_payload_without_doctype",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "config/users.xml",
+          "text": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<users xmlns=\"https://example.com/users/v1\">\n  <user id=\"1\">alice</user>\n</users>\n"
+        }
+      ]
+    }
+  ]
+}

--- a/xml/fixtures/xml_declares_utf8.json
+++ b/xml/fixtures/xml_declares_utf8.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "xml_declares_utf8",
+  "cases": [
+    {
+      "name": "warns_when_xml_declaration_missing",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "config/feed.xml",
+          "text": "<feed xmlns=\"https://example.com/feed/v1\">\n  <entry id=\"1\">hello</entry>\n</feed>\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_utf8_declared_payload",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "config/feed.xml",
+          "text": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<feed xmlns=\"https://example.com/feed/v1\">\n  <entry id=\"1\">hello</entry>\n</feed>\n"
+        }
+      ]
+    }
+  ]
+}

--- a/xml/fixtures/xml_namespace_prefixes_declared.json
+++ b/xml/fixtures/xml_namespace_prefixes_declared.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "xml_namespace_prefixes_declared",
+  "cases": [
+    {
+      "name": "warns_when_prefixes_used_without_xmlns_bindings",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "config/order.xml",
+          "text": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ord:order>\n  <ord:line item=\"book\" qty=\"1\"/>\n</ord:order>\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_when_xmlns_prefix_declared",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "config/order.xml",
+          "text": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ord:order xmlns:ord=\"https://example.com/orders/v1\">\n  <ord:line item=\"book\" qty=\"1\"/>\n</ord:order>\n"
+        }
+      ]
+    }
+  ]
+}

--- a/xml/fixtures/xsd_constrains_user_input.json
+++ b/xml/fixtures/xsd_constrains_user_input.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "xsd_constrains_user_input",
+  "cases": [
+    {
+      "name": "blocks_xsd_relaxing_user_field_to_anytype",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "schemas/comment.xsd",
+          "text": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\n           targetNamespace=\"https://example.com/comments/v1\"\n           xmlns:c=\"https://example.com/comments/v1\"\n           elementFormDefault=\"qualified\">\n  <xs:element name=\"comment\">\n    <xs:complexType>\n      <xs:sequence>\n        <xs:any processContents=\"skip\" minOccurs=\"0\" maxOccurs=\"unbounded\"/>\n      </xs:sequence>\n    </xs:complexType>\n  </xs:element>\n</xs:schema>\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_constrained_user_input_schema",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "schemas/comment.xsd",
+          "text": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\n           targetNamespace=\"https://example.com/comments/v1\"\n           xmlns:c=\"https://example.com/comments/v1\"\n           elementFormDefault=\"qualified\">\n  <xs:element name=\"comment\">\n    <xs:complexType>\n      <xs:sequence>\n        <xs:element name=\"author\">\n          <xs:simpleType>\n            <xs:restriction base=\"xs:string\">\n              <xs:maxLength value=\"80\"/>\n            </xs:restriction>\n          </xs:simpleType>\n        </xs:element>\n        <xs:element name=\"body\">\n          <xs:simpleType>\n            <xs:restriction base=\"xs:string\">\n              <xs:maxLength value=\"4000\"/>\n            </xs:restriction>\n          </xs:simpleType>\n        </xs:element>\n      </xs:sequence>\n    </xs:complexType>\n  </xs:element>\n</xs:schema>\n"
+        }
+      ]
+    }
+  ]
+}

--- a/xml/fixtures/xsd_has_target_namespace.json
+++ b/xml/fixtures/xsd_has_target_namespace.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "xsd_has_target_namespace",
+  "cases": [
+    {
+      "name": "warns_when_xsd_omits_target_namespace",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "schemas/order.xsd",
+          "text": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\">\n  <xs:element name=\"order\" type=\"xs:string\"/>\n</xs:schema>\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_xsd_with_target_namespace",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "schemas/order.xsd",
+          "text": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<xs:schema xmlns:xs=\"http://www.w3.org/2001/XMLSchema\"\n           targetNamespace=\"https://example.com/orders/v1\"\n           xmlns:ord=\"https://example.com/orders/v1\"\n           elementFormDefault=\"qualified\">\n  <xs:element name=\"order\" type=\"xs:string\"/>\n</xs:schema>\n"
+        }
+      ]
+    }
+  ]
+}

--- a/xml/fixtures/xslt_no_external_documents.json
+++ b/xml/fixtures/xslt_no_external_documents.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "xslt_no_external_documents",
+  "cases": [
+    {
+      "name": "blocks_xsl_import_from_remote_url",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "transforms/render.xslt",
+          "text": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<xsl:stylesheet version=\"3.0\" xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\">\n  <xsl:import href=\"https://example.com/transforms/base.xslt\"/>\n  <xsl:template match=\"/\">\n    <out/>\n  </xsl:template>\n</xsl:stylesheet>\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_relative_xsl_import",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "transforms/render.xslt",
+          "text": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<xsl:stylesheet version=\"3.0\" xmlns:xsl=\"http://www.w3.org/1999/XSL/Transform\">\n  <xsl:import href=\"base.xslt\"/>\n  <xsl:template match=\"/\">\n    <out/>\n  </xsl:template>\n</xsl:stylesheet>\n"
+        }
+      ]
+    }
+  ]
+}

--- a/xml/invariants.harn
+++ b/xml/invariants.harn
@@ -1,0 +1,252 @@
+let _EVIDENCE_DOCTYPE_XXE = [
+  "https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html",
+  "https://cwe.mitre.org/data/definitions/611.html",
+  "https://www.w3.org/TR/xml/#dt-doctype",
+]
+
+let _EVIDENCE_EXTERNAL_ENTITIES = [
+  "https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html",
+  "https://cwe.mitre.org/data/definitions/776.html",
+  "https://www.w3.org/TR/xml/#sec-external-ent",
+]
+
+let _EVIDENCE_UTF8 = [
+  "https://www.w3.org/TR/xml/#charencoding",
+  "https://datatracker.ietf.org/doc/html/rfc7303",
+]
+
+let _EVIDENCE_NAMESPACES = [
+  "https://www.w3.org/TR/xml-names/",
+  "https://www.w3.org/TR/xml-names/#scoping",
+]
+
+let _EVIDENCE_XSD_TARGET_NAMESPACE = [
+  "https://www.w3.org/TR/xmlschema11-1/#sec-src-resolve",
+  "https://www.w3.org/TR/xmlschema-0/#NS",
+]
+
+let _EVIDENCE_XSLT_EXTERNAL = [
+  "https://www.w3.org/TR/xslt-30/#dt-stable-uri-collection",
+  "https://owasp.org/www-community/vulnerabilities/XSLT_Injection",
+]
+
+let _EVIDENCE_SECRETS = [
+  "https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html",
+  "https://docs.github.com/code-security/secret-scanning/about-secret-scanning",
+]
+
+let _EVIDENCE_SCHEMA_DOS = [
+  "https://cheatsheetseries.owasp.org/cheatsheets/XML_Security_Cheat_Sheet.html",
+  "https://cwe.mitre.org/data/definitions/776.html",
+]
+
+fn xml_files(slice) {
+  return slice.files
+    .filter(
+    { file -> file.path.ends_with(".xml")
+      || file.path.ends_with(".xsd")
+      || file.path.ends_with(".xsl")
+      || file.path.ends_with(".xslt")
+      || file.path.ends_with(".wsdl")
+      || file.path.ends_with(".svg")
+      || file.path.ends_with(".rss")
+      || file.path.ends_with(".atom") },
+  )
+}
+
+fn xml_payload_files(slice) {
+  return xml_files(slice)
+    .filter(
+    { file -> !file.path.ends_with(".xsd")
+      && !file.path.ends_with(".xsl")
+      && !file.path.ends_with(".xslt") },
+  )
+}
+
+fn xsd_files(slice) {
+  return slice.files.filter({ file -> file.path.ends_with(".xsd") })
+}
+
+fn xslt_files(slice) {
+  return slice.files
+    .filter({ file -> file.path.ends_with(".xsl") || file.path.ends_with(".xslt") })
+}
+
+fn scan_files(files, pattern, flags) {
+  var findings = []
+  for file in files {
+    if regex_match(pattern, file.text, flags) != nil {
+      findings = findings.push({path: file.path, pattern: pattern})
+    }
+  }
+  return findings
+}
+
+fn scan_files_if(files, predicate) {
+  var findings = []
+  for file in files {
+    if predicate(file) {
+      findings = findings.push({path: file.path})
+    }
+  }
+  return findings
+}
+
+fn allow(rule) {
+  return {verdict: "Allow", rule: rule, findings: [], remediation: ""}
+}
+
+fn warn(rule, remediation, findings) {
+  return {verdict: "Warn", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block(rule, remediation, findings) {
+  return {verdict: "Block", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return block(rule, remediation, findings)
+}
+
+fn warn_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return warn(rule, remediation, findings)
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_DOCTYPE_XXE, confidence: 0.92, source_date: "2026-05-09")
+/** Blocks inline DOCTYPE declarations in XML payload files; the entity subset is the primary XXE vector. */
+pub fn no_inline_doctype(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(xml_payload_files(slice), r"<!DOCTYPE\b", "is")
+  return block_on_findings(
+    "no_inline_doctype",
+    "Remove the DOCTYPE; validate against an external schema and disable DTD loading in the parser.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_EXTERNAL_ENTITIES, confidence: 0.95, source_date: "2026-05-09")
+/** Blocks ENTITY declarations that resolve external resources or recursively expand. */
+pub fn no_external_entity_references(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    xml_files(slice),
+    r"<!ENTITY\s+(%\s+)?[A-Za-z_][A-Za-z0-9._-]*\s+(SYSTEM|PUBLIC)\b",
+    "is",
+  )
+  return block_on_findings(
+    "no_external_entity_references",
+    "Remove SYSTEM/PUBLIC entity declarations; reference external content through application code instead.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_UTF8, confidence: 0.78, source_date: "2026-05-09")
+/** Warns when an XML file lacks an XML declaration that pins UTF-8 encoding. */
+pub fn xml_declares_utf8(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    xml_files(slice),
+    { file -> regex_match(r"^\s*<\?xml\b[^?]*encoding\s*=\s*[\"']utf-8[\"'][^?]*\?>", file.text, "is")
+      == nil },
+  )
+  return warn_on_findings(
+    "xml_declares_utf8",
+    "Start XML files with <?xml version=\"1.0\" encoding=\"UTF-8\"?> for stable interop.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_NAMESPACES, confidence: 0.66, source_date: "2026-05-09")
+/** Warns when XML uses prefixed element names but declares no xmlns:prefix bindings in the same file. */
+pub fn xml_namespace_prefixes_declared(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    xml_files(slice),
+    { file -> regex_match(r"<\s*[A-Za-z_][A-Za-z0-9._-]*:[A-Za-z_][A-Za-z0-9._-]*\b", file.text, "s")
+      != nil
+      && regex_match(r"\bxmlns:[A-Za-z_][A-Za-z0-9._-]*\s*=", file.text, "s") == nil },
+  )
+  return warn_on_findings(
+    "xml_namespace_prefixes_declared",
+    "Bind every namespace prefix with xmlns:prefix=\"...\" in the same document.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_XSD_TARGET_NAMESPACE, confidence: 0.74, source_date: "2026-05-09")
+/** Warns when an XSD schema document does not declare a targetNamespace. */
+pub fn xsd_has_target_namespace(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    xsd_files(slice),
+    { file -> regex_match(r"<\s*([A-Za-z_][A-Za-z0-9._-]*:)?schema\b[^>]*\btargetNamespace\s*=", file.text, "is")
+      == nil },
+  )
+  return warn_on_findings(
+    "xsd_has_target_namespace",
+    "Set targetNamespace on the xs:schema root so consumers can disambiguate types.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_XSLT_EXTERNAL, confidence: 0.88, source_date: "2026-05-09")
+/** Blocks XSLT that loads stylesheets or documents from absolute http(s)/file/ftp URIs. */
+pub fn xslt_no_external_documents(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    xslt_files(slice),
+    r"<\s*xsl:(include|import)\b[^>]*\bhref\s*=\s*[\"'](https?|ftp|file)://|\bdocument\s*\(\s*[\"'](https?|ftp|file)://",
+    "is",
+  )
+  return block_on_findings(
+    "xslt_no_external_documents",
+    "Resolve XSLT includes and document() calls through trusted application code, not absolute network URIs.",
+    findings,
+  )
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_SECRETS, confidence: 0.7, source_date: "2026-05-09")
+/** Blocks credentials, tokens, private keys, and production connection strings embedded in XML. */
+pub fn no_hardcoded_secrets(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed XML embeds a credential, API key, bearer token, signing secret, password, private key, or production connection string instead of referencing a managed secret source or environment variable."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: xml_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "no_hardcoded_secrets",
+      "Move credentials to a secret manager or scoped environment variable and rotate exposed values.",
+      judgement.findings,
+    )
+  }
+  return allow("no_hardcoded_secrets")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_SCHEMA_DOS, confidence: 0.62, source_date: "2026-05-09")
+/** Blocks XSD shapes that disable validation or invite quadratic blowup of attacker-controlled input. */
+pub fn xsd_constrains_user_input(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed XSD intentionally weakens input validation on attacker-reachable fields, for example using xs:any or xs:anyType in place of a real type, omitting maxLength on free-form strings nested under unbounded sequences, or removing pattern/enumeration facets that previously constrained an externally posted value."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: xsd_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "xsd_constrains_user_input",
+      "Restore type constraints on externally reachable fields before relaxing the schema.",
+      judgement.findings,
+    )
+  }
+  return allow("xsd_constrains_user_input")
+}


### PR DESCRIPTION
## Summary

Closes #34. Drafts a v0 invariant pack for XML payloads, XSD schemas, XSLT stylesheets, and related XML-shaped formats (WSDL, SVG, RSS, Atom).

Six deterministic + two semantic predicates, all under the 3-8 surface-area target the issue calls out for format packs:

- **`no_inline_doctype`** (block) — `<!DOCTYPE` in payload files; the entity subset is the primary XXE vector.
- **`no_external_entity_references`** (block) — `<!ENTITY ... SYSTEM/PUBLIC>` declarations anywhere.
- **`xml_declares_utf8`** (warn) — `<?xml encoding="UTF-8"?>` for stable interop.
- **`xml_namespace_prefixes_declared`** (warn) — files using `prefix:elem` should declare at least one `xmlns:prefix=` binding.
- **`xsd_has_target_namespace`** (warn) — schemas should declare a `targetNamespace`.
- **`xslt_no_external_documents`** (block) — `xsl:include`, `xsl:import`, and `document()` must not load absolute `http(s)`/`ftp`/`file` URIs.
- **`no_hardcoded_secrets`** (semantic, block) — credentials, tokens, private keys, production connection strings.
- **`xsd_constrains_user_input`** (semantic, block) — schema changes must not weaken validation on attacker-reachable fields.

Evidence: W3C XML 1.0 / Namespaces / XSD 1.1 / XSLT 3.0, IETF RFC 7303, OWASP XXE / XML Security / Secrets / XSLT Injection cheatsheets, MITRE CWE-611 and CWE-776, GitHub secret-scanning docs.

## Test plan

- [ ] CI placeholder jobs (`evidence-links`, `fmt`, `fixture-replay`) pass once Flow toolchain ships.
- [ ] Each predicate has matching `fixtures/*.json` with one Block/Warn case and one Allow case.
- [ ] Top-level `README.md` packs list now includes XML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)