### PR TITLE
Add TOML seed predicate pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ See the Harn Flow design docs for the full predicate language spec.
 - [Rust](./rust/) — v0 draft predicates for Rust application and library code.
 - [SQL](./sql/) — v0 draft predicates for schema, migration, and query safety.
 - [Swift](./swift/) — v0 draft predicates for Swift application and UI code.
+- [TOML](./toml/) — v0 draft predicates for TOML configuration documents (`Cargo.toml`, `pyproject.toml`, tool configs).
 - [TypeScript](./typescript/) — v0 draft predicates for TypeScript and TSX code.
 
 ## Status

--- a/toml/README.md
+++ b/toml/README.md
@@ -1,0 +1,58 @@
+# TOML Seed Predicate Pack
+
+This pack covers TOML configuration documents — Cargo manifests, `pyproject.toml`, tool configs, and any other `.toml` file. TOML has a small surface area, so this v0 ships fewer predicates than a full-language pack and focuses on rules drawn directly from the TOML 1.0 specification plus the dominant lowercase-keys convention used by the largest TOML ecosystems.
+
+## Stack Assumptions
+
+- TOML files use the `.toml` extension (covers `Cargo.toml`, `pyproject.toml`, `taplo.toml`, `deny.toml`, and the long tail of tool configs).
+- Predicates run on changed slices and use file-text scans — no separate TOML parser is invoked, so syntactic edge cases that a parser would catch (e.g. unterminated strings) are out of scope here and remain the parser's job.
+- Advisory rules return `Warn` when a project's existing convention may legitimately diverge. Blocking rules are reserved for spec violations and security-sensitive issues.
+
+## Predicate Coverage
+
+| Predicate | Mode | Verdict | Purpose |
+|---|---|---|---|
+| `no_duplicate_table_headers` | deterministic | Block | TOML 1.0 forbids defining the same standard table more than once. |
+| `no_trailing_comma_in_inline_table` | deterministic | Block | TOML 1.0 inline tables disallow a terminating comma after the last pair. |
+| `key_naming_convention` | deterministic | Warn | Bare keys with uppercase letters drift from the lowercase snake/kebab convention used by Cargo and PEP 621. |
+| `datetime_includes_offset` | deterministic | Warn | Datetime values without an offset are local-date-times and resolve differently across machines. |
+| `secrets_not_hardcoded_in_toml` | semantic | Block | Credentials and signing secrets belong in env vars or a secret manager, not committed config. |
+
+## Evidence
+
+Evidence scanned on 2026-05-09.
+
+- TOML 1.0 specification (canonical reference for table, inline-table, key, and datetime grammar): the `toml.io` rendered spec and the `toml-lang/toml` 1.0.0 source.
+- Cargo manifest reference and PEP 621 `pyproject.toml` specification (lowercase / kebab-case key conventions adopted by the two largest TOML ecosystems).
+- RFC 3339 (datetime grammar that TOML inherits, including the meaning of an absent offset).
+- OWASP Secrets Management Cheat Sheet, GitHub secret-scanning docs, and CWE-798 (hardcoded credentials).
+
+## Known False Positives
+
+- Regex predicates do not parse TOML. Unusual whitespace, comments inside complex values, or inline tables split across (technically invalid) lines may confuse the deterministic checks.
+- `no_duplicate_table_headers` relies on a regex backreference and is intentionally narrow: it catches `[a.b]` repeated verbatim but does not catch the harder case of a dotted key (e.g. `a.b.c = 1`) implicitly redefining a table established with `[a.b]`. Implicit-redefinition detection needs a real parser and is left for a future revision.
+- `no_trailing_comma_in_inline_table` only inspects single-line inline tables (the only shape TOML 1.0 permits). Inline tables that have been illegally split across lines will not be flagged here — the parser will reject them first.
+- `key_naming_convention` flags any bare key containing an uppercase ASCII letter. Projects that intentionally use mixed case (Hugo's `[Params]` style is one example) can suppress per-finding once the predicate runtime exposes suppressions.
+- `datetime_includes_offset` only inspects datetime literals that appear directly on the right-hand side of `=`. Datetime values nested inside arrays or inline tables on separate lines are not flagged in v0.
+- `secrets_not_hardcoded_in_toml` depends on the judge recognizing concrete credential-shaped strings. It should remain high-threshold and cite exact lines before blocking; placeholders, env-var references, and clearly fake fixtures must allow.
+
+## Future Predicates
+
+These were considered for v0 and deferred until the Harn Flow runtime exposes the needed primitives:
+
+- `stable_top_level_table_order` — warn when top-level table headers are reordered relative to `repo_at_base`. Useful for diff hygiene but requires base-state file lookup that no current pack exercises.
+- `no_implicit_table_redefinition` — block dotted keys that implicitly redefine an explicitly opened table. Requires a real TOML parser to avoid heavy false-positive rates.
+
+## Fixtures
+
+Each fixture in `fixtures/` contains one blocked or warned example and one allowed example for the corresponding predicate. The fixture shape matches the current harn-canon convention:
+
+```json
+{
+  "predicate": "name",
+  "cases": [
+    {"expect": "Block", "files": [{"path": "Cargo.toml", "text": "..."}]},
+    {"expect": "Allow", "files": [{"path": "Cargo.toml", "text": "..."}]}
+  ]
+}
+```

--- a/toml/fixtures/datetime_includes_offset.json
+++ b/toml/fixtures/datetime_includes_offset.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "datetime_includes_offset",
+  "cases": [
+    {
+      "name": "warns_on_local_datetime_without_offset",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "schedule.toml",
+          "text": "[run]\nstart = 2026-01-15T09:30:00\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_offset_datetime_and_plain_date",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "schedule.toml",
+          "text": "[run]\nstart_utc = 2026-01-15T09:30:00Z\nstart_pst = 2026-01-15T09:30:00-08:00\nstart_day = 2026-01-15\nstart_time = 09:30:00\n"
+        }
+      ]
+    }
+  ]
+}

