### PR TITLE
Add CSS seed predicate pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ See the Harn Flow design docs for the full predicate language spec.
 ## Packs
 
 - [C#](./csharp/) — v0 draft predicates for plain C# and .NET library or application code.
+- [CSS](./css/) — v0 draft predicates for CSS, Sass, and Less stylesheets covering cascade hygiene, internationalization, and accessibility.
 - [Go](./go/) — v0 draft predicates for Go modules, command packages, and reusable libraries.
 - [Harn](./harn/) — v0 draft predicates for `.harn` scripts, Flow workflows, and agent-facing Harn modules.
 - [Java](./java/) — v0 draft predicates for plain Java application and library code.

--- a/css/README.md
+++ b/css/README.md
@@ -1,0 +1,58 @@
+# CSS Seed Predicate Pack
+
+This pack covers vanilla CSS plus the common preprocessor dialects (Sass `.scss`/`.sass`, Less `.less`). It targets review issues that changed stylesheet slices can catch cheaply: cascade hygiene (`!important`, id selectors), internationalization (logical properties), unit hygiene (zero values, absolute font sizes), and accessibility (focus indicators, reduced-motion respect).
+
+## Stack Assumptions
+
+- Source files end in `.css`, `.scss`, `.sass`, or `.less`. CSS-in-JS, styled-components, and tagged-template stylesheets are out of scope until Harn Flow exposes a stable embedded-CSS extractor.
+- Vendor and build artifacts under `node_modules/`, `vendor/`, `dist/`, `build/`, or matching `*.min.css`/`*.min.scss`/`*.min.less` are skipped.
+- Test stylesheets under `__tests__/`, `test/`, `tests/`, or matching `*.test.css`/`*.spec.scss` are skipped by deterministic source predicates.
+- Deterministic predicates use file-text scans until Harn Flow exposes a stable CSS AST query API. They will accept some false positives in rare grammar shapes; see the list below.
+- Semantic predicates make one cheap judge call over changed stylesheets and use only evidence captured at authoring time.
+- Advisory rules return `Warn` when stylistic exceptions are common (vendor-driven id usage, intentionally physical layouts, decorative micro-transitions). Blocking rules are reserved for `!important` without justification, suppressed focus indicators, and motion that ignores `prefers-reduced-motion`.
+
+## Predicate Coverage
+
+| Predicate | Mode | Verdict | Purpose |
+|---|---|---|---|
+| `no_important_without_comment` | deterministic | Block | `!important` overrides need an inline comment so reviewers can see the override is intentional and bounded. |
+| `no_id_selectors` | deterministic | Warn | Id selectors spike specificity (0,1,0,0) and break component composition; classes and attributes scale better. |
+| `prefer_logical_properties` | deterministic | Warn | Physical-direction properties (`margin-left`, `text-align: right`, …) break in RTL locales; logical equivalents mirror automatically. |
+| `no_zero_with_unit` | deterministic | Warn | Zero-length values are unitless by definition; `0px` adds bytes and minor noise without changing meaning. |
+| `font_size_uses_relative_units` | deterministic | Warn | Absolute font sizes (`px`, `pt`) ignore the user's browser font-size preference and fail WCAG 1.4.4 resize-text. |
+| `accessible_focus_indicator` | semantic | Block | Suppressing focus outlines without a visible replacement breaks keyboard navigation (WCAG 2.4.7). |
+| `respect_prefers_reduced_motion` | semantic | Block | Non-trivial animations and transitions need a `prefers-reduced-motion` escape hatch (WCAG 2.3.3). |
+
+## Evidence
+
+Evidence scanned on 2026-05-09.
+
+- MDN Web Docs: `!important`, specificity, ID selectors, logical properties and values, length units, `font-size`, `:focus-visible`, `outline`, and `@media (prefers-reduced-motion)`.
+- W3C / CSSWG: CSS Logical Properties Level 1 editor's draft.
+- W3C WAI / WCAG 2.2: Understanding Focus Visible (2.4.7), Resize Text (1.4.4), Animation from Interactions (2.3.3).
+- web.dev: logical-properties learn module, font-size guidance, reduced-motion article.
+- Stylelint docs: `declaration-no-important`, `selector-max-id`, `length-zero-no-unit` rule references for cross-tool calibration of common style issues.
+
+## Known False Positives
+
+- Regex predicates do not parse CSS. Comments, multi-line declarations, Sass interpolation, nested rules, and `@supports` blocks can confuse deterministic checks.
+- `no_important_without_comment` accepts the file as soon as one `!important` is paired with a nearby comment; multiple unjustified overrides in the same file will not all be flagged independently. It also cannot tell whether a comment actually explains the override versus being unrelated.
+- `no_id_selectors` flags any `#name` selector form. Sass interpolation `#{$var}` is excluded, but `#main` rules deliberately used to style ids written by a CMS will need a local suppression once the predicate runtime supports them.
+- `prefer_logical_properties` flags only the most common physical properties (`margin/padding/border-left|right`, `text-align|float|clear: left|right`). Vertical-axis properties and `*-top`/`*-bottom` are intentionally not flagged because the inline-axis cases drive most RTL bugs.
+- `no_zero_with_unit` excludes time (`0s`, `0ms`) and angle units (`0deg`) because their unit can carry intent in animation/transform contexts. Decimal lengths like `0.5px` are not flagged.
+- `font_size_uses_relative_units` flags only `px` and `pt`. Container queries with `cqw` font-size and clamp expressions that contain a `px` term may produce false positives.
+- Semantic predicates depend on the judge recognizing concrete changed spans. They should stay high-threshold and cite the exact selector or media query before blocking.
+
+## Fixtures
+
+Each fixture in `fixtures/` contains one blocked or warned example and one allowed example for the corresponding predicate. The fixture shape matches the current harn-canon convention:
+
+```json
+{
+  "predicate": "name",
+  "cases": [
+    {"expect": "Block", "files": [{"path": "components/card.css", "text": "..."}]},
+    {"expect": "Allow", "files": [{"path": "components/card.css", "text": "..."}]}
+  ]
+}
+```

--- a/css/fixtures/accessible_focus_indicator.json
+++ b/css/fixtures/accessible_focus_indicator.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "accessible_focus_indicator",
+  "cases": [
+    {
+      "name": "blocks_outline_none_without_replacement",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "components/button.css",
+          "text": ".button:focus {\n  outline: none;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_outline_none_paired_with_focus_visible_replacement",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "components/button.css",
+          "text": ".button:focus {\n  outline: none;\n}\n\n.button:focus-visible {\n  outline: 2px solid #0a84ff;\n  outline-offset: 2px;\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/css/fixtures/font_size_uses_relative_units.json
+++ b/css/fixtures/font_size_uses_relative_units.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "font_size_uses_relative_units",
+  "cases": [
+    {
+      "name": "warns_on_pixel_font_size",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "components/typography.css",
+          "text": "body {\n  font-size: 14px;\n  line-height: 1.5;\n}\n\nh1 {\n  font-size: 24pt;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_relative_units",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "components/typography.css",
+          "text": "body {\n  font-size: 1rem;\n  line-height: 1.5;\n}\n\nh1 {\n  font-size: 2em;\n}\n\nsmall {\n  font-size: 87.5%;\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/css/fixtures/no_id_selectors.json
+++ b/css/fixtures/no_id_selectors.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "no_id_selectors",
+  "cases": [
+    {
+      "name": "warns_on_id_rule",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "components/sidebar.css",
+          "text": "#sidebar {\n  width: 240px;\n  background: #f5f5f5;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "warns_on_id_in_multiline_selector_list",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "components/footer.scss",
+          "text": ".footer-link,\n#legal-link {\n  color: #333;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_class_rule_hex_colors_and_sass_interpolation",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "components/sidebar.scss",
+          "text": "$prefix: nav;\n\n.#{$prefix}-sidebar {\n  width: 240px;\n  background: linear-gradient(45deg, #abc, #def);\n  color: #f5f5f5;\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/css/fixtures/no_important_without_comment.json
+++ b/css/fixtures/no_important_without_comment.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_important_without_comment",
+  "cases": [
+    {
+      "name": "blocks_unjustified_important",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "components/banner.css",
+          "text": ".banner {\n  color: red !important;\n  padding: 1rem;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_important_with_inline_justification",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "components/banner.css",
+          "text": ".banner {\n  /* third-party widget injects a higher-specificity rule we cannot reach */\n  color: red !important;\n  padding: 1rem;\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/css/fixtures/no_zero_with_unit.json
+++ b/css/fixtures/no_zero_with_unit.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_zero_with_unit",
+  "cases": [
+    {
+      "name": "warns_on_zero_px",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "components/card.css",
+          "text": ".card {\n  margin: 0px;\n  padding: 1rem;\n  border: 0em solid transparent;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_unitless_zero_and_nonzero_lengths",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "components/card.css",
+          "text": ".card {\n  margin: 0;\n  padding: 1rem;\n  border: 0 solid transparent;\n  transition: opacity 0.2s ease;\n  transform: rotate(0deg);\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/css/fixtures/prefer_logical_properties.json
+++ b/css/fixtures/prefer_logical_properties.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "prefer_logical_properties",
+  "cases": [
+    {
+      "name": "warns_on_physical_margin_left",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "components/list.css",
+          "text": ".list-item {\n  margin-left: 1rem;\n  text-align: right;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_logical_equivalents",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "components/list.css",
+          "text": ".list-item {\n  margin-inline-start: 1rem;\n  text-align: end;\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/css/fixtures/respect_prefers_reduced_motion.json
+++ b/css/fixtures/respect_prefers_reduced_motion.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "respect_prefers_reduced_motion",
+  "cases": [
+    {
+      "name": "blocks_long_animation_without_reduced_motion_guard",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "components/spinner.css",
+          "text": "@keyframes spin {\n  from { transform: rotate(0deg); }\n  to { transform: rotate(360deg); }\n}\n\n.spinner {\n  animation: spin 1.2s linear infinite;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_animation_with_reduced_motion_guard",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "components/spinner.css",
+          "text": "@keyframes spin {\n  from { transform: rotate(0deg); }\n  to { transform: rotate(360deg); }\n}\n\n.spinner {\n  animation: spin 1.2s linear infinite;\n}\n\n@media (prefers-reduced-motion: reduce) {\n  .spinner {\n    animation: none;\n  }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/css/invariants.harn
+++ b/css/invariants.harn
@@ -1,0 +1,246 @@
+let _EVIDENCE_IMPORTANT = [
+  "https://developer.mozilla.org/en-US/docs/Web/CSS/important",
+  "https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_cascade/Specificity",
+  "https://stylelint.io/user-guide/rules/declaration-no-important/",
+]
+
+let _EVIDENCE_ID_SELECTORS = [
+  "https://developer.mozilla.org/en-US/docs/Web/CSS/ID_selectors",
+  "https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_cascade/Specificity",
+  "https://stylelint.io/user-guide/rules/selector-max-id/",
+]
+
+let _EVIDENCE_LOGICAL_PROPERTIES = [
+  "https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_logical_properties_and_values",
+  "https://drafts.csswg.org/css-logical/",
+  "https://web.dev/learn/css/logical-properties",
+]
+
+let _EVIDENCE_ZERO_UNIT = [
+  "https://developer.mozilla.org/en-US/docs/Web/CSS/length",
+  "https://stylelint.io/user-guide/rules/length-zero-no-unit/",
+]
+
+let _EVIDENCE_RELATIVE_FONT_SIZE = [
+  "https://developer.mozilla.org/en-US/docs/Web/CSS/font-size",
+  "https://www.w3.org/WAI/WCAG22/Understanding/resize-text.html",
+  "https://web.dev/learn/accessibility/typography",
+]
+
+let _EVIDENCE_FOCUS_INDICATOR = [
+  "https://www.w3.org/WAI/WCAG22/Understanding/focus-visible.html",
+  "https://developer.mozilla.org/en-US/docs/Web/CSS/:focus-visible",
+  "https://developer.mozilla.org/en-US/docs/Web/CSS/outline",
+]
+
+let _EVIDENCE_REDUCED_MOTION = [
+  "https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion",
+  "https://www.w3.org/WAI/WCAG22/Understanding/animation-from-interactions.html",
+  "https://web.dev/articles/prefers-reduced-motion",
+]
+
+fn is_css_path(path) {
+  return path.ends_with(".css")
+    || path.ends_with(".scss")
+    || path.ends_with(".sass")
+    || path.ends_with(".less")
+}
+
+fn is_minified_path(path) {
+  return path.ends_with(".min.css")
+    || path.ends_with(".min.scss")
+    || path.ends_with(".min.less")
+}
+
+fn is_vendor_or_generated_path(path) {
+  return path.contains("node_modules/")
+    || path.contains("/vendor/")
+    || path.contains("/dist/")
+    || path.contains("/build/")
+    || is_minified_path(path)
+}
+
+fn is_test_path(path) {
+  return path.contains("/__tests__/")
+    || path.contains("/tests/")
+    || path.contains("/test/")
+    || regex_match(r"\.(test|spec)\.(css|scss|sass|less)$", path, "") != nil
+}
+
+fn css_files(slice) {
+  return slice.files
+    .filter({ file -> is_css_path(file.path) && !is_vendor_or_generated_path(file.path) })
+}
+
+fn production_css_files(slice) {
+  return css_files(slice).filter({ file -> !is_test_path(file.path) })
+}
+
+fn scan_files(files, pattern, flags) {
+  var findings = []
+  for file in files {
+    if regex_match(pattern, file.text, flags) != nil {
+      findings = findings
+        .push({path: file.path, pattern: pattern})
+    }
+  }
+  return findings
+}
+
+fn scan_files_if(files, predicate) {
+  var findings = []
+  for file in files {
+    if predicate(file) {
+      findings = findings
+        .push({path: file.path})
+    }
+  }
+  return findings
+}
+
+fn allow(rule) {
+  return {verdict: "Allow", rule: rule, findings: [], remediation: ""}
+}
+
+fn warn(rule, remediation, findings) {
+  return {verdict: "Warn", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block(rule, remediation, findings) {
+  return {verdict: "Block", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return block(rule, remediation, findings)
+}
+
+fn warn_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return warn(rule, remediation, findings)
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_IMPORTANT, confidence: 0.7, source_date: "2026-05-09")
+/** Blocks `!important` declarations that lack a nearby justifying comment. */
+pub fn no_important_without_comment(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    production_css_files(slice),
+    { file -> regex_match(r"!important\b", file.text, "s") != nil
+      && regex_match(r"/\*[\s\S]{0,400}?\*/\s*[^;{}]{0,160}!important", file.text, "s") == nil
+      && regex_match(r"//[^\n]*\n\s*[^;{}\n]{0,160}!important", file.text, "s") == nil
+      && regex_match(r"!important[^;\n]{0,80}(/\*|//)", file.text, "s") == nil },
+  )
+  return block_on_findings(
+    "no_important_without_comment",
+    "Refactor specificity, or document each !important with an inline /* … */ explaining the override.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_ID_SELECTORS, confidence: 0.72, source_date: "2026-05-09")
+/** Warns when stylesheets use `#id` selectors instead of class selectors. */
+pub fn no_id_selectors(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_css_files(slice),
+    r"#(?!\{)[A-Za-z_][A-Za-z0-9_-]*[^;{}]*?\{",
+    "s",
+  )
+  return warn_on_findings(
+    "no_id_selectors",
+    "Prefer class or attribute selectors so component styles compose; ids spike specificity and resist overrides.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_LOGICAL_PROPERTIES, confidence: 0.66, source_date: "2026-05-09")
+/** Warns on physical-direction properties that have a logical equivalent. */
+pub fn prefer_logical_properties(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_css_files(slice),
+    r"(?m)(?:^|[\s;{])(?:(?:margin|padding|border)-(?:left|right)\b|(?:text-align|float|clear)\s*:\s*(?:left|right)\b)",
+    "m",
+  )
+  return warn_on_findings(
+    "prefer_logical_properties",
+    "Use logical properties (e.g. `margin-inline-start`, `text-align: start`) so layouts mirror correctly in RTL locales.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_ZERO_UNIT, confidence: 0.85, source_date: "2026-05-09")
+/** Warns when zero-length values include a unit (e.g. `0px`); plain `0` is sufficient. */
+pub fn no_zero_with_unit(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_css_files(slice),
+    r"(?:^|[^.\d])0(?:px|em|rem|%|vh|vw|vmin|vmax|pt|pc|in|cm|mm|q|ex|ch|fr)\b",
+    "s",
+  )
+  return warn_on_findings(
+    "no_zero_with_unit",
+    "Drop the unit on zero-length values; `0` is unambiguous and shaves bytes uniformly across declarations.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_RELATIVE_FONT_SIZE, confidence: 0.7, source_date: "2026-05-09")
+/** Warns when `font-size` uses absolute units (`px`, `pt`) that ignore user font-size preferences. */
+pub fn font_size_uses_relative_units(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_css_files(slice),
+    r"\bfont-size\s*:\s*[+-]?\d+(?:\.\d+)?\s*(?:px|pt)\b",
+    "s",
+  )
+  return warn_on_findings(
+    "font_size_uses_relative_units",
+    "Use relative units (`rem`, `em`, `%`) for font-size so users who set a larger default text size are respected (WCAG 1.4.4).",
+    findings,
+  )
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_FOCUS_INDICATOR, confidence: 0.66, source_date: "2026-05-09")
+/** Blocks suppressing the default focus outline without supplying a visible replacement. */
+pub fn accessible_focus_indicator(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed CSS suppresses the keyboard focus indicator (e.g. `outline: none`, `outline: 0`, `outline: 0px`, or sets outline width to 0) on focusable elements and the same slice does not provide a clearly visible replacement focus style for `:focus` or `:focus-visible` (such as a non-transparent box-shadow, border, background, or outline applied via the focus pseudo-classes). Allow suppressions that are paired with an obvious focus-visible replacement, that target non-interactive selectors, or that scope the suppression to `:focus:not(:focus-visible)` while leaving keyboard focus styled."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: production_css_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "accessible_focus_indicator",
+      "Keep a visible focus indicator (WCAG 2.4.7); pair any `outline: none` with a `:focus-visible` style that has ≥3:1 contrast against adjacent colors.",
+      judgement.findings,
+    )
+  }
+  return allow("accessible_focus_indicator")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_REDUCED_MOTION, confidence: 0.62, source_date: "2026-05-09")
+/** Blocks new non-trivial animations or transitions that ignore `prefers-reduced-motion`. */
+pub fn respect_prefers_reduced_motion(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed CSS introduces a non-trivial animation or transition (an `animation`, `@keyframes`, or `transition` longer than ~150ms or that involves transform/translate/scale/rotate/opacity loops) and the slice does not include a `@media (prefers-reduced-motion: reduce)` block that disables, shortens, or removes the offending animation/transition. Allow purely instantaneous transitions, hover-only color tweens shorter than ~150ms, or changes that already gate motion behind the reduced-motion media query."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: production_css_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "respect_prefers_reduced_motion",
+      "Wrap or override the new animation/transition inside `@media (prefers-reduced-motion: reduce)` so users who opt out of motion are not subjected to it (WCAG 2.3.3).",
+      judgement.findings,
+    )
+  }
+  return allow("respect_prefers_reduced_motion")
+}


### PR DESCRIPTION
## Summary
- Adds a v0 CSS/Sass/Less seed predicate pack with 5 deterministic and 2 semantic predicates: `no_important_without_comment`, `no_id_selectors`, `prefer_logical_properties`, `no_zero_with_unit`, `font_size_uses_relative_units`, `accessible_focus_indicator`, `respect_prefers_reduced_motion`.
- Documents stack assumptions (skips `node_modules/`, `vendor/`, `dist/`, `build/`, `*.min.*`, and test paths), per-predicate verdict + purpose, evidence sources scanned 2026-05-09, and known false-positive shapes.
- Ships allow + block/warn fixtures for every predicate (including hex-color and multi-line-selector edge cases for `no_id_selectors`) and lists CSS in the root pack index alphabetically.

Closes #32

## Test plan
- [x] `jq empty css/fixtures/*.json`
- [x] Pre-flight regex replay against every deterministic fixture (Python re-implementation; all expected verdicts match)
- [x] HTTP HEAD check on every evidence URL (all 200; replaced one stale `web.dev/articles/font-size` with `web.dev/learn/accessibility/typography`)
- [x] Rebased on latest `origin/main` after #50 / #49 / #46 landed

🤖 Generated with [Claude Code](https://claude.com/claude-code)