### PR TITLE
Add JSON seed predicate pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ See the Harn Flow design docs for the full predicate language spec.
 - [Harn](./harn/) — v0 draft predicates for `.harn` scripts, Flow workflows, and agent-facing Harn modules.
 - [Java](./java/) — v0 draft predicates for plain Java application and library code.
 - [JavaScript](./javascript/) — v0 draft predicates for plain JavaScript source, async handling, dynamic-code hazards, and untrusted data boundaries.
+- [JSON](./json/) — v0 draft predicates for strict JSON conformance, encoding hygiene, declared-schema respect, and untrusted-data boundaries.
 - [Kotlin](./kotlin/) — v0 draft predicates for Kotlin JVM, Android, and Multiplatform source.
 - [Python](./python/) — v0 draft predicates for Python application and library code.
 - [Ruby](./ruby/) — v0 draft predicates for Ruby application and library code.

--- a/json/README.md
+++ b/json/README.md
@@ -1,0 +1,56 @@
+# JSON Seed Predicate Pack
+
+This pack covers strict JSON content quality before format-specific packs (npm `package.json` rules, JSON Schema authoring, OpenAPI documents, etc.) layer narrower checks on top. It focuses on RFC 8259 conformance, encoding hygiene, and untrusted-data hazards that show up across most JSON files a repo ships.
+
+## Stack Assumptions
+
+- Files use `.json`, `.jsonc`, or `.json5`. Strict-conformance predicates apply only to `.json`; `.jsonc` and `.json5` are exempt because their parsers accept comments and trailing commas by design.
+- Files matching `tsconfig*.json`, `jsconfig*.json`, or paths under `.vscode/` and `.devcontainer/` are treated as JSONC-by-convention and exempt from the strict checks; the toolchains that read them allow comments and trailing commas.
+- Deterministic predicates work on changed source text until Flow exposes a stable JSON AST and value-tree query API.
+- Semantic predicates may block only when the judge can cite a concrete changed value or property and the issue is not reliably expressible with simple syntax checks.
+
+## Predicate Coverage
+
+| Predicate | Mode | Verdict | Purpose |
+|---|---|---|---|
+| `no_trailing_commas` | deterministic | Block | Strict `.json` must follow RFC 8259, which forbids trailing commas. |
+| `no_comments_in_json` | deterministic | Block | Strict `.json` must not contain `//` or `/*` comment markers; rename to `.jsonc` or `.json5` if comments are required. |
+| `no_bom_prefix` | deterministic | Warn | JSON files must not begin with a UTF-8 byte order mark. |
+| `no_nan_or_infinity_literals` | deterministic | Block | `NaN`, `Infinity`, and `-Infinity` are not valid JSON numbers. |
+| `no_hardcoded_secrets` | semantic | Block | Credentials, tokens, private keys, and production connection strings must not live in committed JSON values. |
+| `respects_declared_schema` | semantic | Block | When a JSON file declares a `$schema` reference, changed values must satisfy it. |
+| `stable_key_ordering` | semantic | Warn | Config-shaped JSON edits should not reorder unrelated keys and create diff noise. |
+
+## Evidence
+
+Evidence scanned on 2026-05-09.
+
+- IETF RFC 8259 — JSON grammar (numbers, objects, strings), the explicit "no comments" stance, and the byte-order-mark prohibition.
+- json.org canonical syntax reference.
+- VS Code JSON-with-comments documentation describing the `.jsonc` convention.
+- MDN `JSON.stringify` documentation showing how `NaN` and `Infinity` are serialized to `null`.
+- OWASP Secrets Management cheat sheet and GitHub secret-scanning documentation.
+- JSON Schema specification and the JSON Schema "getting started" guide.
+- npm `package.json` configuration reference describing the conventional ordering authors expect tooling to preserve.
+
+## Known False Positives
+
+- Regex predicates are intentionally conservative and file-scoped. A literal `,]`, `//`, `/*`, `NaN`, or `Infinity` substring inside a JSON string value can trip the corresponding predicate until value-aware matching lands.
+- `no_trailing_commas` and `no_comments_in_json` apply only to `.json`; `.jsonc`, `.json5`, and the JSONC-by-convention paths listed above are exempt. Project-specific JSONC formats not on that list (for example, `tslint.json`) will need an explicit allowlist later.
+- `no_bom_prefix` triggers any time the file's first three bytes are the UTF-8 BOM, even when downstream tooling silently strips it. The verdict is `Warn` because the file usually still works but eventually breaks a parser somewhere.
+- `respects_declared_schema` only fires when a `$schema` reference is present and the violation is concretely visible in the slice; it is not a full JSON Schema validator.
+- `stable_key_ordering` is intentionally narrow and should stay out of changes that touch the reordered region for substantive reasons; it is biased toward warning rather than blocking to avoid fighting alphabetizing formatters.
+
+## Fixtures
+
+Each fixture in `fixtures/` contains one blocked or warned example and one allowed example for the corresponding predicate. The fixture shape matches the other packs in this repo:
+
+```json
+{
+  "predicate": "name",
+  "cases": [
+    {"expect": "Block", "files": [{"path": "config/app.json", "text": "..."}]},
+    {"expect": "Allow", "files": [{"path": "config/app.json", "text": "..."}]}
+  ]
+}
+```

