### PR TITLE
Add Dockerfile seed predicate pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ See the Harn Flow design docs for the full predicate language spec.
 
 - [C#](./csharp/) — v0 draft predicates for plain C# and .NET library or application code.
 - [CSS](./css/) — v0 draft predicates for CSS, Sass, and Less stylesheets covering cascade hygiene, internationalization, and accessibility.
+- [Dockerfile](./dockerfile/) — v0 draft predicates for `Dockerfile` and `Containerfile` build recipes.
 - [Go](./go/) — v0 draft predicates for Go modules, command packages, and reusable libraries.
 - [Harn](./harn/) — v0 draft predicates for `.harn` scripts, Flow workflows, and agent-facing Harn modules.
 - [Java](./java/) — v0 draft predicates for plain Java application and library code.

--- a/dockerfile/README.md
+++ b/dockerfile/README.md
@@ -1,0 +1,63 @@
+# Dockerfile Seed Predicate Pack
+
+This pack covers `Dockerfile` and `Containerfile` build recipes. It targets high-signal review issues that changed Dockerfile slices can catch cheaply: floating base-image tags, noisy or leaky `apt-get` invocations, `ADD` misuse, supply-chain-unsafe `curl | sh` installs, missing non-root user, secret-shaped values baked into image layers, shell-form `CMD`/`ENTRYPOINT`, single-stage builds that ship build toolchains, and unnecessary layer fragmentation.
+
+## Stack Assumptions
+
+- Build recipes are named `Dockerfile`, `Dockerfile.<variant>`, `<name>.Dockerfile`, or `Containerfile` (Podman/Buildah convention).
+- Dockerfiles are linted as build-system source, so every changed file flows through this pack regardless of subdirectory.
+- Deterministic predicates use file-text scans until Harn Flow exposes a stable Dockerfile parser; Hadolint-style AST queries can replace the regex layer later without changing predicate semantics.
+- Semantic predicates make one cheap judge call over changed Dockerfiles and use only evidence captured at authoring time.
+- Advisory rules return `Warn` when idiomatic exceptions are common (slim base images that already drop privileges, `apt-get`-free distros, single-stage debug images). Blocking rules are reserved for floating base-image tags, `curl | sh` installs, and secrets baked into `ENV`/`ARG`.
+
+## Predicate Coverage
+
+| Predicate | Mode | Verdict | Purpose |
+|---|---|---|---|
+| `no_latest_or_unpinned_base_image` | deterministic | Block | `FROM` must pin a tag (preferably a digest); bare images and `:latest` make rebuilds non-reproducible. |
+| `apt_get_no_install_recommends` | deterministic | Warn | `apt-get install` should pass `--no-install-recommends` to avoid pulling optional dependencies into the image. |
+| `apt_get_clean_lists` | deterministic | Warn | The same `RUN` that installs packages should `rm -rf /var/lib/apt/lists/*` so caches do not bloat the layer. |
+| `prefer_copy_over_add` | deterministic | Warn | Local file copies should use `COPY`; `ADD` is reserved for remote URLs and auto-extracted archives. |
+| `no_curl_pipe_shell` | deterministic | Block | Piping `curl`/`wget` directly into a shell skips checksum and signature verification. |
+| `non_root_user_set` | deterministic | Warn | Containers should drop to a non-root account via an explicit `USER` directive. |
+| `no_secrets_in_env_or_arg` | deterministic | Block | Credentials, tokens, and private keys must not be baked into image layers via `ENV` or `ARG` defaults. |
+| `use_exec_form_for_cmd_entrypoint` | deterministic | Warn | `CMD` and `ENTRYPOINT` should use the JSON exec form so the process receives signals directly. |
+| `multi_stage_build_preferred` | semantic | Block | Single-stage builds that ship compilers, package managers, or dev dependencies should split into build and runtime stages. |
+| `minimize_layer_count` | semantic | Warn | Consecutive related `RUN` steps that leak intermediate artifacts across layers should be merged. |
+
+## Evidence
+
+Evidence scanned on 2026-05-09.
+
+- Docker Build best practices: `FROM` pinning, `apt-get` patterns, `ADD` vs `COPY`, `USER`, `RUN` layering, multi-stage builds, layer minimization.
+- Docker Reference: directives `FROM`, `ADD`, `COPY`, `USER`, `ARG`, `CMD`, `ENTRYPOINT`.
+- Docker Build secrets: BuildKit `--mount=type=secret` for build-time credentials.
+- OWASP Docker Security Cheat Sheet and Code Injection guidance for `curl | sh` and non-root recommendations.
+- OWASP Secrets Management Cheat Sheet for hardcoded credential risk.
+- Debian `apt-get` manpage for `--no-install-recommends` semantics.
+
+## Known False Positives
+
+- Regex predicates do not parse Dockerfiles. Inline comments, `\` line continuations across many lines, heredocs, and multi-stage `FROM ... AS build` aliases can confuse deterministic checks.
+- `no_latest_or_unpinned_base_image` allows digest pins (`@sha256:...`) and any explicit non-`latest` tag, and exempts `FROM scratch`. It does not catch `FROM --platform=$BUILDPLATFORM image` (no tag) because the leading `--platform` flag suppresses the unpinned match. Pin freshness still belongs in dependency management.
+- `apt_get_no_install_recommends` requires the `--no-install-recommends` flag on the same physical line as `apt-get install`; multi-line `RUN` blocks that put the flag on a continuation line will warn until a Dockerfile parser lands.
+- `apt_get_no_install_recommends` and `apt_get_clean_lists` are file-scoped and Debian/Ubuntu-specific. Alpine (`apk`), Red Hat (`dnf`/`microdnf`), and distroless images are not flagged; future packs should add per-distro predicates.
+- `prefer_copy_over_add` warns on every local-path `ADD`, including the legitimate "auto-extract local tarball" case. It does not warn on `ADD --chown=...` style flag forms because the leading `--` suppresses the match. Treat the warning as a prompt to confirm extraction is intended.
+- `non_root_user_set` cannot read base-image metadata, so it warns even when the base image (e.g., `node:*-alpine`, `nginxinc/nginx-unprivileged`) already sets a non-root `USER`. Multi-stage builds whose final stage drops privileges in a later `USER` directive are correctly allowed because the file as a whole contains a non-root `USER`. A repo-level allow can suppress this once the predicate runtime supports suppressions.
+- `no_secrets_in_env_or_arg` is keyword-based. `ARG` declarations without a default value (e.g., `ARG NPM_TOKEN`) and `ENV` values that reference shell or BuildKit substitutions (e.g., `ENV PASSWORD=$BUILD_PASSWORD`) are intentionally allowed because they expect runtime injection.
+- `use_exec_form_for_cmd_entrypoint` warns on the shell form across the file, including stages where shell expansion is genuinely required. Prefer wrapping the command in an explicit `bash -lc` exec-form invocation.
+- Semantic predicates depend on the judge recognizing concrete changed spans. They should stay high-threshold and cite the specific stage and instructions before blocking or warning.
+
+## Fixtures
+
+Each fixture in `fixtures/` contains one blocked or warned example and one allowed example for the corresponding predicate. The fixture shape matches the current harn-canon convention:
+
+```json
+{
+  "predicate": "name",
+  "cases": [
+    {"expect": "Block", "files": [{"path": "Dockerfile", "text": "..."}]},
+    {"expect": "Allow", "files": [{"path": "Dockerfile", "text": "..."}]}
+  ]
+}
+```

--- a/dockerfile/fixtures/apt_get_clean_lists.json
+++ b/dockerfile/fixtures/apt_get_clean_lists.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "apt_get_clean_lists",
+  "cases": [
+    {
+      "name": "warns_when_apt_lists_left_behind",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "Dockerfile",
+          "text": "FROM debian:12.7-slim\nRUN apt-get update \\\n  && apt-get install -y --no-install-recommends curl ca-certificates\nUSER 1000\nCMD [\"/usr/bin/curl\", \"--version\"]\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_when_apt_lists_cleaned",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "Dockerfile",
+          "text": "FROM debian:12.7-slim\nRUN apt-get update \\\n  && apt-get install -y --no-install-recommends curl ca-certificates \\\n  && rm -rf /var/lib/apt/lists/*\nUSER 1000\nCMD [\"/usr/bin/curl\", \"--version\"]\n"
+        }
+      ]
+    }
+  ]
+}

--- a/dockerfile/fixtures/apt_get_no_install_recommends.json
+++ b/dockerfile/fixtures/apt_get_no_install_recommends.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "apt_get_no_install_recommends",
+  "cases": [
+    {
+      "name": "warns_when_recommends_flag_missing",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "Dockerfile",
+          "text": "FROM debian:12.7-slim\nRUN apt-get update \\\n  && apt-get install -y curl ca-certificates \\\n  && rm -rf /var/lib/apt/lists/*\nUSER 1000\nCMD [\"/usr/bin/curl\", \"--version\"]\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_when_no_install_recommends_present",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "Dockerfile",
+          "text": "FROM debian:12.7-slim\nRUN apt-get update \\\n  && apt-get install -y --no-install-recommends curl ca-certificates \\\n  && rm -rf /var/lib/apt/lists/*\nUSER 1000\nCMD [\"/usr/bin/curl\", \"--version\"]\n"
+        }
+      ]
+    }
+  ]
+}

--- a/dockerfile/fixtures/minimize_layer_count.json
+++ b/dockerfile/fixtures/minimize_layer_count.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "minimize_layer_count",
+  "cases": [
+    {
+      "name": "warns_when_install_and_cleanup_split_across_layers",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "Dockerfile",
+          "text": "FROM debian:12.7-slim\nRUN apt-get update\nRUN apt-get install -y --no-install-recommends curl ca-certificates\nRUN apt-get clean\nRUN rm -rf /var/lib/apt/lists/*\nUSER 1000\nCMD [\"/usr/bin/curl\", \"--version\"]\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_combined_install_and_cleanup",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "Dockerfile",
+          "text": "FROM debian:12.7-slim\nRUN apt-get update \\\n  && apt-get install -y --no-install-recommends curl ca-certificates \\\n  && apt-get clean \\\n  && rm -rf /var/lib/apt/lists/*\nUSER 1000\nCMD [\"/usr/bin/curl\", \"--version\"]\n"
+        }
+      ]
+    }
+  ]
+}

--- a/dockerfile/fixtures/multi_stage_build_preferred.json
+++ b/dockerfile/fixtures/multi_stage_build_preferred.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "multi_stage_build_preferred",
+  "cases": [
+    {
+      "name": "blocks_single_stage_with_build_toolchain",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "Dockerfile",
+          "text": "FROM golang:1.23.2\nWORKDIR /src\nCOPY . .\nRUN go build -o /usr/local/bin/server ./cmd/server\nUSER 1001\nCMD [\"/usr/local/bin/server\"]\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_multi_stage_build",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "Dockerfile",
+          "text": "FROM golang:1.23.2 AS build\nWORKDIR /src\nCOPY . .\nRUN go build -o /out/server ./cmd/server\n\nFROM gcr.io/distroless/static-debian12:nonroot\nCOPY --from=build /out/server /usr/local/bin/server\nUSER nonroot\nCMD [\"/usr/local/bin/server\"]\n"
+        }
+      ]
+    }
+  ]
+}

--- a/dockerfile/fixtures/no_curl_pipe_shell.json
+++ b/dockerfile/fixtures/no_curl_pipe_shell.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "no_curl_pipe_shell",
+  "cases": [
+    {
+      "name": "blocks_curl_piped_to_bash",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "Dockerfile",
+          "text": "FROM debian:12.7-slim\nRUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates && rm -rf /var/lib/apt/lists/*\nRUN curl -fsSL https://example.com/install.sh | bash\nUSER 1000\nCMD [\"/usr/local/bin/example\"]\n"
+        }
+      ]
+    },
+    {
+      "name": "blocks_wget_piped_to_sh",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "Dockerfile",
+          "text": "FROM debian:12.7-slim\nRUN apt-get update && apt-get install -y --no-install-recommends wget ca-certificates && rm -rf /var/lib/apt/lists/*\nRUN wget -qO- https://example.com/install.sh | sh\nUSER 1000\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_download_then_verify_then_run",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "Dockerfile",
+          "text": "FROM debian:12.7-slim\nRUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates && rm -rf /var/lib/apt/lists/*\nRUN curl -fsSLo /tmp/install.sh https://example.com/install.sh \\\n  && echo \"a1b2c3 /tmp/install.sh\" | sha256sum -c - \\\n  && bash /tmp/install.sh \\\n  && rm /tmp/install.sh\nUSER 1000\n"
+        }
+      ]
+    }
+  ]
+}

--- a/dockerfile/fixtures/no_latest_or_unpinned_base_image.json
+++ b/dockerfile/fixtures/no_latest_or_unpinned_base_image.json
@@ -1,0 +1,45 @@
+{
+  "predicate": "no_latest_or_unpinned_base_image",
+  "cases": [
+    {
+      "name": "blocks_latest_tag",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "Dockerfile",
+          "text": "FROM node:latest\nWORKDIR /app\nCOPY . .\nRUN npm ci\nCMD [\"node\", \"server.js\"]\n"
+        }
+      ]
+    },
+    {
+      "name": "blocks_missing_tag",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "Dockerfile",
+          "text": "FROM node\nWORKDIR /app\nCOPY . .\nRUN npm ci\nCMD [\"node\", \"server.js\"]\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_pinned_tag",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "Dockerfile",
+          "text": "FROM node:22.11.0-alpine\nWORKDIR /app\nCOPY . .\nRUN npm ci\nCMD [\"node\", \"server.js\"]\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_digest_pin",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "Dockerfile",
+          "text": "FROM node@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\nWORKDIR /app\nCOPY . .\nCMD [\"node\", \"server.js\"]\n"
+        }
+      ]
+    }
+  ]
+}

--- a/dockerfile/fixtures/no_secrets_in_env_or_arg.json
+++ b/dockerfile/fixtures/no_secrets_in_env_or_arg.json
@@ -1,0 +1,45 @@
+{
+  "predicate": "no_secrets_in_env_or_arg",
+  "cases": [
+    {
+      "name": "blocks_env_with_baked_password",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "Dockerfile",
+          "text": "FROM postgres:16.4\nENV POSTGRES_PASSWORD=hunter2\nUSER 999\nEXPOSE 5432\n"
+        }
+      ]
+    },
+    {
+      "name": "blocks_arg_with_default_api_key",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "Dockerfile",
+          "text": "FROM node:22.11.0-alpine\nARG NPM_TOKEN=npm_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nWORKDIR /app\nCOPY package*.json ./\nRUN npm ci\nUSER node\nCMD [\"node\", \"server.js\"]\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_arg_without_default",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "Dockerfile",
+          "text": "FROM node:22.11.0-alpine\nARG NPM_TOKEN\nWORKDIR /app\nCOPY package*.json ./\nRUN --mount=type=secret,id=npm_token \\\n  NPM_TOKEN=\"$(cat /run/secrets/npm_token)\" npm ci\nUSER node\nCMD [\"node\", \"server.js\"]\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_env_referencing_runtime_value",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "Dockerfile",
+          "text": "FROM node:22.11.0-alpine\nENV PORT=3000\nWORKDIR /app\nCOPY . .\nUSER node\nCMD [\"node\", \"server.js\"]\n"
+        }
+      ]
+    }
+  ]
+}

--- a/dockerfile/fixtures/non_root_user_set.json
+++ b/dockerfile/fixtures/non_root_user_set.json
@@ -1,0 +1,45 @@
+{
+  "predicate": "non_root_user_set",
+  "cases": [
+    {
+      "name": "warns_when_no_user_directive",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "Dockerfile",
+          "text": "FROM python:3.12.7-slim\nWORKDIR /app\nCOPY . .\nRUN pip install --no-cache-dir -r requirements.txt\nCMD [\"python\", \"-m\", \"app\"]\n"
+        }
+      ]
+    },
+    {
+      "name": "warns_when_user_is_root",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "Dockerfile",
+          "text": "FROM python:3.12.7-slim\nWORKDIR /app\nCOPY . .\nRUN pip install --no-cache-dir -r requirements.txt\nUSER root\nCMD [\"python\", \"-m\", \"app\"]\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_named_non_root_user",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "Dockerfile",
+          "text": "FROM python:3.12.7-slim\nRUN useradd --system --uid 1001 --create-home appuser\nWORKDIR /app\nCOPY --chown=appuser:appuser . .\nRUN pip install --no-cache-dir -r requirements.txt\nUSER appuser\nCMD [\"python\", \"-m\", \"app\"]\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_numeric_non_root_user",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "Dockerfile",
+          "text": "FROM python:3.12.7-slim\nWORKDIR /app\nCOPY . .\nRUN pip install --no-cache-dir -r requirements.txt\nUSER 1001\nCMD [\"python\", \"-m\", \"app\"]\n"
+        }
+      ]
+    }
+  ]
+}

--- a/dockerfile/fixtures/prefer_copy_over_add.json
+++ b/dockerfile/fixtures/prefer_copy_over_add.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "prefer_copy_over_add",
+  "cases": [
+    {
+      "name": "warns_on_local_path_add",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "Dockerfile",
+          "text": "FROM python:3.12.7-slim\nWORKDIR /app\nADD requirements.txt /app/requirements.txt\nRUN pip install --no-cache-dir -r requirements.txt\nUSER 1000\nCMD [\"python\", \"-m\", \"app\"]\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_copy_for_local_paths",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "Dockerfile",
+          "text": "FROM python:3.12.7-slim\nWORKDIR /app\nCOPY requirements.txt /app/requirements.txt\nRUN pip install --no-cache-dir -r requirements.txt\nUSER 1000\nCMD [\"python\", \"-m\", \"app\"]\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_add_for_remote_url",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "Dockerfile",
+          "text": "FROM debian:12.7-slim\nADD https://example.com/installer.sh /tmp/installer.sh\nRUN sha256sum -c /tmp/installer.sha256 && bash /tmp/installer.sh\nUSER 1000\n"
+        }
+      ]
+    }
+  ]
+}

--- a/dockerfile/fixtures/use_exec_form_for_cmd_entrypoint.json
+++ b/dockerfile/fixtures/use_exec_form_for_cmd_entrypoint.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "use_exec_form_for_cmd_entrypoint",
+  "cases": [
+    {
+      "name": "warns_on_shell_form_cmd",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "Dockerfile",
+          "text": "FROM node:22.11.0-alpine\nWORKDIR /app\nCOPY . .\nUSER node\nCMD node server.js --port 3000\n"
+        }
+      ]
+    },
+    {
+      "name": "warns_on_shell_form_entrypoint",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "Dockerfile",
+          "text": "FROM nginx:1.27.2-alpine\nUSER nginx\nENTRYPOINT /docker-entrypoint.sh\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_exec_form_cmd_and_entrypoint",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "Dockerfile",
+          "text": "FROM node:22.11.0-alpine\nWORKDIR /app\nCOPY . .\nUSER node\nENTRYPOINT [\"node\"]\nCMD [\"server.js\", \"--port\", \"3000\"]\n"
+        }
+      ]
+    }
+  ]
+}

--- a/dockerfile/invariants.harn
+++ b/dockerfile/invariants.harn
@@ -1,0 +1,272 @@
+let _EVIDENCE_FROM_TAG = [
+  "https://docs.docker.com/build/building/best-practices/#pin-base-image-versions",
+  "https://docs.docker.com/reference/dockerfile/#from",
+]
+
+let _EVIDENCE_APT_RECOMMENDS = [
+  "https://docs.docker.com/build/building/best-practices/#apt-get",
+  "https://manpages.debian.org/bookworm/apt/apt-get.8.en.html",
+]
+
+let _EVIDENCE_APT_CLEAN = [
+  "https://docs.docker.com/build/building/best-practices/#apt-get",
+  "https://docs.docker.com/build/cache/#minimize-the-number-of-layers",
+]
+
+let _EVIDENCE_ADD_VS_COPY = [
+  "https://docs.docker.com/build/building/best-practices/#add-or-copy",
+  "https://docs.docker.com/reference/dockerfile/#add",
+  "https://docs.docker.com/reference/dockerfile/#copy",
+]
+
+let _EVIDENCE_CURL_PIPE_SHELL = [
+  "https://owasp.org/www-community/attacks/Code_Injection",
+  "https://docs.docker.com/build/building/best-practices/#run",
+  "https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html",
+]
+
+let _EVIDENCE_NON_ROOT = [
+  "https://docs.docker.com/reference/dockerfile/#user",
+  "https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html",
+]
+
+let _EVIDENCE_BUILD_SECRETS = [
+  "https://docs.docker.com/build/building/secrets/",
+  "https://docs.docker.com/reference/dockerfile/#arg",
+  "https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html",
+]
+
+let _EVIDENCE_EXEC_FORM = [
+  "https://docs.docker.com/reference/dockerfile/#cmd",
+  "https://docs.docker.com/reference/dockerfile/#entrypoint",
+]
+
+let _EVIDENCE_MULTI_STAGE = [
+  "https://docs.docker.com/build/building/multi-stage/",
+  "https://docs.docker.com/build/building/best-practices/#use-multi-stage-builds",
+]
+
+let _EVIDENCE_MINIMIZE_LAYERS = [
+  "https://docs.docker.com/build/cache/#minimize-the-number-of-layers",
+  "https://docs.docker.com/build/building/best-practices/#sort-multi-line-arguments",
+]
+
+fn is_dockerfile_path(path) {
+  return regex_match(r"(?i)(^|/)(Dockerfile|Containerfile)(\.[A-Za-z0-9._-]+)?$", path, "s") != nil
+    || regex_match(r"(?i)\.dockerfile$", path, "s") != nil
+}
+
+fn dockerfile_files(slice) {
+  return slice.files.filter({ file -> is_dockerfile_path(file.path) })
+}
+
+fn scan_files(files, pattern) {
+  var findings = []
+  for file in files {
+    if regex_match(pattern, file.text, "m") != nil {
+      findings = findings.push({path: file.path, pattern: pattern})
+    }
+  }
+  return findings
+}
+
+fn scan_files_if(files, predicate) {
+  var findings = []
+  for file in files {
+    if predicate(file.text) {
+      findings = findings.push({path: file.path})
+    }
+  }
+  return findings
+}
+
+fn allow(rule) {
+  return {verdict: "Allow", rule: rule, findings: [], remediation: ""}
+}
+
+fn warn(rule, remediation, findings) {
+  return {verdict: "Warn", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block(rule, remediation, findings) {
+  return {verdict: "Block", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return block(rule, remediation, findings)
+}
+
+fn warn_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return warn(rule, remediation, findings)
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_FROM_TAG, confidence: 0.88, source_date: "2026-05-09")
+/** Blocks FROM directives that float on :latest or omit a tag and digest. */
+pub fn no_latest_or_unpinned_base_image(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    dockerfile_files(slice),
+    { text -> regex_match(r"(?mi)^\s*FROM\s+[^\s#]+:latest(\s|$)", text, "m") != nil
+      || regex_match(r"(?mi)^\s*FROM\s+(?!--)(?!scratch\b)[^\s#:@]+(\s+AS\s+\S+)?\s*$", text, "m") != nil },
+  )
+  return block_on_findings(
+    "no_latest_or_unpinned_base_image",
+    "Pin every FROM to an explicit tag (preferably a digest) so rebuilds are reproducible.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_APT_RECOMMENDS, confidence: 0.74, source_date: "2026-05-09")
+/** Warns on apt-get install invocations that omit --no-install-recommends. */
+pub fn apt_get_no_install_recommends(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    dockerfile_files(slice),
+    { text -> regex_match(r"apt-get\s+install\b", text, "s") != nil
+      && regex_match(r"apt-get\s+install\b[^\n]*--no-install-recommends", text, "s") == nil },
+  )
+  return warn_on_findings(
+    "apt_get_no_install_recommends",
+    "Pass --no-install-recommends to apt-get install so images do not pull optional dependencies.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_APT_CLEAN, confidence: 0.78, source_date: "2026-05-09")
+/** Warns when apt-get install runs without removing /var/lib/apt/lists in the same layer. */
+pub fn apt_get_clean_lists(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    dockerfile_files(slice),
+    { text -> regex_match(r"apt-get\s+install\b", text, "s") != nil
+      && regex_match(r"rm\s+-rf\s+/var/lib/apt/lists", text, "s") == nil },
+  )
+  return warn_on_findings(
+    "apt_get_clean_lists",
+    "Remove /var/lib/apt/lists/* in the same RUN as apt-get install so the layer stays small.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_ADD_VS_COPY, confidence: 0.8, source_date: "2026-05-09")
+/** Warns on ADD with local paths; COPY is preferred unless extracting an archive or fetching a URL. */
+pub fn prefer_copy_over_add(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    dockerfile_files(slice),
+    r"(?mi)^\s*ADD\s+(?!--)(?!https?://)(?!git@)(?!git://)\S+",
+  )
+  return warn_on_findings(
+    "prefer_copy_over_add",
+    "Use COPY for local files; reserve ADD for remote URLs or auto-extracted archives so semantics stay predictable.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_CURL_PIPE_SHELL, confidence: 0.9, source_date: "2026-05-09")
+/** Blocks piping the output of curl or wget straight into a shell interpreter. */
+pub fn no_curl_pipe_shell(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    dockerfile_files(slice),
+    r"\b(curl|wget)\b[^\n|]*\|\s*(sudo\s+)?(sh|bash|zsh|ksh|dash|ash)\b",
+  )
+  return block_on_findings(
+    "no_curl_pipe_shell",
+    "Download to a file, verify a checksum or signature, then execute it instead of piping the network into a shell.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_NON_ROOT, confidence: 0.7, source_date: "2026-05-09")
+/** Warns when a Dockerfile never sets a non-root USER. */
+pub fn non_root_user_set(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    dockerfile_files(slice),
+    { text -> regex_match(r"(?mi)^\s*USER\s+(?!root\b)(?!0\b)\S+", text, "m") == nil },
+  )
+  return warn_on_findings(
+    "non_root_user_set",
+    "Add a USER directive that drops to a non-root account; rely on base-image defaults only when explicitly documented.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_BUILD_SECRETS, confidence: 0.85, source_date: "2026-05-09")
+/** Blocks secret-shaped values baked into ENV or ARG defaults at build time. */
+pub fn no_secrets_in_env_or_arg(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    dockerfile_files(slice),
+    r"(?mi)^\s*(ENV|ARG)\s+[A-Za-z0-9_]*(PASSWORD|PASSWD|SECRET|TOKEN|API[_-]?KEY|ACCESS[_-]?KEY|PRIVATE[_-]?KEY)[A-Za-z0-9_]*\s*[= ]\s*[^\s#$\n]\S*",
+  )
+  return block_on_findings(
+    "no_secrets_in_env_or_arg",
+    "Use BuildKit --mount=type=secret or a runtime secret manager instead of baking credentials into image layers.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_EXEC_FORM, confidence: 0.7, source_date: "2026-05-09")
+/** Warns when CMD or ENTRYPOINT use the shell form, which loses signal forwarding. */
+pub fn use_exec_form_for_cmd_entrypoint(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    dockerfile_files(slice),
+    r"(?mi)^\s*(CMD|ENTRYPOINT)\s+(?!\[)\S",
+  )
+  return warn_on_findings(
+    "use_exec_form_for_cmd_entrypoint",
+    "Prefer the JSON exec form like CMD [\"bin\", \"--flag\"] so the process receives signals directly.",
+    findings,
+  )
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_MULTI_STAGE, confidence: 0.66, source_date: "2026-05-09")
+/** Blocks single-stage Dockerfiles that ship build toolchains into the runtime image. */
+pub fn multi_stage_build_preferred(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when a changed Dockerfile builds an application from source using compilers, package managers, or development toolchains (gcc, make, cargo build, go build, npm install with dev dependencies, mvn package, pip wheel, dotnet build, webpack, etc.) and ships those build tools or intermediate artifacts in the final image instead of using a multi-stage build that copies only the runtime artifact into a smaller base. Allow Dockerfiles that already use multi-stage builds, that only install runtime dependencies, or that document why a single stage is required."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: dockerfile_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "multi_stage_build_preferred",
+      "Split the Dockerfile into a build stage and a runtime stage and COPY only the final artifact forward.",
+      judgement.findings,
+    )
+  }
+  return allow("multi_stage_build_preferred")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_MINIMIZE_LAYERS, confidence: 0.6, source_date: "2026-05-09")
+/** Warns when consecutive RUN steps could be merged to shrink the image and cache surface. */
+pub fn minimize_layer_count(slice, ctx, _repo_at_base) {
+  let rubric = "Warn only when a changed Dockerfile contains three or more consecutive RUN instructions that perform clearly related package installation, download, extract, or cleanup work, and the cleanup of one step undoes state created by an earlier step in a different layer. Allow Dockerfiles whose RUN steps stay separated for caching, readability, or because the steps are genuinely independent."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: dockerfile_files(slice)})
+  if judgement.verdict == "Block" {
+    return warn(
+      "minimize_layer_count",
+      "Combine related package install, download, and cleanup steps into a single RUN with && so artifacts do not leak across layers.",
+      judgement.findings,
+    )
+  }
+  return allow("minimize_layer_count")
+}


### PR DESCRIPTION
## Summary

Closes #28. Ships v0 invariants for `Dockerfile` and `Containerfile` build recipes:

- 8 deterministic predicates: floating `:latest` / unpinned `FROM`, missing `--no-install-recommends`, leftover `apt` lists, `ADD` for local paths, `curl | sh` installs, missing non-root `USER`, secret-shaped `ENV`/`ARG` defaults, shell-form `CMD`/`ENTRYPOINT`.
- 2 semantic predicates: multi-stage build preference (block when build toolchains ship into runtime), layer minimization (warn when consecutive related `RUN`s leak intermediate state).

Each predicate carries `@archivist` evidence (≥2 sources, ≤18 months old, scanned 2026-05-09) and one fixture JSON with both blocked/warned and allowed cases. README documents stack assumptions, evidence sources, and known false positives (e.g., `FROM scratch` exemption, `ARG NAME` without default).

## Test plan

- [x] All 25 deterministic fixture cases simulated against the predicate regexes (Python re; semantics match the Harn `regex_match` lookahead-supported flavor used by the C#, Kotlin, and Python packs).
- [x] Edge cases verified: `FROM scratch` allowed, `FROM scratchx` blocked, `ENV PORT=3000` allowed, `ENV API_KEY=abc` blocked, `ARG NPM_TOKEN` (no default) allowed, `ENV PASSWORD=$VAR` substitution allowed.
- [ ] Real fixture replay will run once the Harn Flow runtime ships (CI placeholder will pick this up automatically).