### PR TITLE
Add YAML seed predicate pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ See the Harn Flow design docs for the full predicate language spec.
 - [TOML](./toml/) — v0 draft predicates for TOML configuration documents (`Cargo.toml`, `pyproject.toml`, tool configs).
 - [TypeScript](./typescript/) — v0 draft predicates for TypeScript and TSX code.
 - [XML](./xml/) — v0 draft predicates for XML payloads, XSD schemas, XSLT stylesheets, and related XML-shaped formats.
+- [YAML](./yaml/) — v0 draft predicates for plain YAML configuration covering parser footguns and unsafe deserialization tags.
 
 ## Status
 

--- a/yaml/README.md
+++ b/yaml/README.md
@@ -1,0 +1,57 @@
+# YAML Seed Predicate Pack
+
+This pack covers plain YAML configuration before stack-specific packs (Kubernetes, GitHub Actions, Ansible, Helm) layer tighter rules on top. YAML's surface area is small but its parser quirks are loud, so the v0 set focuses on long-known footguns: tab indentation, the YAML 1.1 vs 1.2 boolean drift (the "Norway problem"), bare scalars that parsers re-type, the cross-document anchor scope rule, and language-specific object tags that are remote-code-execution sinks.
+
+## Stack Assumptions
+
+- Source checks target `.yaml` and `.yml` files.
+- Syntactic predicates skip YAML living under `fixtures/`, `__fixtures__/`, `testdata/`, `test-data/`, `test/`, `tests/`, and `spec/` paths because parser fixtures intentionally include malformed input. Security predicates (`no_unsafe_yaml_tags`, `no_hardcoded_secrets`) and `yamllint_compliance` still check those paths.
+- Deterministic predicates run over changed source text until Flow exposes a stable YAML AST query API. Rules with meaningful false-positive risk warn rather than block.
+- Semantic predicates use one cheap judge call and should block only when they can cite a concrete changed span.
+
+## Predicate Coverage
+
+| Predicate | Mode | Verdict | Purpose |
+|---|---|---|---|
+| `no_tabs_for_indent` | deterministic | Block | YAML 1.2 forbids tabs as indentation; loaders error inconsistently. |
+| `explicit_boolean_types` | deterministic | Warn | Bare `yes`/`no`/`on`/`off`/`y`/`n` change meaning between YAML 1.1 and 1.2 parsers. |
+| `quoted_ambiguous_scalars` | deterministic | Warn | Trailing-zero versions, leading-zero ids, and `12:34:56`-shaped scalars must be quoted to stay strings. |
+| `consistent_indent` | deterministic | Warn | Lines indented by an odd number of spaces almost always indicate a broken indent step. |
+| `no_unsafe_yaml_tags` | deterministic | Block | `!!python/object`, `!ruby/object`, `!!java`, and similar tags are RCE sinks under unsafe loaders. |
+| `no_anchors_across_docs` | deterministic | Warn | Anchors reset at every `---`; aliases across documents resolve to nothing or to a stale anchor. |
+| `yamllint_compliance` | semantic | Block | Catches errors yamllint's default profile would surface: duplicate keys, empty required values, parser-fatal syntax. |
+| `no_hardcoded_secrets` | semantic | Block | API keys, tokens, private keys, and production connection strings must come from a secret store. |
+
+## Evidence
+
+Evidence scanned on 2026-05-09.
+
+- YAML 1.2.2 specification: indentation (§6.1), boolean tag resolution (§10.2.1.2), tag resolution (§10.3.2), node anchors (§6.9.2), and YAML streams (§9.2).
+- yamllint stable rules and configuration documentation: `indentation`, `truthy`, `quoted-strings`, `key-duplicates`, plus the rules index and configuration reference.
+- PyYAML documentation on safe vs full loaders, and the OWASP Deserialization Cheat Sheet for unsafe-tag risk and remediation.
+- OWASP Secrets Management Cheat Sheet and GitHub secret-scanning documentation for hardcoded credential risk and remediation context.
+
+## Known False Positives
+
+- All deterministic predicates run on raw source text. Comments, block scalars, multi-line quoted strings, and flow-style mappings can fool simple regexes until AST-level matching lands.
+- `no_tabs_for_indent` does not distinguish a tab inside a quoted string from a tab used as indentation; tabs inside string content are rare in practice but will trigger the block.
+- `explicit_boolean_types` only flags bare values after `key:`. Block-scalar children, flow-style sequences, and multi-line strings can hide an offending value.
+- `quoted_ambiguous_scalars` is intentionally narrow: it covers the three highest-signal shapes (`0\d+`, `\d+\.\d+0`, sexagesimal). Other ambiguous bare scalars (`null`, `~`, `NaN`, `.inf`) are left to `yamllint_compliance` and stack-specific packs.
+- `consistent_indent` warns on any line indented by 1, 3, 5, or 7 spaces. Some hand-formatted multi-line block scalars or comments may exceed this and trip the warn.
+- `no_anchors_across_docs` warns at file granularity whenever a multi-document YAML file uses any alias; an alias that genuinely references a same-document anchor will still warn until structural matching lands.
+- `no_unsafe_yaml_tags` blocks all language-specific `!!lang/` tags. A repo that intentionally uses `!!python/object` with a safe whitelisted loader would still need to suppress this rule.
+- The semantic predicates depend on a cheap judge call and stay high-threshold; they should not block on speculative concerns.
+
+## Fixtures
+
+Each fixture in `fixtures/` contains one blocked or warned example and one allowed example for the corresponding predicate. The fixture shape mirrors the existing seed packs:
+
+```json
+{
+  "predicate": "name",
+  "cases": [
+    {"expect": "Block", "files": [{"path": "config/app.yaml", "text": "..."}]},
+    {"expect": "Allow", "files": [{"path": "config/app.yaml", "text": "..."}]}
+  ]
+}
+```

