### PR TITLE
Add GraphQL seed predicate pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ See the Harn Flow design docs for the full predicate language spec.
 
 - [C#](./csharp/) — v0 draft predicates for plain C# and .NET library or application code.
 - [Go](./go/) — v0 draft predicates for Go modules, command packages, and reusable libraries.
+- [GraphQL](./graphql/) — v0 draft predicates for GraphQL schema files and the server wiring that hosts them.
 - [Harn](./harn/) — v0 draft predicates for `.harn` scripts, Flow workflows, and agent-facing Harn modules.
 - [Java](./java/) — v0 draft predicates for plain Java application and library code.
 - [JavaScript](./javascript/) — v0 draft predicates for plain JavaScript source, async handling, dynamic-code hazards, and untrusted data boundaries.

--- a/graphql/README.md
+++ b/graphql/README.md
@@ -1,0 +1,60 @@
+# GraphQL Seed Predicate Pack
+
+This pack covers GraphQL schema files (`.graphql`, `.graphqls`, `.gql`) and the server wiring that hosts them. The surface area is small relative to a full language pack, so v0 prioritizes high-signal naming, documentation, evolution, and resource-bound rules drawn from the GraphQL spec, the Apollo schema-design tech notes, the Relay connection spec, and the OWASP GraphQL cheat sheet.
+
+## Stack Assumptions
+
+- Schema checks target `.graphql`, `.graphqls`, and `.gql` files. Generated paths (`/generated/`, `/__generated__/`, `*.generated.*`) are excluded.
+- Schemas are written in GraphQL SDL, not introspected JSON; client document linting belongs in a separate pack.
+- The server-config check is intentionally framework-broad: Apollo Server, Apollo Router, GraphQL Yoga, Mercurius, gqlgen, graphql-ruby, Strawberry, Ariadne, and similar all qualify.
+- Deterministic predicates run over changed schema source text. AST queries will replace the regexes once Flow exposes a stable GraphQL query API.
+- Semantic predicates use `ctx.semantic_judge(...)` and must cite concrete changed spans before blocking; schema-evolution checks rely on the judge to reason about the diff until the runtime exposes paired base-and-head schema snapshots.
+
+## Predicate Coverage
+
+| Predicate | Mode | Verdict | Purpose |
+|---|---|---|---|
+| `enum_values_upper_snake_case` | deterministic | Block | Enum values follow the Apollo and graphql-eslint UPPER_SNAKE_CASE convention. |
+| `no_double_underscore_names` | deterministic | Block | The GraphQL spec reserves a leading double underscore for introspection. |
+| `descriptions_on_public_types` | deterministic | Warn | Schema files declaring public types should carry at least one description block. |
+| `mutation_uses_input_type` | deterministic | Warn | Mutations should take a single `input` object so callers can evolve fields safely. |
+| `pagination_args_on_root_list_fields` | deterministic | Warn | Root Query list fields should expose pagination arguments to bound result size. |
+| `no_breaking_schema_change` | semantic | Block | Schema changes must keep a backwards-compatible alias or staging path for removed or narrowed elements. |
+| `deprecation_over_removal` | semantic | Block | Public schema elements must be `@deprecated` with a reason before removal. |
+| `query_depth_limit_enforced` | semantic | Block | Public GraphQL endpoints must configure a depth, complexity, alias, token, or persisted-operation limit. |
+
+## Evidence
+
+Evidence scanned on 2026-05-09.
+
+- GraphQL October 2021 specification: reserved names (§ 2.1.9), descriptions (§ 2.4), and the `@deprecated` directive.
+- graphql.org learn pages: introspection, pagination, and best-practices guidance on schema versioning.
+- Apollo schema design tech notes: TN0002 schema naming conventions and the GraphOS schema-checks workflow.
+- Apollo Router operation-limits configuration for depth, complexity, alias, and token bounds.
+- Relay specifications: cursor connections for pagination and the mutation input-object convention.
+- The Guild graphql-eslint rule documentation: `naming-convention` and `require-description`.
+- The Guild graphql-inspector docs for diff-based breaking-change detection.
+- OWASP GraphQL Security Cheat Sheet for query-cost and depth-limit guidance.
+
+## Known False Positives
+
+- `enum_values_upper_snake_case` is line-anchored: an enum value that starts with an uppercase letter but contains lowercase mid-identifier (`MixedCase`) is not flagged until AST checks land.
+- `no_double_underscore_names` matches type and field declaration sites only; it does not inspect references to introspection types in queries.
+- `descriptions_on_public_types` warns at file granularity. A schema file with one description and many undocumented types is currently treated as documented.
+- `mutation_uses_input_type` flags any mutation whose first argument is not named `input`, which can be noisy for projects that intentionally take a single scalar argument such as `id`.
+- `pagination_args_on_root_list_fields` only inspects bare `name: [...]` and `name(): [...]` shapes; a list field that takes filter arguments but no pagination cursor is not yet flagged.
+- The semantic predicates depend on the judge being able to reason about removals or server wiring from the changed slice; until the runtime exposes paired base-and-head schemas and richer change context, blocking should stay anchored to clear, citable spans.
+
+## Fixtures
+
+Each fixture in `fixtures/` contains at least one blocked or warned example and one allowed example for the corresponding predicate:
+
+```json
+{
+  "predicate": "name",
+  "cases": [
+    {"expect": "Block", "files": [{"path": "schema/user.graphql", "text": "..."}]},
+    {"expect": "Allow", "files": [{"path": "schema/user.graphql", "text": "..."}]}
+  ]
+}
+```

--- a/graphql/fixtures/deprecation_over_removal.json
+++ b/graphql/fixtures/deprecation_over_removal.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "deprecation_over_removal",
+  "cases": [
+    {
+      "name": "blocks_undeprecated_removal",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "schema/user.graphql",
+          "text": "type User {\n  id: ID!\n  displayName: String\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_deprecated_then_removed",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "schema/user.graphql",
+          "text": "type User {\n  id: ID!\n  email: String! @deprecated(reason: \"Use contactEmail; will be removed 2027-01-01.\")\n  contactEmail: String!\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/graphql/fixtures/descriptions_on_public_types.json
+++ b/graphql/fixtures/descriptions_on_public_types.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "descriptions_on_public_types",
+  "cases": [
+    {
+      "name": "warns_on_undocumented_schema",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "schema/user.graphql",
+          "text": "type User {\n  id: ID!\n  email: String!\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_documented_schema",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "schema/user.graphql",
+          "text": "\"\"\"\nA registered account.\n\"\"\"\ntype User {\n  id: ID!\n  email: String!\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/graphql/fixtures/enum_values_upper_snake_case.json
+++ b/graphql/fixtures/enum_values_upper_snake_case.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "enum_values_upper_snake_case",
+  "cases": [
+    {
+      "name": "blocks_lowercase_enum_value",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "schema/order.graphql",
+          "text": "enum OrderStatus {\n  PLACED\n  pending\n  SHIPPED\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_upper_snake_case_values",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "schema/order.graphql",
+          "text": "enum OrderStatus {\n  PLACED\n  PENDING_FULFILLMENT\n  SHIPPED\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/graphql/fixtures/mutation_uses_input_type.json
+++ b/graphql/fixtures/mutation_uses_input_type.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "mutation_uses_input_type",
+  "cases": [
+    {
+      "name": "warns_on_loose_mutation_arguments",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "schema/mutation.graphql",
+          "text": "type Mutation {\n  createUser(name: String!, email: String!): User\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_input_object_mutation",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "schema/mutation.graphql",
+          "text": "input CreateUserInput {\n  name: String!\n  email: String!\n}\n\ntype Mutation {\n  createUser(input: CreateUserInput!): User\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/graphql/fixtures/no_breaking_schema_change.json
+++ b/graphql/fixtures/no_breaking_schema_change.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_breaking_schema_change",
+  "cases": [
+    {
+      "name": "blocks_field_removal_without_alias",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "schema/user.graphql",
+          "text": "type User {\n  id: ID!\n  email: String!\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_additive_field_change",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "schema/user.graphql",
+          "text": "type User {\n  id: ID!\n  email: String!\n  displayName: String\n  legacyName: String @deprecated(reason: \"Use displayName.\")\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/graphql/fixtures/no_double_underscore_names.json
+++ b/graphql/fixtures/no_double_underscore_names.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_double_underscore_names",
+  "cases": [
+    {
+      "name": "blocks_double_underscore_type_name",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "schema/internal.graphql",
+          "text": "type __InternalCache {\n  hitRate: Float!\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_normal_type_name",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "schema/internal.graphql",
+          "text": "type InternalCache {\n  hitRate: Float!\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/graphql/fixtures/pagination_args_on_root_list_fields.json
+++ b/graphql/fixtures/pagination_args_on_root_list_fields.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "pagination_args_on_root_list_fields",
+  "cases": [
+    {
+      "name": "warns_on_unbounded_list_field",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "schema/query.graphql",
+          "text": "type Query {\n  users: [User!]!\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_paginated_list_field",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "schema/query.graphql",
+          "text": "type Query {\n  users(first: Int!, after: String): UserConnection!\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/graphql/fixtures/query_depth_limit_enforced.json
+++ b/graphql/fixtures/query_depth_limit_enforced.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "query_depth_limit_enforced",
+  "cases": [
+    {
+      "name": "blocks_unbounded_apollo_server",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/server.ts",
+          "text": "import { ApolloServer } from '@apollo/server';\nimport { startStandaloneServer } from '@apollo/server/standalone';\nimport { typeDefs, resolvers } from './schema';\n\nconst server = new ApolloServer({ typeDefs, resolvers });\nawait startStandaloneServer(server, { listen: { port: 4000 } });\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_depth_limited_server",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/server.ts",
+          "text": "import { ApolloServer } from '@apollo/server';\nimport { startStandaloneServer } from '@apollo/server/standalone';\nimport depthLimit from 'graphql-depth-limit';\nimport { typeDefs, resolvers } from './schema';\n\nconst server = new ApolloServer({\n  typeDefs,\n  resolvers,\n  validationRules: [depthLimit(7)],\n});\nawait startStandaloneServer(server, { listen: { port: 4000 } });\n"
+        }
+      ]
+    }
+  ]
+}

--- a/graphql/invariants.harn
+++ b/graphql/invariants.harn
@@ -1,0 +1,259 @@
+let _EVIDENCE_NAMING = [
+  "https://www.apollographql.com/docs/technotes/TN0002-schema-naming-conventions/",
+  "https://the-guild.dev/graphql/eslint/rules/naming-convention",
+]
+
+let _EVIDENCE_RESERVED_NAMES = [
+  "https://spec.graphql.org/October2021/#sec-Names.Reserved-Names",
+  "https://graphql.org/learn/introspection/",
+]
+
+let _EVIDENCE_DESCRIPTIONS = [
+  "https://spec.graphql.org/October2021/#sec-Descriptions",
+  "https://the-guild.dev/graphql/eslint/rules/require-description",
+]
+
+let _EVIDENCE_MUTATION_INPUT = [
+  "https://www.apollographql.com/docs/technotes/TN0002-schema-naming-conventions/",
+  "https://relay.dev/docs/guides/graphql-server-specification/#mutations",
+]
+
+let _EVIDENCE_PAGINATION = [
+  "https://relay.dev/graphql/connections.htm",
+  "https://graphql.org/learn/pagination/",
+]
+
+let _EVIDENCE_BREAKING = [
+  "https://www.apollographql.com/docs/graphos/platform/schema-management/checks/",
+  "https://the-guild.dev/graphql/inspector/docs/essentials/diff",
+]
+
+let _EVIDENCE_DEPRECATION = [
+  "https://spec.graphql.org/October2021/#sec--deprecated",
+  "https://graphql.org/learn/best-practices/#versioning",
+]
+
+let _EVIDENCE_DEPTH_LIMIT = [
+  "https://cheatsheetseries.owasp.org/cheatsheets/GraphQL_Cheat_Sheet.html",
+  "https://www.apollographql.com/docs/router/configuration/operation-limits/",
+]
+
+fn schema_files(slice) {
+  return slice.files.filter(
+    { file -> file.path.ends_with(".graphql")
+      || file.path.ends_with(".graphqls")
+      || file.path.ends_with(".gql") },
+  )
+}
+
+fn is_generated_path(path) {
+  return contains(path, "/generated/")
+    || contains(path, "/__generated__/")
+    || contains(path, ".generated.")
+}
+
+fn production_schema_files(slice) {
+  return schema_files(slice).filter({ file -> !is_generated_path(file.path) })
+}
+
+fn server_config_files(slice) {
+  return slice.files.filter(
+    { file -> file.path.ends_with(".ts")
+      || file.path.ends_with(".tsx")
+      || file.path.ends_with(".js")
+      || file.path.ends_with(".mjs")
+      || file.path.ends_with(".py")
+      || file.path.ends_with(".rb")
+      || file.path.ends_with(".go")
+      || file.path.ends_with(".rs")
+      || file.path.ends_with(".kt")
+      || file.path.ends_with(".java") },
+  )
+}
+
+fn scan_files(files, pattern, flags) {
+  var findings = []
+  for file in files {
+    if regex_match(pattern, file.text, flags) != nil {
+      findings = findings.push({path: file.path, pattern: pattern})
+    }
+  }
+  return findings
+}
+
+fn scan_files_if(files, predicate) {
+  var findings = []
+  for file in files {
+    if predicate(file) {
+      findings = findings.push({path: file.path})
+    }
+  }
+  return findings
+}
+
+fn allow(rule) {
+  return {verdict: "Allow", rule: rule, findings: [], remediation: ""}
+}
+
+fn warn(rule, remediation, findings) {
+  return {verdict: "Warn", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block(rule, remediation, findings) {
+  return {verdict: "Block", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return block(rule, remediation, findings)
+}
+
+fn warn_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return warn(rule, remediation, findings)
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_NAMING, confidence: 0.84, source_date: "2026-05-09")
+/** Blocks GraphQL enum values that are not UPPER_SNAKE_CASE. */
+pub fn enum_values_upper_snake_case(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_schema_files(slice),
+    r"\benum\s+\w+\s*\{[^}]*?(?m:^\s*[a-z])",
+    "s",
+  )
+  return block_on_findings(
+    "enum_values_upper_snake_case",
+    "Rename enum values to UPPER_SNAKE_CASE per the Apollo and graphql-eslint convention.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_RESERVED_NAMES, confidence: 0.94, source_date: "2026-05-09")
+/** Blocks user-defined names that begin with a double underscore. */
+pub fn no_double_underscore_names(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_schema_files(slice),
+    r"^\s*(?:type|interface|enum|input|union|scalar|directive)\s+__\w+|^\s*__\w+\s*[:(]",
+    "m",
+  )
+  return block_on_findings(
+    "no_double_underscore_names",
+    "Rename the type or field; the GraphQL spec reserves a leading double underscore for introspection.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_DESCRIPTIONS, confidence: 0.6, source_date: "2026-05-09")
+/** Warns when a schema file declares public types without any descriptions. */
+pub fn descriptions_on_public_types(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    production_schema_files(slice),
+    { file -> regex_match(
+      r"^\s*(?:type|interface|input|enum|union)\s+[A-Z]\w*",
+      file.text,
+      "m",
+    )
+      != nil
+      && regex_match(r"\"\"\"|^\s*\"[^\"]+\"", file.text, "m") == nil },
+  )
+  return warn_on_findings(
+    "descriptions_on_public_types",
+    "Add a description string above each public type and field so clients and tools can render documentation.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_MUTATION_INPUT, confidence: 0.7, source_date: "2026-05-09")
+/** Warns when Mutation fields take arguments other than a single input object. */
+pub fn mutation_uses_input_type(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_schema_files(slice),
+    r"\btype\s+Mutation\s*\{[^}]*?\b\w+\s*\(\s*(?!input\s*:)[^)]+\)",
+    "s",
+  )
+  return warn_on_findings(
+    "mutation_uses_input_type",
+    "Wrap mutation arguments in a single input object so the field can evolve without breaking callers.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_PAGINATION, confidence: 0.66, source_date: "2026-05-09")
+/** Warns when root Query list-returning fields expose no pagination arguments. */
+pub fn pagination_args_on_root_list_fields(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_schema_files(slice),
+    r"\btype\s+Query\s*\{[^}]*?(?m:^\s*\w+\s*(?::\s*\[|\(\s*\)\s*:\s*\[))",
+    "s",
+  )
+  return warn_on_findings(
+    "pagination_args_on_root_list_fields",
+    "Expose pagination arguments such as first/after or limit/offset on root Query list fields to bound result size.",
+    findings,
+  )
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_BREAKING, confidence: 0.7, source_date: "2026-05-09")
+/** Blocks schema changes that break existing clients without an aliasing or migration path. */
+pub fn no_breaking_schema_change(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed GraphQL schema files remove a public type, field, enum value, union member, interface implementation, or directive; rename one in place; narrow a return type; widen an input type; mark a previously optional argument as non-null; or change an argument's type, and the change does not retain a backwards-compatible alias, default, or wrapper."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: production_schema_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "no_breaking_schema_change",
+      "Keep the prior surface area as a deprecated alias or stage the change behind a new field, then remove later.",
+      judgement.findings,
+    )
+  }
+  return allow("no_breaking_schema_change")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_DEPRECATION, confidence: 0.7, source_date: "2026-05-09")
+/** Blocks removal of public schema elements that were not first marked @deprecated. */
+pub fn deprecation_over_removal(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed GraphQL schema files delete a public field, enum value, type, union member, or argument that was not marked @deprecated with a reason in the same file before the deletion, and the slice does not show the @deprecated annotation being removed alongside the deletion as part of a documented sunset window."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: production_schema_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "deprecation_over_removal",
+      "Mark the element @deprecated with a reason and removal date first, then drop it after callers have migrated.",
+      judgement.findings,
+    )
+  }
+  return allow("deprecation_over_removal")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_DEPTH_LIMIT, confidence: 0.6, source_date: "2026-05-09")
+/** Blocks new public GraphQL endpoints that lack a query depth or complexity limit. */
+pub fn query_depth_limit_enforced(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed code wires up a public GraphQL HTTP endpoint or router using Apollo Server, Apollo Router, GraphQL Yoga, Mercurius, Strawberry, Ariadne, gqlgen, graphql-ruby, or a similar server, and the changed configuration does not set a max query depth, max query complexity, max alias count, max token count, or persisted-query allowlist."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: server_config_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "query_depth_limit_enforced",
+      "Configure a query depth, complexity, or persisted-operation limit on the GraphQL server to bound execution cost.",
+      judgement.findings,
+    )
+  }
+  return allow("query_depth_limit_enforced")
+}


### PR DESCRIPTION
## Summary

- Adds a GraphQL v0 seed predicate pack with 5 deterministic predicates (enum casing, reserved-name guard, descriptions, mutation input objects, root list pagination) and 3 semantic predicates (breaking-change guard, deprecation-before-removal, query-depth limit).
- Documents stack assumptions, evidence sources, and known false positives in `graphql/README.md`; lists the pack in the repo README.
- Adds allow/block (or allow/warn) fixtures for every predicate.

Closes #26.

## Verification

- `find graphql/fixtures -name '*.json' -print0 | xargs -0 -n1 jq empty`
- Local Python regex replay against every deterministic fixture (5 predicates × 2 cases = 10/10 pass).
- HEAD-check on every URL in `graphql/invariants.harn` (15/15 returned HTTP 200).
- Verified `spec.graphql.org/October2021` anchors `sec-Names.Reserved-Names`, `sec-Descriptions`, and `sec--deprecated` resolve.

## Notes

- Semantic predicates rely on `ctx.semantic_judge(...)` and currently judge from the changed slice only; a richer paired base-and-head schema view will tighten `no_breaking_schema_change` once Flow exposes it.
- Generated paths (`/generated/`, `/__generated__/`, `*.generated.*`) are excluded from schema scans to keep `graphql-codegen` output out of the verdict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)