### PR TITLE
Add Protocol Buffers seed predicate pack

### DIFF
--- a/protobuf/README.md
+++ b/protobuf/README.md
@@ -1,0 +1,56 @@
+# Protocol Buffers Seed Predicate Pack
+
+This pack covers `.proto` schemas — proto2, proto3, and the newer Editions syntax. Protobuf has a small surface area but a brutal failure mode: a renumbered field or a deleted-then-reused tag silently corrupts data on the wire across every consumer that has not yet redeployed. The predicates here target the handful of authoring mistakes that are cheap to catch on a slice and expensive to recover from in production.
+
+## Stack Assumptions
+
+- Schema sources end in `.proto`; generated stubs (`*.pb.go`, `*.pb.cc`, `*_pb2.py`, etc.) are out of scope for this pack — those should be reviewed by the consuming language's pack.
+- Vendored or generated proto trees under `/vendor/`, `/third_party/`, `/node_modules/`, `/generated/`, or `/.proto-cache/` are excluded from first-party scans.
+- Deterministic predicates use file-text scans until Harn Flow exposes a stable proto descriptor query API.
+- Semantic predicates make one cheap judge call over changed `.proto` files and rely on the diff context to compare against the prior schema.
+- Advisory rules return `Warn` when official guidance is style-level. Blocking rules are reserved for declarations the protobuf compiler or wire format outright rejects, and for changes that break wire compatibility for already-deployed consumers.
+
+## Predicate Coverage
+
+| Predicate | Mode | Verdict | Purpose |
+|---|---|---|---|
+| `explicit_syntax_version` | deterministic | Block | Every `.proto` file must declare `syntax = "proto2" / "proto3"` or `edition = "YYYY"` so parsers pick the correct dialect. |
+| `package_declaration_required` | deterministic | Warn | Schemas should namespace generated symbols with a dotted `package` to avoid cross-schema collisions. |
+| `no_required_in_proto3` | deterministic | Block | proto3 dropped the `required` field rule; the protoc parser rejects it. |
+| `field_names_lower_snake_case` | deterministic | Warn | Field names should be `lower_snake_case` so generated bindings stay idiomatic across languages. |
+| `enum_zero_value_unspecified` | deterministic | Warn | Enums should start with `<NAME>_UNSPECIFIED = 0` so the default is explicit and forward-compatible. |
+| `no_reserved_field_number_range` | deterministic | Block | Field numbers 19000-19999 are reserved by the protobuf implementation and refused by protoc. |
+| `no_field_number_renumbering` | semantic | Block | Existing field numbers must stay stable; reusing or repurposing a tag silently corrupts wire-compatible data. |
+| `reserved_on_field_removal` | semantic | Block | Deleted fields must be `reserved` so future fields cannot accidentally reuse the freed number or name. |
+
+## Evidence
+
+Evidence scanned on 2026-05-09.
+
+- protobuf.dev programming guides for [proto3](https://protobuf.dev/programming-guides/proto3/), [proto2](https://protobuf.dev/programming-guides/proto2/), and [style](https://protobuf.dev/programming-guides/style/).
+- protobuf.dev [best practices: dos and don'ts](https://protobuf.dev/best-practices/dos-donts/) for the wire-compat and enum-zero guidance.
+- Editions [overview](https://protobuf.dev/editions/overview/) for the post-syntax declaration form.
+- Updating-a-message and deleting-a-field sections of the proto3 and proto2 guides for wire-compat rules.
+
+## Known False Positives
+
+- Regex predicates do not parse protobuf. Block comments, unusual whitespace, and macros (when proto files are templated) can confuse deterministic checks.
+- `field_names_lower_snake_case` looks at simple `optional/repeated/required type field = N` shapes; map fields and `oneof` members with type parameters may not match the same regex and can slip through.
+- `enum_zero_value_unspecified` scans for the conventional `_UNSPECIFIED = 0` suffix. Some legacy schemas use `_INVALID = 0` or `_NONE = 0` as the sentinel; those will warn until the convention is normalized or a suppression lands.
+- `no_reserved_field_number_range` only catches the always-reserved 19000-19999 implementation range. Per-message `reserved` ranges declared in the schema are out of scope for the deterministic check and should be enforced at the descriptor layer once available.
+- `no_required_in_proto3` looks for `required` in files that explicitly declare `syntax = "proto3"`. Files using Editions with `features.field_presence = LEGACY_REQUIRED` are out of scope for this check.
+- Semantic predicates depend on the judge recognizing the prior shape of the message from diff context. They should stay high-threshold and cite the exact field number, name, or type change before blocking.
+
+## Fixtures
+
+Each fixture in `fixtures/` contains one blocked or warned example and one allowed example for the corresponding predicate. The fixture shape matches the current harn-canon convention:
+
+```json
+{
+  "predicate": "name",
+  "cases": [
+    {"expect": "Block", "files": [{"path": "api/v1/user.proto", "text": "..."}]},
+    {"expect": "Allow", "files": [{"path": "api/v1/user.proto", "text": "..."}]}
+  ]
+}
+```

--- a/protobuf/fixtures/enum_zero_value_unspecified.json
+++ b/protobuf/fixtures/enum_zero_value_unspecified.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "enum_zero_value_unspecified",
+  "cases": [
+    {
+      "name": "warns_enum_without_unspecified_zero",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "api/v1/user.proto",
+          "text": "syntax = \"proto3\";\n\npackage api.v1;\n\nenum Status {\n  ACTIVE = 0;\n  INACTIVE = 1;\n  BANNED = 2;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_enum_with_unspecified_zero",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "api/v1/user.proto",
+          "text": "syntax = \"proto3\";\n\npackage api.v1;\n\nenum Status {\n  STATUS_UNSPECIFIED = 0;\n  STATUS_ACTIVE = 1;\n  STATUS_INACTIVE = 2;\n  STATUS_BANNED = 3;\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/protobuf/fixtures/explicit_syntax_version.json
+++ b/protobuf/fixtures/explicit_syntax_version.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "explicit_syntax_version",
+  "cases": [
+    {
+      "name": "blocks_proto_without_syntax_or_edition",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "api/v1/user.proto",
+          "text": "package api.v1;\n\nmessage User {\n  string id = 1;\n  string email = 2;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_proto3_syntax_declaration",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "api/v1/user.proto",
+          "text": "syntax = \"proto3\";\n\npackage api.v1;\n\nmessage User {\n  string id = 1;\n  string email = 2;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_editions_declaration",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "api/v1/user.proto",
+          "text": "edition = \"2023\";\n\npackage api.v1;\n\nmessage User {\n  string id = 1;\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/protobuf/fixtures/field_names_lower_snake_case.json
+++ b/protobuf/fixtures/field_names_lower_snake_case.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "field_names_lower_snake_case",
+  "cases": [
+    {
+      "name": "warns_camel_case_field",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "api/v1/user.proto",
+          "text": "syntax = \"proto3\";\n\npackage api.v1;\n\nmessage User {\n  string userId = 1;\n  string emailAddress = 2;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_lower_snake_case_fields",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "api/v1/user.proto",
+          "text": "syntax = \"proto3\";\n\npackage api.v1;\n\nmessage User {\n  string user_id = 1;\n  string email_address = 2;\n  repeated string role_ids = 3;\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/protobuf/fixtures/no_field_number_renumbering.json
+++ b/protobuf/fixtures/no_field_number_renumbering.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_field_number_renumbering",
+  "cases": [
+    {
+      "name": "blocks_renumbered_existing_field",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "api/v1/user.proto",
+          "text": "syntax = \"proto3\";\n\npackage api.v1;\n\n// Previously: string email = 2; — this change reassigns the existing field\n// to a new tag, breaking every already-deployed client.\nmessage User {\n  string id = 1;\n  string email = 7;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_additive_field",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "api/v1/user.proto",
+          "text": "syntax = \"proto3\";\n\npackage api.v1;\n\n// Adds a new optional field with a fresh number; existing tags untouched.\nmessage User {\n  string id = 1;\n  string email = 2;\n  optional string display_name = 3;\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/protobuf/fixtures/no_required_in_proto3.json
+++ b/protobuf/fixtures/no_required_in_proto3.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "no_required_in_proto3",
+  "cases": [
+    {
+      "name": "blocks_required_field_in_proto3",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "api/v1/user.proto",
+          "text": "syntax = \"proto3\";\n\npackage api.v1;\n\nmessage User {\n  required string id = 1;\n  string email = 2;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_singular_and_optional_proto3",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "api/v1/user.proto",
+          "text": "syntax = \"proto3\";\n\npackage api.v1;\n\nmessage User {\n  string id = 1;\n  optional string email = 2;\n  repeated string roles = 3;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_required_in_proto2",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "api/v1/legacy.proto",
+          "text": "syntax = \"proto2\";\n\npackage api.legacy;\n\nmessage Legacy {\n  required string id = 1;\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/protobuf/fixtures/no_reserved_field_number_range.json
+++ b/protobuf/fixtures/no_reserved_field_number_range.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_reserved_field_number_range",
+  "cases": [
+    {
+      "name": "blocks_field_number_in_implementation_reserved_range",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "api/v1/user.proto",
+          "text": "syntax = \"proto3\";\n\npackage api.v1;\n\nmessage User {\n  string id = 1;\n  string email = 19500;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_field_numbers_outside_reserved_range",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "api/v1/user.proto",
+          "text": "syntax = \"proto3\";\n\npackage api.v1;\n\nmessage User {\n  string id = 1;\n  string email = 2;\n  string display_name = 18999;\n  string avatar_url = 20000;\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/protobuf/fixtures/package_declaration_required.json
+++ b/protobuf/fixtures/package_declaration_required.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "package_declaration_required",
+  "cases": [
+    {
+      "name": "warns_proto_without_package",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "api/v1/user.proto",
+          "text": "syntax = \"proto3\";\n\nmessage User {\n  string id = 1;\n  string email = 2;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_dotted_package",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "api/v1/user.proto",
+          "text": "syntax = \"proto3\";\n\npackage api.v1;\n\nmessage User {\n  string id = 1;\n  string email = 2;\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/protobuf/fixtures/reserved_on_field_removal.json
+++ b/protobuf/fixtures/reserved_on_field_removal.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "reserved_on_field_removal",
+  "cases": [
+    {
+      "name": "blocks_field_removal_without_reserved",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "api/v1/user.proto",
+          "text": "syntax = \"proto3\";\n\npackage api.v1;\n\n// Previously: string email = 2; legacy_id = 3; — both removed without a\n// reserved declaration, so a future field could silently reuse tag 2 or 3\n// and corrupt data on the wire for any client still on the old schema.\nmessage User {\n  string id = 1;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_removal_with_reserved_number_and_name",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "api/v1/user.proto",
+          "text": "syntax = \"proto3\";\n\npackage api.v1;\n\nmessage User {\n  reserved 2, 3;\n  reserved \"email\", \"legacy_id\";\n  string id = 1;\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/protobuf/invariants.harn
+++ b/protobuf/invariants.harn
@@ -1,0 +1,258 @@
+let _EVIDENCE_SYNTAX_VERSION = [
+  "https://protobuf.dev/programming-guides/proto3/#simple",
+  "https://protobuf.dev/programming-guides/proto2/#simple",
+  "https://protobuf.dev/editions/overview/",
+]
+
+let _EVIDENCE_PACKAGE = [
+  "https://protobuf.dev/programming-guides/proto3/#packages",
+  "https://protobuf.dev/programming-guides/style/#packages",
+]
+
+let _EVIDENCE_NO_REQUIRED = [
+  "https://protobuf.dev/programming-guides/proto3/#specifying-field-rules",
+  "https://protobuf.dev/best-practices/dos-donts/#dont-add-a-required-field",
+]
+
+let _EVIDENCE_FIELD_NAMES = [
+  "https://protobuf.dev/programming-guides/style/#field-names",
+  "https://protobuf.dev/programming-guides/proto3/#assigning",
+]
+
+let _EVIDENCE_ENUM_ZERO = [
+  "https://protobuf.dev/programming-guides/proto3/#enum",
+  "https://protobuf.dev/best-practices/dos-donts/#do-include-an-unspecified-value-in-an-enum",
+  "https://protobuf.dev/programming-guides/style/#enums",
+]
+
+let _EVIDENCE_RESERVED_RANGE = [
+  "https://protobuf.dev/programming-guides/proto3/#assigning",
+  "https://protobuf.dev/programming-guides/proto2/#assigning",
+]
+
+let _EVIDENCE_FIELD_RENUMBER = [
+  "https://protobuf.dev/programming-guides/proto3/#updating",
+  "https://protobuf.dev/best-practices/dos-donts/#dont-re-use-a-tag-number",
+  "https://protobuf.dev/programming-guides/proto2/#updating",
+]
+
+let _EVIDENCE_RESERVED_ON_DELETE = [
+  "https://protobuf.dev/programming-guides/proto3/#deleting",
+  "https://protobuf.dev/best-practices/dos-donts/#do-reserve-tag-numbers-for-deleted-fields",
+]
+
+fn proto_files(slice) {
+  return slice.files.filter({ file -> file.path.ends_with(".proto") })
+}
+
+fn is_vendored_path(path) {
+  return contains(path, "/vendor/")
+    || contains(path, "/third_party/")
+    || contains(path, "/node_modules/")
+    || contains(path, "/.proto-cache/")
+    || contains(path, "/generated/")
+}
+
+fn first_party_proto_files(slice) {
+  return proto_files(slice).filter({ file -> !is_vendored_path(file.path) })
+}
+
+fn scan_files(files, pattern, flags) {
+  var findings = []
+  for file in files {
+    if regex_match(pattern, file.text, flags) != nil {
+      findings = findings.push({path: file.path, pattern: pattern})
+    }
+  }
+  return findings
+}
+
+fn scan_files_if(files, predicate) {
+  var findings = []
+  for file in files {
+    if predicate(file) {
+      findings = findings.push({path: file.path})
+    }
+  }
+  return findings
+}
+
+fn scan_files_without(files, include_pattern, exclude_pattern) {
+  return scan_files_if(
+    files,
+    { file -> regex_match(include_pattern, file.text, "s") != nil
+      && regex_match(exclude_pattern, file.text, "s") == nil },
+  )
+}
+
+fn allow(rule) {
+  return {verdict: "Allow", rule: rule, findings: [], remediation: ""}
+}
+
+fn warn(rule, remediation, findings) {
+  return {verdict: "Warn", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block(rule, remediation, findings) {
+  return {verdict: "Block", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return block(rule, remediation, findings)
+}
+
+fn warn_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return warn(rule, remediation, findings)
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_SYNTAX_VERSION, confidence: 0.92, source_date: "2026-05-09")
+/** Blocks .proto files that omit an explicit syntax or edition declaration. */
+pub fn explicit_syntax_version(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    first_party_proto_files(slice),
+    { file -> regex_match(r"(?m)^\s*syntax\s*=\s*\"proto[23]\"\s*;", file.text, "m") == nil
+      && regex_match(r"(?m)^\s*edition\s*=\s*\"\d{4}\"\s*;", file.text, "m") == nil },
+  )
+  return block_on_findings(
+    "explicit_syntax_version",
+    "Declare syntax = \"proto2\" / \"proto3\" or edition = \"YYYY\" at the top of every .proto file.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_PACKAGE, confidence: 0.78, source_date: "2026-05-09")
+/** Warns when .proto files omit a package declaration, risking name collisions across schemas. */
+pub fn package_declaration_required(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    first_party_proto_files(slice),
+    { file -> regex_match(r"(?m)^\s*package\s+[A-Za-z_][A-Za-z0-9_.]*\s*;", file.text, "m") == nil },
+  )
+  return warn_on_findings(
+    "package_declaration_required",
+    "Add a dotted package declaration so generated symbols are namespaced and protected from cross-schema collisions.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_NO_REQUIRED, confidence: 0.95, source_date: "2026-05-09")
+/** Blocks the proto2-only required field rule in proto3 schemas. */
+pub fn no_required_in_proto3(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    first_party_proto_files(slice),
+    { file -> regex_match(r"(?m)^\s*syntax\s*=\s*\"proto3\"\s*;", file.text, "m") != nil
+      && regex_match(r"(?m)^\s*required\s+[A-Za-z_][A-Za-z0-9_.]*\s+[A-Za-z_][A-Za-z0-9_]*\s*=\s*\d+", file.text, "m")
+      != nil },
+  )
+  return block_on_findings(
+    "no_required_in_proto3",
+    "Remove required from proto3 fields; proto3 only supports singular, optional, repeated, and map.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_FIELD_NAMES, confidence: 0.7, source_date: "2026-05-09")
+/** Warns when message field names use camelCase or PascalCase instead of lower_snake_case. */
+pub fn field_names_lower_snake_case(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    first_party_proto_files(slice),
+    r"(?m)^\s*(?:optional\s+|repeated\s+|required\s+)?[A-Za-z_][A-Za-z0-9_.]*\s+([A-Za-z_]*[A-Z][A-Za-z0-9_]*)\s*=\s*\d+\s*[;\[]",
+    "m",
+  )
+  return warn_on_findings(
+    "field_names_lower_snake_case",
+    "Rename fields to lower_snake_case so generated bindings remain idiomatic across languages.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_ENUM_ZERO, confidence: 0.74, source_date: "2026-05-09")
+/** Warns when an enum's first value is not an *_UNSPECIFIED zero entry. */
+pub fn enum_zero_value_unspecified(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    first_party_proto_files(slice),
+    { file -> regex_match(
+      r"(?s)enum\s+[A-Za-z_][A-Za-z0-9_]*\s*\{\s*(?:reserved[^;]*;\s*|option[^;]*;\s*|//[^\n]*\n\s*)*([A-Z][A-Z0-9_]*)\s*=\s*(\d+)",
+      file.text,
+      "s",
+    )
+      != nil
+      && regex_match(
+      r"(?s)enum\s+[A-Za-z_][A-Za-z0-9_]*\s*\{\s*(?:reserved[^;]*;\s*|option[^;]*;\s*|//[^\n]*\n\s*)*[A-Z][A-Z0-9_]*_UNSPECIFIED\s*=\s*0\b",
+      file.text,
+      "s",
+    )
+      == nil },
+  )
+  return warn_on_findings(
+    "enum_zero_value_unspecified",
+    "Make the first enum value <ENUM>_UNSPECIFIED = 0 so the default is explicit and forward-compatible.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_RESERVED_RANGE, confidence: 0.96, source_date: "2026-05-09")
+/** Blocks field numbers that fall in the protobuf-reserved 19000-19999 range. */
+pub fn no_reserved_field_number_range(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    first_party_proto_files(slice),
+    r"(?m)^\s*(?:optional\s+|repeated\s+|required\s+)?[A-Za-z_][A-Za-z0-9_.]*\s+[A-Za-z_][A-Za-z0-9_]*\s*=\s*(?:19[0-9]{3})\s*[;\[]",
+    "m",
+  )
+  return block_on_findings(
+    "no_reserved_field_number_range",
+    "Pick a field number outside 19000-19999; that range is reserved by the protobuf implementation.",
+    findings,
+  )
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_FIELD_RENUMBER, confidence: 0.7, source_date: "2026-05-09")
+/** Blocks renumbered or repurposed field tags that would break wire compatibility. */
+pub fn no_field_number_renumbering(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed .proto files alter the field number of an existing field, reuse a previously-used field number for a different field, or change the wire-incompatible type of an existing field number (for example int32 to string, or singular to map). Allow strictly additive changes that introduce new fields with fresh numbers, or pure renames that keep the original number and type."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: first_party_proto_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "no_field_number_renumbering",
+      "Keep existing field numbers stable; reserve old numbers and add new fields with fresh numbers instead.",
+      judgement.findings,
+    )
+  }
+  return allow("no_field_number_renumbering")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_RESERVED_ON_DELETE, confidence: 0.72, source_date: "2026-05-09")
+/** Blocks field deletions that omit a matching reserved declaration for the freed number or name. */
+pub fn reserved_on_field_removal(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed .proto files remove a field from an existing message without adding a reserved entry that covers the removed field number and the removed field name. Allow removals that add the matching reserved declaration, removals from messages that have never been deployed, and additive changes."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: first_party_proto_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "reserved_on_field_removal",
+      "When deleting a field, add reserved <number>; and reserved \"<name>\"; so future fields cannot accidentally reuse the slot.",
+      judgement.findings,
+    )
+  }
+  return allow("reserved_on_field_removal")
+}


### PR DESCRIPTION
## Summary
- Add `protobuf/` v0 seed predicate pack with eight invariants covering authoring mistakes that are cheap to catch and expensive to recover from in production.
- Six deterministic predicates (`explicit_syntax_version`, `package_declaration_required`, `no_required_in_proto3`, `field_names_lower_snake_case`, `enum_zero_value_unspecified`, `no_reserved_field_number_range`) plus two semantic wire-compat predicates (`no_field_number_renumbering`, `reserved_on_field_removal`).
- Allow/Block fixtures per predicate; vendored / generated proto trees excluded; Editions syntax (`edition = "YYYY"`) accepted alongside `syntax = "proto[23]"`.
- Closes #29 (umbrella #1).

## Evidence
All 18 evidence URLs return 200 and resolve to the expected anchors on protobuf.dev programming guides, the style guide, the editions overview, and the best-practices dos-donts page (verified against the 2026-05-09 scan).

## Test plan
- [ ] Predicate `fmt` placeholder check passes.
- [ ] Evidence link check placeholder passes.
- [ ] Fixture replay placeholder passes.
- [ ] Once Harn Flow ships, fixtures replay end-to-end (each Block fixture blocks, each Allow fixture allows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)