--- a/yaml/fixtures/consistent_indent.json
+++ b/yaml/fixtures/consistent_indent.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "consistent_indent",
+  "cases": [
+    {
+      "name": "warns_on_three_space_indent",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "config/app.yaml",
+          "text": "service:\n  name: api\n   port: 8080\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_consistent_two_space_indent",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "config/app.yaml",
+          "text": "service:\n  name: api\n  port: 8080\n  metrics:\n    enabled: true\n"
+        }
+      ]
+    }
+  ]
+}

--- a/yaml/fixtures/explicit_boolean_types.json
+++ b/yaml/fixtures/explicit_boolean_types.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "explicit_boolean_types",
+  "cases": [
+    {
+      "name": "warns_on_yes_boolean_value",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "config/feature.yaml",
+          "text": "feature:\n  enabled: yes\n  retry: no\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_true_false_booleans",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "config/feature.yaml",
+          "text": "feature:\n  enabled: true\n  retry: false\n"
+        }
+      ]
+    }
+  ]
+}

--- a/yaml/fixtures/no_anchors_across_docs.json
+++ b/yaml/fixtures/no_anchors_across_docs.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_anchors_across_docs",
+  "cases": [
+    {
+      "name": "warns_on_alias_in_multi_document_file",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "config/pipeline.yaml",
+          "text": "---\ndefaults: &defaults\n  retries: 3\n  timeout: 30\n---\njob: build\nsettings: *defaults\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_alias_in_single_document_file",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "config/pipeline.yaml",
+          "text": "defaults: &defaults\n  retries: 3\n  timeout: 30\njob: build\nsettings: *defaults\n"
+        }
+      ]
+    }
+  ]
+}

--- a/yaml/fixtures/no_hardcoded_secrets.json
+++ b/yaml/fixtures/no_hardcoded_secrets.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_hardcoded_secrets",
+  "cases": [
+    {
+      "name": "blocks_inline_api_token",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "config/billing.yaml",
+          "text": "billing:\n  api_token: \"example_live_token_do_not_use_0123456789abcdef\"\n  endpoint: https://billing.example.com\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_secret_reference",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "config/billing.yaml",
+          "text": "billing:\n  api_token: ${BILLING_API_TOKEN}\n  endpoint: https://billing.example.com\n"
+        }
+      ]
+    }
+  ]
+}