--- a/toml/fixtures/key_naming_convention.json
+++ b/toml/fixtures/key_naming_convention.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "key_naming_convention",
+  "cases": [
+    {
+      "name": "warns_on_mixed_case_bare_key",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "Cargo.toml",
+          "text": "[package]\nname = \"demo\"\napiKey = \"placeholder\"\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_lowercase_snake_and_kebab_keys",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "Cargo.toml",
+          "text": "[package]\nname = \"demo\"\nrust-version = \"1.78\"\nedition = \"2021\"\n\n[dev-dependencies]\nserde_json = \"1\"\n\n[tool.metadata]\n\"Quoted Mixed Case\" = true\n"
+        }
+      ]
+    }
+  ]
+}

--- a/toml/fixtures/no_duplicate_table_headers.json
+++ b/toml/fixtures/no_duplicate_table_headers.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_duplicate_table_headers",
+  "cases": [
+    {
+      "name": "blocks_repeated_standard_table",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "config.toml",
+          "text": "[server]\nhost = \"localhost\"\nport = 8080\n\n[server]\ntimeout = 30\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_distinct_tables_and_array_of_tables",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "config.toml",
+          "text": "[server]\nhost = \"localhost\"\nport = 8080\n\n[client]\ntimeout = 30\n\n[[products]]\nname = \"a\"\n\n[[products]]\nname = \"b\"\n"
+        }
+      ]
+    }
+  ]
+}

--- a/toml/fixtures/no_trailing_comma_in_inline_table.json
+++ b/toml/fixtures/no_trailing_comma_in_inline_table.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_trailing_comma_in_inline_table",
+  "cases": [
+    {
+      "name": "blocks_trailing_comma",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "config.toml",
+          "text": "point = { x = 1, y = 2, }\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_inline_table_without_trailing_comma",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "config.toml",
+          "text": "point = { x = 1, y = 2 }\nempty = {}\narr = [1, 2, 3,]\n"
+        }
+      ]
+    }
+  ]
+}

--- a/toml/fixtures/secrets_not_hardcoded_in_toml.json
+++ b/toml/fixtures/secrets_not_hardcoded_in_toml.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "secrets_not_hardcoded_in_toml",
+  "cases": [
+    {
+      "name": "blocks_hardcoded_database_password",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "config/production.toml",
+          "text": "[database]\nhost = \"db.internal\"\nuser = \"app\"\npassword = \"r3al-pr0d-passw0rd-do-not-commit\"\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_env_var_reference",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "config/production.toml",
+          "text": "[database]\nhost = \"db.internal\"\nuser = \"app\"\npassword = \"${DB_PASSWORD}\"\n"
+        }
+      ]
+    }
+  ]
+}