--- a/json/fixtures/no_bom_prefix.json
+++ b/json/fixtures/no_bom_prefix.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_bom_prefix",
+  "cases": [
+    {
+      "name": "warns_on_utf8_bom",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "config/app.json",
+          "text": "﻿{\n  \"port\": 8080\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_clean_utf8",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "config/app.json",
+          "text": "{\n  \"port\": 8080\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/json/fixtures/no_comments_in_json.json
+++ b/json/fixtures/no_comments_in_json.json
@@ -1,0 +1,55 @@
+{
+  "predicate": "no_comments_in_json",
+  "cases": [
+    {
+      "name": "blocks_line_comment",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "config/app.json",
+          "text": "{\n  // application port\n  \"port\": 8080\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "blocks_block_comment",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "config/app.json",
+          "text": "{\n  \"port\": 8080,\n  /* timeout in ms */\n  \"timeout\": 30000\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_clean_json",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "config/app.json",
+          "text": "{\n  \"port\": 8080,\n  \"timeoutMs\": 30000\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_url_with_double_slash",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "config/links.json",
+          "text": "{\n  \"docs\": \"https://example.com/docs\"\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_comments_in_tsconfig",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "tsconfig.json",
+          "text": "{\n  // strict TypeScript settings\n  \"compilerOptions\": {\n    \"strict\": true\n  }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/json/fixtures/no_hardcoded_secrets.json
+++ b/json/fixtures/no_hardcoded_secrets.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_hardcoded_secrets",
+  "cases": [
+    {
+      "name": "blocks_committed_api_key",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "config/payment.json",
+          "text": "{\n  \"provider\": \"stripe\",\n  \"apiKey\": \"sk_live_51NHardcodedSecretValue\"\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_environment_reference",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "config/payment.json",
+          "text": "{\n  \"provider\": \"stripe\",\n  \"apiKey\": \"${PAYMENT_API_KEY}\"\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/json/fixtures/no_nan_or_infinity_literals.json
+++ b/json/fixtures/no_nan_or_infinity_literals.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "no_nan_or_infinity_literals",
+  "cases": [
+    {
+      "name": "blocks_nan_value",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "metrics/snapshot.json",
+          "text": "{\n  \"latencyMs\": NaN\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "blocks_negative_infinity",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "metrics/snapshot.json",
+          "text": "{\n  \"floor\": -Infinity\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_null_for_missing_value",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "metrics/snapshot.json",
+          "text": "{\n  \"latencyMs\": null\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/json/fixtures/no_trailing_commas.json
+++ b/json/fixtures/no_trailing_commas.json
@@ -1,0 +1,45 @@
+{
+  "predicate": "no_trailing_commas",
+  "cases": [
+    {
+      "name": "blocks_trailing_comma_in_object",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "config/app.json",
+          "text": "{\n  \"name\": \"app\",\n  \"port\": 8080,\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "blocks_trailing_comma_in_array",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "config/hosts.json",
+          "text": "{\n  \"hosts\": [\n    \"a.example.com\",\n    \"b.example.com\",\n  ]\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_clean_object",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "config/app.json",
+          "text": "{\n  \"name\": \"app\",\n  \"port\": 8080\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_trailing_comma_in_jsonc",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "config/app.jsonc",
+          "text": "{\n  \"name\": \"app\",\n  \"port\": 8080,\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/json/fixtures/respects_declared_schema.json
+++ b/json/fixtures/respects_declared_schema.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "respects_declared_schema",
+  "cases": [
+    {
+      "name": "blocks_value_violating_declared_schema",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "config/server.json",
+          "text": "{\n  \"$schema\": \"https://example.com/schemas/server.v1.json\",\n  \"port\": \"eight thousand\"\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_value_matching_declared_schema",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "config/server.json",
+          "text": "{\n  \"$schema\": \"https://example.com/schemas/server.v1.json\",\n  \"port\": 8080\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/json/fixtures/stable_key_ordering.json
+++ b/json/fixtures/stable_key_ordering.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "stable_key_ordering",
+  "cases": [
+    {
+      "name": "warns_when_unrelated_keys_reordered",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "package.json",
+          "text": "{\n  \"version\": \"1.2.4\",\n  \"name\": \"app\",\n  \"description\": \"a tiny demo\",\n  \"scripts\": {\n    \"build\": \"tsc\",\n    \"test\": \"vitest\"\n  }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_value_only_change",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "package.json",
+          "text": "{\n  \"name\": \"app\",\n  \"version\": \"1.2.4\",\n  \"description\": \"a tiny demo\",\n  \"scripts\": {\n    \"build\": \"tsc\",\n    \"test\": \"vitest\"\n  }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/json/invariants.harn
+++ b/json/invariants.harn
@@ -1,0 +1,211 @@
+let _EVIDENCE_TRAILING_COMMAS = [
+  "https://www.rfc-editor.org/rfc/rfc8259#section-5",
+  "https://www.json.org/json-en.html",
+]
+
+let _EVIDENCE_NO_COMMENTS = [
+  "https://www.rfc-editor.org/rfc/rfc8259#section-12",
+  "https://code.visualstudio.com/docs/languages/json#_json-with-comments",
+]
+
+let _EVIDENCE_BOM = [
+  "https://www.rfc-editor.org/rfc/rfc8259#section-8.1",
+  "https://datatracker.ietf.org/doc/html/rfc8259#section-8.1",
+]
+
+let _EVIDENCE_NAN_INFINITY = [
+  "https://www.rfc-editor.org/rfc/rfc8259#section-6",
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify",
+]
+
+let _EVIDENCE_SECRETS = [
+  "https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html",
+  "https://docs.github.com/en/code-security/concepts/secret-security/about-secret-scanning",
+]
+
+let _EVIDENCE_SCHEMA = [
+  "https://json-schema.org/specification",
+  "https://json-schema.org/learn/getting-started-step-by-step",
+]
+
+let _EVIDENCE_KEY_ORDER = [
+  "https://www.rfc-editor.org/rfc/rfc8259#section-4",
+  "https://docs.npmjs.com/cli/v10/configuring-npm/package-json",
+]
+
+let _BOM = "﻿"
+
+fn is_strict_json_path(path) {
+  return path.ends_with(".json")
+    && regex_match(r"(^|/)((tsconfig|jsconfig)[^/]*\.json$|\.(vscode|devcontainer)/)", path, "") == nil
+}
+
+fn strict_json_files(slice) {
+  return slice.files.filter({ file -> is_strict_json_path(file.path) })
+}
+
+fn all_json_files(slice) {
+  return slice.files
+    .filter(
+    { file -> file.path.ends_with(".json")
+      || file.path.ends_with(".jsonc")
+      || file.path.ends_with(".json5") },
+  )
+}
+
+fn scan_files(files, pattern, flags) {
+  var findings = []
+  for file in files {
+    if regex_match(pattern, file.text, flags) != nil {
+      findings = findings.push({path: file.path, pattern: pattern})
+    }
+  }
+  return findings
+}
+
+fn scan_files_if(files, predicate) {
+  var findings = []
+  for file in files {
+    if predicate(file.text) {
+      findings = findings.push({path: file.path})
+    }
+  }
+  return findings
+}
+
+fn allow(rule) {
+  return {verdict: "Allow", rule: rule, findings: [], remediation: ""}
+}
+
+fn warn(rule, remediation, findings) {
+  return {verdict: "Warn", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block(rule, remediation, findings) {
+  return {verdict: "Block", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return block(rule, remediation, findings)
+}
+
+fn warn_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return warn(rule, remediation, findings)
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_TRAILING_COMMAS, confidence: 0.82, source_date: "2026-05-09")
+/** Blocks trailing commas in strict .json files; .jsonc and .json5 are exempt. */
+pub fn no_trailing_commas(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(strict_json_files(slice), r",\s*[\}\]]", "s")
+  return block_on_findings(
+    "no_trailing_commas",
+    "Remove the trailing comma; rename the file to .jsonc or .json5 if JSONC syntax is intentional.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_NO_COMMENTS, confidence: 0.78, source_date: "2026-05-09")
+/** Blocks JSONC-style comment markers in strict .json files; .jsonc and .json5 are exempt. */
+pub fn no_comments_in_json(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    strict_json_files(slice),
+    r"(?m)((^\s*)|([\}\],]\s*))(//|/\*)",
+    "m",
+  )
+  return block_on_findings(
+    "no_comments_in_json",
+    "Remove the comment; rename the file to .jsonc or .json5 if comments are required.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_BOM, confidence: 0.9, source_date: "2026-05-09")
+/** Warns when a JSON file begins with a UTF-8 byte order mark. */
+pub fn no_bom_prefix(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(all_json_files(slice), { text -> text.starts_with(_BOM) })
+  return warn_on_findings(
+    "no_bom_prefix",
+    "Strip the UTF-8 BOM; RFC 8259 forbids it and many parsers reject the file outright.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_NAN_INFINITY, confidence: 0.78, source_date: "2026-05-09")
+/** Blocks NaN, Infinity, and -Infinity literals, which the JSON grammar does not define. */
+pub fn no_nan_or_infinity_literals(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    all_json_files(slice),
+    r"(?m)[:\[,]\s*-?\s*(NaN|Infinity)\b",
+    "m",
+  )
+  return block_on_findings(
+    "no_nan_or_infinity_literals",
+    "Replace NaN or Infinity with null, a sentinel string, or a documented numeric bound.",
+    findings,
+  )
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_SECRETS, confidence: 0.68, source_date: "2026-05-09")
+/** Blocks credentials, tokens, and private keys committed in JSON values. */
+pub fn no_hardcoded_secrets(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed JSON commits a credential, API key, OAuth token, signed JWT, private key, signing secret, password, or production connection string in a JSON value, instead of referencing a secret manager, environment variable, or templated placeholder."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: all_json_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "no_hardcoded_secrets",
+      "Move the secret to a secret manager or templated environment reference and rotate the exposed value.",
+      judgement.findings,
+    )
+  }
+  return allow("no_hardcoded_secrets")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_SCHEMA, confidence: 0.66, source_date: "2026-05-09")
+/** Blocks JSON files that declare a $schema reference but introduce values that violate it. */
+pub fn respects_declared_schema(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when a changed JSON file declares a top-level \"$schema\" URL and the change introduces a value the referenced JSON Schema would clearly reject — wrong type, missing required property, additional property in a closed schema, or an enum or range violation that the schema documents."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: all_json_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "respects_declared_schema",
+      "Adjust the JSON to satisfy the declared $schema, or update the schema reference if the divergence is intentional.",
+      judgement.findings,
+    )
+  }
+  return allow("respects_declared_schema")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_KEY_ORDER, confidence: 0.6, source_date: "2026-05-09")
+/** Warns when config-shaped JSON edits gratuitously reorder unrelated keys. */
+pub fn stable_key_ordering(slice, ctx, _repo_at_base) {
+  let rubric = "Warn only when a changed config-shaped JSON file (package.json, tsconfig.json, manifest, lockfile, or settings file) reorders keys the change otherwise leaves untouched, producing diff noise without a value or structural change. Allow ordering changes that are forced by a value edit, alphabetization the project explicitly enforces, or initial file creation."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: all_json_files(slice)})
+  if judgement.verdict == "Warn" || judgement.verdict == "Block" {
+    return warn(
+      "stable_key_ordering",
+      "Preserve existing key ordering when the change does not require a structural edit.",
+      judgement.findings,
+    )
+  }
+  return allow("stable_key_ordering")
+}


### PR DESCRIPTION
## Summary

- Adds `json/` v0 seed pack with 4 deterministic + 3 semantic predicates: `no_trailing_commas`, `no_comments_in_json`, `no_bom_prefix`, `no_nan_or_infinity_literals`, `no_hardcoded_secrets`, `respects_declared_schema`, `stable_key_ordering`.
- Strict-syntax checks scope to `.json` and exempt JSONC-by-convention paths (`tsconfig*.json`, `jsconfig*.json`, `.vscode/`, `.devcontainer/`); `.jsonc` and `.json5` files are also exempt.
- Each predicate ships with allow/block (or warn) fixtures and `@archivist` evidence pinned to RFC 8259, json.org, MDN, OWASP, JSON Schema, and the npm `package.json` reference.

Closes #23.

## Test plan

- [x] Every fixture file parses as valid JSON (`python3 -c "import json; json.load(open(p))"` for all seven).
- [x] Cross-checked the regex predicates (`no_trailing_commas`, `no_comments_in_json`, `no_nan_or_infinity_literals`) against their fixture cases with an equivalent Python regex; all expected verdicts match.
- [x] Verified the `_BOM` constant and the BOM fixture's inner string both contain the UTF-8 byte sequence `EF BB BF`.
- [ ] Fixture replay once the Flow harness lands (CI placeholder today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)