--- a/yaml/fixtures/no_tabs_for_indent.json
+++ b/yaml/fixtures/no_tabs_for_indent.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_tabs_for_indent",
+  "cases": [
+    {
+      "name": "blocks_tab_indented_value",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "config/app.yaml",
+          "text": "service:\n\tname: api\n\tport: 8080\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_space_indented_value",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "config/app.yaml",
+          "text": "service:\n  name: api\n  port: 8080\n"
+        }
+      ]
+    }
+  ]
+}

--- a/yaml/fixtures/no_unsafe_yaml_tags.json
+++ b/yaml/fixtures/no_unsafe_yaml_tags.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_unsafe_yaml_tags",
+  "cases": [
+    {
+      "name": "blocks_python_object_apply_tag",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "config/jobs.yaml",
+          "text": "job: !!python/object/apply:os.system\n  args: [\"echo unsafe\"]\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_standard_tags_only",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "config/jobs.yaml",
+          "text": "job:\n  command: echo safe\n  args: []\n"
+        }
+      ]
+    }
+  ]
+}

--- a/yaml/fixtures/quoted_ambiguous_scalars.json
+++ b/yaml/fixtures/quoted_ambiguous_scalars.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "quoted_ambiguous_scalars",
+  "cases": [
+    {
+      "name": "warns_on_unquoted_version_with_trailing_zero",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "config/release.yaml",
+          "text": "release:\n  version: 1.10\n  legacy_id: 0123\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_quoted_ambiguous_values",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "config/release.yaml",
+          "text": "release:\n  version: \"1.10\"\n  legacy_id: \"0123\"\n"
+        }
+      ]
+    }
+  ]
+}

--- a/yaml/fixtures/yamllint_compliance.json
+++ b/yaml/fixtures/yamllint_compliance.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "yamllint_compliance",
+  "cases": [
+    {
+      "name": "blocks_duplicate_top_level_keys",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "config/app.yaml",
+          "text": "service:\n  name: api\nservice:\n  name: worker\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_clean_yaml",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "config/app.yaml",
+          "text": "service:\n  name: api\nworker:\n  name: worker\n"
+        }
+      ]
+    }
+  ]
+}