--- a/toml/invariants.harn
+++ b/toml/invariants.harn
@@ -1,0 +1,149 @@
+let _EVIDENCE_DUPLICATE_TABLES = [
+  "https://toml.io/en/v1.0.0#table",
+  "https://toml.io/en/v1.0.0#keys",
+  "https://github.com/toml-lang/toml/blob/1.0.0/toml.md",
+]
+
+let _EVIDENCE_INLINE_TABLE_COMMA = [
+  "https://toml.io/en/v1.0.0#inline-table",
+  "https://github.com/toml-lang/toml/blob/1.0.0/toml.md",
+]
+
+let _EVIDENCE_KEY_NAMING = [
+  "https://toml.io/en/v1.0.0#keys",
+  "https://doc.rust-lang.org/cargo/reference/manifest.html",
+  "https://packaging.python.org/en/latest/specifications/pyproject-toml/",
+]
+
+let _EVIDENCE_DATETIME_OFFSET = [
+  "https://toml.io/en/v1.0.0#offset-date-time",
+  "https://toml.io/en/v1.0.0#local-date-time",
+  "https://datatracker.ietf.org/doc/html/rfc3339",
+]
+
+let _EVIDENCE_SECRETS = [
+  "https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html",
+  "https://docs.github.com/code-security/secret-scanning/about-secret-scanning",
+  "https://cwe.mitre.org/data/definitions/798.html",
+]
+
+fn toml_files(slice) {
+  return slice.files.filter({ file -> file.path.ends_with(".toml") })
+}
+
+fn scan_files(files, pattern, flags) {
+  var findings = []
+  for file in files {
+    if regex_match(pattern, file.text, flags) != nil {
+      findings = findings.push({path: file.path, pattern: pattern})
+    }
+  }
+  return findings
+}
+
+fn allow(rule) {
+  return {verdict: "Allow", rule: rule, findings: [], remediation: ""}
+}
+
+fn warn(rule, remediation, findings) {
+  return {verdict: "Warn", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block(rule, remediation, findings) {
+  return {verdict: "Block", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return block(rule, remediation, findings)
+}
+
+fn warn_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return warn(rule, remediation, findings)
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_DUPLICATE_TABLES, confidence: 0.78, source_date: "2026-05-09")
+/** Blocks the same standard-table header being defined more than once in a TOML file. */
+pub fn no_duplicate_table_headers(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    toml_files(slice),
+    r"(?ms)^[ \t]*\[([^\]\[\n]+)\][ \t]*(?:#[^\n]*)?$.*?^[ \t]*\[\1\][ \t]*(?:#[^\n]*)?$",
+    "ms",
+  )
+  return block_on_findings(
+    "no_duplicate_table_headers",
+    "Merge the duplicate sections, or rename one; standard tables may only be defined once per TOML document.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_INLINE_TABLE_COMMA, confidence: 0.86, source_date: "2026-05-09")
+/** Blocks trailing commas inside inline tables, which TOML 1.0 rejects. */
+pub fn no_trailing_comma_in_inline_table(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(toml_files(slice), r"\{[^{}\n]*,[ \t]*\}", "s")
+  return block_on_findings(
+    "no_trailing_comma_in_inline_table",
+    "Drop the trailing comma; inline tables disallow it (arrays do permit a trailing comma).",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_KEY_NAMING, confidence: 0.66, source_date: "2026-05-09")
+/** Warns on bare keys that contain uppercase letters; prefer snake_case or kebab-case. */
+pub fn key_naming_convention(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    toml_files(slice),
+    r"(?m)^[ \t]*[A-Za-z0-9_.-]*[A-Z][A-Za-z0-9_.-]*[ \t]*=",
+    "m",
+  )
+  return warn_on_findings(
+    "key_naming_convention",
+    "Use lowercase bare keys (snake_case or kebab-case); quote the key if mixed case is required.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_DATETIME_OFFSET, confidence: 0.7, source_date: "2026-05-09")
+/** Warns on RFC 3339 datetime values that omit a timezone offset (local-date-time). */
+pub fn datetime_includes_offset(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    toml_files(slice),
+    r"(?m)^[^=\n#]*=[ \t]*\d{4}-\d{2}-\d{2}[Tt ]\d{2}:\d{2}:\d{2}(?:\.\d+)?[ \t]*(?:#[^\n]*)?$",
+    "m",
+  )
+  return warn_on_findings(
+    "datetime_includes_offset",
+    "Add a timezone offset (e.g. Z or +00:00) so the value is unambiguous across machines.",
+    findings,
+  )
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_SECRETS, confidence: 0.62, source_date: "2026-05-09")
+/** Blocks hardcoded credentials, tokens, or signing secrets in TOML configuration. */
+pub fn secrets_not_hardcoded_in_toml(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when TOML configuration contains a hardcoded credential value such as an API token, database password, signing key, OAuth client secret, private key, or production service credential, instead of a placeholder, environment-variable reference, secret-manager reference, or test/example fixture clearly marked as fake."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: toml_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "secrets_not_hardcoded_in_toml",
+      "Reference the secret via env var, secret manager, or templated config instead of inlining the value.",
+      judgement.findings,
+    )
+  }
+  return allow("secrets_not_hardcoded_in_toml")
+}


### PR DESCRIPTION
## Summary

Adds a v0 seed predicate pack for TOML configuration documents (`Cargo.toml`, `pyproject.toml`, tool configs, etc.). Closes #25.

Five predicates — all evidence-backed (≥2 independent sources, scanned 2026-05-09):

| Predicate | Mode | Verdict | Source |
|---|---|---|---|
| `no_duplicate_table_headers` | deterministic | Block | TOML 1.0 spec |
| `no_trailing_comma_in_inline_table` | deterministic | Block | TOML 1.0 spec |
| `key_naming_convention` | deterministic | Warn | TOML keys grammar + Cargo / PEP 621 conventions |
| `datetime_includes_offset` | deterministic | Warn | TOML / RFC 3339 |
| `secrets_not_hardcoded_in_toml` | semantic | Block | OWASP, GitHub secret-scanning, CWE-798 |

Smaller surface than the language packs — the issue called out 3–8 predicates as the target for format packs. README documents known false positives, fixture shape, and two predicates intentionally deferred (`stable_top_level_table_order`, `no_implicit_table_redefinition`) until the runtime exposes the needed primitives.

Root `README.md` packs list updated to include TOML.

## Test plan

- [ ] CI placeholders pass (evidence-link, fmt, fixture-replay all stub-only today).
- [ ] Once the runtime ships: each fixture's expected verdict (`Block` / `Warn` / `Allow`) matches the predicate's actual verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)