--- a/yaml/invariants.harn
+++ b/yaml/invariants.harn
@@ -1,0 +1,231 @@
+let _EVIDENCE_INDENT_TABS = [
+  "https://yaml.org/spec/1.2.2/#61-indentation-spaces",
+  "https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.indentation",
+]
+
+let _EVIDENCE_BOOLEAN = [
+  "https://yaml.org/spec/1.2.2/#10212-boolean",
+  "https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.truthy",
+]
+
+let _EVIDENCE_AMBIGUOUS_SCALARS = [
+  "https://yaml.org/spec/1.2.2/#1032-tag-resolution",
+  "https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.quoted-strings",
+]
+
+let _EVIDENCE_CONSISTENT_INDENT = [
+  "https://yaml.org/spec/1.2.2/#61-indentation-spaces",
+  "https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.indentation",
+]
+
+let _EVIDENCE_UNSAFE_TAGS = [
+  "https://pyyaml.org/wiki/PyYAMLDocumentation",
+  "https://cheatsheetseries.owasp.org/cheatsheets/Deserialization_Cheat_Sheet.html",
+]
+
+let _EVIDENCE_ANCHORS = [
+  "https://yaml.org/spec/1.2.2/#692-node-anchors",
+  "https://yaml.org/spec/1.2.2/#92-streams",
+]
+
+let _EVIDENCE_YAMLLINT = [
+  "https://yamllint.readthedocs.io/en/stable/rules.html",
+  "https://yamllint.readthedocs.io/en/stable/configuration.html",
+]
+
+let _EVIDENCE_SECRETS = [
+  "https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html",
+  "https://docs.github.com/code-security/secret-scanning/about-secret-scanning",
+]
+
+fn yaml_files(slice) {
+  return slice.files.filter({ file -> file.path.ends_with(".yaml") || file.path.ends_with(".yml") })
+}
+
+fn is_test_path(path) {
+  return contains(path, "/fixtures/")
+    || contains(path, "/__fixtures__/")
+    || contains(path, "/testdata/")
+    || contains(path, "/test-data/")
+    || contains(path, "/test/")
+    || contains(path, "/tests/")
+    || contains(path, "/spec/")
+}
+
+fn non_test_yaml_files(slice) {
+  return yaml_files(slice).filter({ file -> !is_test_path(file.path) })
+}
+
+fn scan_files(files, pattern, flags) {
+  var findings = []
+  for file in files {
+    if regex_match(pattern, file.text, flags) != nil {
+      findings = findings.push({path: file.path, pattern: pattern})
+    }
+  }
+  return findings
+}
+
+fn scan_files_if(files, predicate) {
+  var findings = []
+  for file in files {
+    if predicate(file) {
+      findings = findings.push({path: file.path})
+    }
+  }
+  return findings
+}
+
+fn allow(rule) {
+  return {verdict: "Allow", rule: rule, findings: [], remediation: ""}
+}
+
+fn warn(rule, remediation, findings) {
+  return {verdict: "Warn", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block(rule, remediation, findings) {
+  return {verdict: "Block", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return block(rule, remediation, findings)
+}
+
+fn warn_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return warn(rule, remediation, findings)
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_INDENT_TABS, confidence: 0.92, source_date: "2026-05-09")
+/** Blocks tabs used as indentation; the YAML 1.2 spec allows only spaces. */
+pub fn no_tabs_for_indent(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(non_test_yaml_files(slice), r"(?m)^\t+\S", "m")
+  return block_on_findings(
+    "no_tabs_for_indent",
+    "Replace leading tabs with spaces; YAML forbids tab characters as indentation.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_BOOLEAN, confidence: 0.84, source_date: "2026-05-09")
+/** Warns on bare yes/no/on/off/y/n values that change meaning between YAML 1.1 and 1.2 parsers. */
+pub fn explicit_boolean_types(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    non_test_yaml_files(slice),
+    r"(?mi)(?::\s+|^\s*-\s+)(?:yes|no|on|off|y|n)\s*(?:#.*)?$",
+    "m",
+  )
+  return warn_on_findings(
+    "explicit_boolean_types",
+    "Use true/false for booleans, or quote yes/no/on/off when they are strings.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_AMBIGUOUS_SCALARS, confidence: 0.7, source_date: "2026-05-09")
+/** Warns on bare scalars that parsers commonly mis-type: trailing-zero versions, leading-zero numbers, sexagesimal forms. */
+pub fn quoted_ambiguous_scalars(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    non_test_yaml_files(slice),
+    r"(?m):\s+(?:0\d+|\d+\.\d+0|\d+:\d+(?::\d+)+)\s*(?:#.*)?$",
+    "m",
+  )
+  return warn_on_findings(
+    "quoted_ambiguous_scalars",
+    "Quote version numbers, leading-zero ids, and time-like scalars to keep them as strings.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_CONSISTENT_INDENT, confidence: 0.74, source_date: "2026-05-09")
+/** Warns on lines whose leading indentation is an odd number of spaces, which almost always signals an inconsistent indent step. */
+pub fn consistent_indent(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(non_test_yaml_files(slice), r"(?m)^(?: |   |     |       )\S", "m")
+  return warn_on_findings(
+    "consistent_indent",
+    "Use a single, consistent indent step (typically two spaces) for all nested blocks in a YAML file.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_UNSAFE_TAGS, confidence: 0.95, source_date: "2026-05-09")
+/** Blocks YAML language-specific object construction tags that map to remote-code-execution sinks. */
+pub fn no_unsafe_yaml_tags(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    yaml_files(slice),
+    r"(?m)!{1,2}(?:python|ruby|java|javax|perl|exec)\b",
+    "m",
+  )
+  return block_on_findings(
+    "no_unsafe_yaml_tags",
+    "Remove language-specific !!python/!ruby/!!java tags; load this YAML with a safe loader instead.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_ANCHORS, confidence: 0.66, source_date: "2026-05-09")
+/** Warns when a multi-document YAML file uses aliases that may reference anchors in a different document. */
+pub fn no_anchors_across_docs(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    non_test_yaml_files(slice),
+    { file -> regex_match(r"(?ms)^---\s*$.+?^---\s*$", file.text, "ms") != nil
+      && regex_match(r"(?m)(?:^|[^&\\])\*[A-Za-z_][A-Za-z0-9_-]*", file.text, "m") != nil },
+  )
+  return warn_on_findings(
+    "no_anchors_across_docs",
+    "YAML anchors reset at every --- separator; inline the shared content into each document or split the file.",
+    findings,
+  )
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_YAMLLINT, confidence: 0.66, source_date: "2026-05-09")
+/** Blocks changed YAML that yamllint would flag as an error under a sensible default configuration. */
+pub fn yamllint_compliance(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed YAML clearly violates a yamllint default rule that yamllint reports as an error: duplicate keys, empty mapping values where a value is required, line-length runaway, missing document start when policy requires it, octal value misuse, or syntax that fails to parse. Do not block on style preferences when yamllint defaults treat them as warnings."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: yaml_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "yamllint_compliance",
+      "Resolve the yamllint error or scope a narrow rule disable with a justification comment.",
+      judgement.findings,
+    )
+  }
+  return allow("yamllint_compliance")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_SECRETS, confidence: 0.7, source_date: "2026-05-09")
+/** Blocks credentials, tokens, and private keys committed in YAML configuration. */
+pub fn no_hardcoded_secrets(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed YAML embeds an API key, access token, password, private key, signing secret, or production connection string instead of referencing a secret manager, environment variable, or sealed/encrypted secret store."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: yaml_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "no_hardcoded_secrets",
+      "Move the secret to a managed store (e.g. SealedSecrets, SOPS, env-injected reference) and rotate exposed values.",
+      judgement.findings,
+    )
+  }
+  return allow("no_hardcoded_secrets")
+}


### PR DESCRIPTION
## Summary
- Adds the `yaml/` v0 seed predicate pack (closes #24): six deterministic predicates and two semantic predicates covering YAML's well-known footguns.
- Deterministic: `no_tabs_for_indent` (Block), `explicit_boolean_types` (Warn — Norway problem), `quoted_ambiguous_scalars` (Warn — version/octal/sexagesimal), `consistent_indent` (Warn — odd-count leading spaces), `no_unsafe_yaml_tags` (Block — `!!python/object`, `!ruby/object`, `!!java*`, `!!perl/`, `!!exec`), `no_anchors_across_docs` (Warn — multi-doc files using aliases).
- Semantic: `yamllint_compliance` (Block) and `no_hardcoded_secrets` (Block).
- Evidence cites the YAML 1.2.2 spec, yamllint stable rules, PyYAML, OWASP cheat sheets, and GitHub secret-scanning docs (≥2 sources, scanned 2026-05-09).
- Includes one Block/Allow fixture per predicate plus a `yaml/README.md` with stack assumptions, coverage table, and known false positives. Root README links the new pack.

## Test plan
- [x] Each fixture's bad input matches its predicate's regex; each good input does not (verified locally with Python's `re`, which is a strict superset of the RE2-compatible patterns used here).
- [x] All eight fixture JSONs parse cleanly.
- [x] `yaml/invariants.harn` follows the existing Java/Ruby pack template (same helper signatures, same `@archivist` shape, same `verdict`/`findings`/`remediation` triple).
- [ ] Repo CI checks (placeholder until the Harn Flow runtime ships).

🤖 Generated with [Claude Code](https://claude.com/claude-code)