### PR TITLE
Add HTML seed predicate pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ See the Harn Flow design docs for the full predicate language spec.
 - [C#](./csharp/) — v0 draft predicates for plain C# and .NET library or application code.
 - [Go](./go/) — v0 draft predicates for Go modules, command packages, and reusable libraries.
 - [Harn](./harn/) — v0 draft predicates for `.harn` scripts, Flow workflows, and agent-facing Harn modules.
+- [HTML](./html/) — v0 draft predicates for plain HTML markup, accessibility, and safe new-window navigation.
 - [Java](./java/) — v0 draft predicates for plain Java application and library code.
 - [JavaScript](./javascript/) — v0 draft predicates for plain JavaScript source, async handling, dynamic-code hazards, and untrusted data boundaries.
 - [Kotlin](./kotlin/) — v0 draft predicates for Kotlin JVM, Android, and Multiplatform source.

--- a/html/README.md
+++ b/html/README.md
@@ -1,0 +1,58 @@
+# HTML Seed Predicate Pack
+
+This pack covers plain HTML markup before framework-specific packs (React, Vue, Astro, server-side templating engines) layer tighter rules on top. It targets high-signal accessibility and security defaults that survive direct inspection of changed HTML files: image alternative text, document language, inline event handlers, inline styles, semantic landmarks, safe new-window anchors, accessible form controls, and accessible link purpose.
+
+## Stack Assumptions
+
+- Source checks target files ending in `.html` or `.htm`. Templating dialects with non-HTML syntax (`.hbs`, `.ejs`, `.liquid`, `.pug`, framework-specific single-file components) are out of scope until per-framework packs land.
+- Build, dependency, and report directories are excluded: `node_modules/`, `dist/`, `build/`, `out/`, `coverage/`, `vendor/`, `.next/`, `.nuxt/`, `.svelte-kit/`, `.cache/`, `target/`, and `test-results/`.
+- Predicates that require a full document (`documents_specify_lang`) only fire on files that contain a root `<html>` element, so HTML fragments and partials remain quiet.
+- Deterministic predicates are regex-driven scans of changed source text. They are intentionally tolerant of whitespace and case, but they do not parse HTML, so attribute order and quoting style matter.
+- Semantic predicates make one cheap judge call over changed HTML files and use only evidence captured at authoring time. They block only when the judge can cite a concrete changed span.
+
+## Predicate Coverage
+
+| Predicate | Mode | Verdict | Purpose |
+|---|---|---|---|
+| `images_have_alt_text` | deterministic | Block | Every `<img>` must carry an `alt` attribute (`alt=""` is acceptable for decorative images). |
+| `documents_specify_lang` | deterministic | Block | Full HTML documents must declare a primary language on `<html>`. |
+| `no_inline_event_handlers` | deterministic | Block | Inline `on*=` event-handler attributes must move to scripts so a strict CSP can apply. |
+| `no_inline_styles` | deterministic | Warn | Inline `style="…"` declarations should move to stylesheets or scoped classes. |
+| `prefer_semantic_landmarks` | deterministic | Warn | `<div>`s named after landmark roles should usually be `<nav>`, `<header>`, `<main>`, `<footer>`, `<aside>`, or `<article>`. |
+| `target_blank_uses_rel_noopener` | deterministic | Block | Anchors with `target="_blank"` must include `rel="noopener"` (or `rel="noreferrer"`) to prevent reverse-tabnabbing. |
+| `form_controls_have_accessible_names` | semantic | Block | Form controls require an accessible name from `<label>`, `aria-label`, `aria-labelledby`, or `title`. |
+| `link_purpose_is_clear` | semantic | Block | Generic placeholder anchor text must be replaced or contextualized so the destination is clear. |
+
+## Evidence
+
+Evidence scanned on 2026-05-09.
+
+- MDN Web Docs: `<img>` element, `<a>` element, `lang` global attribute, `style` global attribute, event handler attribute reference, `rel="noopener"`, and Content Security Policy.
+- WHATWG HTML Living Standard: sections module for the `<nav>`, `<header>`, `<main>`, `<footer>`, `<aside>`, and `<article>` semantics.
+- W3C WAI tutorials: image-alt decision tree and form-label patterns.
+- W3C WCAG 2.2 Understanding documents: Language of Page (3.1.1), Labels or Instructions (3.3.2), and Link Purpose (In Context) (2.4.4).
+- web.dev guides: strict CSP and external-anchors-use-rel-noopener.
+
+## Known False Positives
+
+- Regex predicates do not parse HTML. Comments, embedded `<script>` or `<style>` blocks, conditional comments, and unusually formatted multi-line tags can confuse deterministic checks.
+- `images_have_alt_text` ignores `<img>` tags that *contain* an `alt` attribute regardless of value. It does not detect placeholder alt text such as the file name; the semantic judge can still flag those when `link_purpose_is_clear` and follow-up accessibility predicates land.
+- `documents_specify_lang` only fires on files that include a `<html>` element, so server-rendered partials and component fragments are silent. It accepts `lang=` and `xml:lang=`, including templated values like `lang="{{ locale }}"`.
+- `no_inline_event_handlers` is keyword-shaped and ignores any attribute that does not begin with `on` followed by lowercase letters. SVG-specific or vendor-prefixed handlers may need an explicit allow once suppressions ship.
+- `prefer_semantic_landmarks` matches landmark-shaped tokens inside any class or id value, so a div with `class="my-nav-bar"` will warn even when it is not a navigation region. The verdict is intentionally `Warn` for this reason.
+- `target_blank_uses_rel_noopener` accepts any `rel` value containing `noopener` or `noreferrer`. It does not enforce explicit ordering, so `rel="external noopener"` is allowed.
+- The semantic predicates depend on the judge recognizing concrete changed spans. They should stay high-threshold and cite specific control or anchor changes before blocking.
+
+## Fixtures
+
+Each fixture in `fixtures/` contains one blocked or warned example and one allowed example for the corresponding predicate. The fixture shape matches the current harn-canon convention:
+
+```json
+{
+  "predicate": "name",
+  "cases": [
+    {"expect": "Block", "files": [{"path": "public/index.html", "text": "..."}]},
+    {"expect": "Allow", "files": [{"path": "public/index.html", "text": "..."}]}
+  ]
+}
+```

--- a/html/fixtures/documents_specify_lang.json
+++ b/html/fixtures/documents_specify_lang.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "documents_specify_lang",
+  "cases": [
+    {
+      "name": "blocks_html_without_lang",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "public/index.html",
+          "text": "<!DOCTYPE html>\n<html>\n<head><title>Home</title></head>\n<body><p>Hello.</p></body>\n</html>\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_html_with_lang",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "public/index.html",
+          "text": "<!DOCTYPE html>\n<html lang=\"en\">\n<head><title>Home</title></head>\n<body><p>Hello.</p></body>\n</html>\n"
+        }
+      ]
+    }
+  ]
+}

--- a/html/fixtures/form_controls_have_accessible_names.json
+++ b/html/fixtures/form_controls_have_accessible_names.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "form_controls_have_accessible_names",
+  "cases": [
+    {
+      "name": "blocks_input_without_label",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "public/signup.html",
+          "text": "<!DOCTYPE html>\n<html lang=\"en\">\n<body>\n  <form>\n    <input type=\"email\" name=\"email\" placeholder=\"you@example.com\">\n    <button type=\"submit\">Sign up</button>\n  </form>\n</body>\n</html>\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_input_with_label",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "public/signup.html",
+          "text": "<!DOCTYPE html>\n<html lang=\"en\">\n<body>\n  <form>\n    <label for=\"email\">Email address</label>\n    <input id=\"email\" type=\"email\" name=\"email\">\n    <button type=\"submit\">Sign up</button>\n  </form>\n</body>\n</html>\n"
+        }
+      ]
+    }
+  ]
+}

--- a/html/fixtures/images_have_alt_text.json
+++ b/html/fixtures/images_have_alt_text.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "images_have_alt_text",
+  "cases": [
+    {
+      "name": "blocks_img_without_alt",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "public/index.html",
+          "text": "<!DOCTYPE html>\n<html lang=\"en\">\n<body>\n  <img src=\"/logo.png\" width=\"120\">\n</body>\n</html>\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_img_with_alt",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "public/index.html",
+          "text": "<!DOCTYPE html>\n<html lang=\"en\">\n<body>\n  <img src=\"/logo.png\" alt=\"Acme logo\" width=\"120\">\n  <img src=\"/divider.png\" alt=\"\" role=\"presentation\">\n</body>\n</html>\n"
+        }
+      ]
+    }
+  ]
+}

--- a/html/fixtures/link_purpose_is_clear.json
+++ b/html/fixtures/link_purpose_is_clear.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "link_purpose_is_clear",
+  "cases": [
+    {
+      "name": "blocks_generic_click_here",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "public/docs.html",
+          "text": "<!DOCTYPE html>\n<html lang=\"en\">\n<body>\n  <p>For installation instructions, <a href=\"/install\">click here</a>.</p>\n</body>\n</html>\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_descriptive_link_text",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "public/docs.html",
+          "text": "<!DOCTYPE html>\n<html lang=\"en\">\n<body>\n  <p>Read the <a href=\"/install\">installation guide</a> to get started.</p>\n</body>\n</html>\n"
+        }
+      ]
+    }
+  ]
+}

--- a/html/fixtures/no_inline_event_handlers.json
+++ b/html/fixtures/no_inline_event_handlers.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_inline_event_handlers",
+  "cases": [
+    {
+      "name": "blocks_inline_onclick",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "public/checkout.html",
+          "text": "<!DOCTYPE html>\n<html lang=\"en\">\n<body>\n  <button onclick=\"submit()\">Pay</button>\n</body>\n</html>\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_handler_bound_in_script",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "public/checkout.html",
+          "text": "<!DOCTYPE html>\n<html lang=\"en\">\n<body>\n  <button id=\"pay\">Pay</button>\n  <script src=\"/checkout.js\" type=\"module\"></script>\n</body>\n</html>\n"
+        }
+      ]
+    }
+  ]
+}

--- a/html/fixtures/no_inline_styles.json
+++ b/html/fixtures/no_inline_styles.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_inline_styles",
+  "cases": [
+    {
+      "name": "warns_on_inline_style",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "public/index.html",
+          "text": "<!DOCTYPE html>\n<html lang=\"en\">\n<body>\n  <p style=\"color: red; font-weight: bold;\">Sale!</p>\n</body>\n</html>\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_class_styling",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "public/index.html",
+          "text": "<!DOCTYPE html>\n<html lang=\"en\">\n<head><link rel=\"stylesheet\" href=\"/site.css\"></head>\n<body>\n  <p class=\"sale-banner\">Sale!</p>\n</body>\n</html>\n"
+        }
+      ]
+    }
+  ]
+}

--- a/html/fixtures/prefer_semantic_landmarks.json
+++ b/html/fixtures/prefer_semantic_landmarks.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "prefer_semantic_landmarks",
+  "cases": [
+    {
+      "name": "warns_on_div_named_nav",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "public/index.html",
+          "text": "<!DOCTYPE html>\n<html lang=\"en\">\n<body>\n  <div class=\"nav\">\n    <a href=\"/\">Home</a>\n    <a href=\"/about\">About</a>\n  </div>\n</body>\n</html>\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_semantic_nav_element",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "public/index.html",
+          "text": "<!DOCTYPE html>\n<html lang=\"en\">\n<body>\n  <nav class=\"primary\">\n    <a href=\"/\">Home</a>\n    <a href=\"/about\">About</a>\n  </nav>\n</body>\n</html>\n"
+        }
+      ]
+    }
+  ]
+}

--- a/html/fixtures/target_blank_uses_rel_noopener.json
+++ b/html/fixtures/target_blank_uses_rel_noopener.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "target_blank_uses_rel_noopener",
+  "cases": [
+    {
+      "name": "blocks_target_blank_without_rel",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "public/index.html",
+          "text": "<!DOCTYPE html>\n<html lang=\"en\">\n<body>\n  <a href=\"https://example.com\" target=\"_blank\">Docs</a>\n</body>\n</html>\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_target_blank_with_noopener",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "public/index.html",
+          "text": "<!DOCTYPE html>\n<html lang=\"en\">\n<body>\n  <a href=\"https://example.com\" target=\"_blank\" rel=\"noopener\">Docs</a>\n  <a href=\"https://example.org\" target=\"_blank\" rel=\"external noreferrer\">Mirror</a>\n</body>\n</html>\n"
+        }
+      ]
+    }
+  ]
+}

--- a/html/invariants.harn
+++ b/html/invariants.harn
@@ -1,0 +1,241 @@
+let _EVIDENCE_IMG_ALT = [
+  "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/img",
+  "https://www.w3.org/WAI/tutorials/images/decision-tree/",
+]
+
+let _EVIDENCE_HTML_LANG = [
+  "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/lang",
+  "https://www.w3.org/WAI/WCAG22/Understanding/language-of-page.html",
+]
+
+let _EVIDENCE_INLINE_HANDLERS = [
+  "https://developer.mozilla.org/en-US/docs/Web/Events/Event_handlers",
+  "https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP",
+  "https://web.dev/articles/strict-csp",
+]
+
+let _EVIDENCE_INLINE_STYLES = [
+  "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/style",
+  "https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP",
+]
+
+let _EVIDENCE_SEMANTIC = [
+  "https://html.spec.whatwg.org/multipage/sections.html",
+  "https://developer.mozilla.org/en-US/docs/Glossary/Semantics",
+]
+
+let _EVIDENCE_TARGET_BLANK = [
+  "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel/noopener",
+  "https://web.dev/articles/external-anchors-use-rel-noopener",
+]
+
+let _EVIDENCE_FORM_LABELS = [
+  "https://www.w3.org/WAI/tutorials/forms/labels/",
+  "https://www.w3.org/WAI/WCAG22/Understanding/labels-or-instructions.html",
+]
+
+let _EVIDENCE_LINK_PURPOSE = [
+  "https://www.w3.org/WAI/WCAG22/Understanding/link-purpose-in-context.html",
+  "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a",
+]
+
+fn is_html_path(path) {
+  return path.ends_with(".html") || path.ends_with(".htm")
+}
+
+fn is_excluded_path(path) {
+  return contains(path, "node_modules/")
+    || path.starts_with("dist/") || contains(path, "/dist/")
+    || path.starts_with("build/") || contains(path, "/build/")
+    || path.starts_with("out/") || contains(path, "/out/")
+    || path.starts_with("coverage/") || contains(path, "/coverage/")
+    || path.starts_with("vendor/") || contains(path, "/vendor/")
+    || path.starts_with(".next/") || contains(path, "/.next/")
+    || path.starts_with(".nuxt/") || contains(path, "/.nuxt/")
+    || path.starts_with(".svelte-kit/") || contains(path, "/.svelte-kit/")
+    || path.starts_with(".cache/") || contains(path, "/.cache/")
+    || path.starts_with("target/") || contains(path, "/target/")
+    || path.starts_with("test-results/") || contains(path, "/test-results/")
+}
+
+fn html_files(slice) {
+  return slice.files.filter({ file -> is_html_path(file.path) && !is_excluded_path(file.path) })
+}
+
+fn scan_files(files, pattern, flags) {
+  var findings = []
+  for file in files {
+    if regex_match(pattern, file.text, flags) != nil {
+      findings = findings.push({path: file.path, pattern: pattern})
+    }
+  }
+  return findings
+}
+
+fn scan_files_if(files, predicate) {
+  var findings = []
+  for file in files {
+    if predicate(file) {
+      findings = findings.push({path: file.path})
+    }
+  }
+  return findings
+}
+
+fn allow(rule) {
+  return {verdict: "Allow", rule: rule, findings: [], remediation: ""}
+}
+
+fn warn(rule, remediation, findings) {
+  return {verdict: "Warn", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block(rule, remediation, findings) {
+  return {verdict: "Block", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return block(rule, remediation, findings)
+}
+
+fn warn_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return warn(rule, remediation, findings)
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_IMG_ALT, confidence: 0.86, source_date: "2026-05-09")
+/** Blocks <img> elements that omit an alt attribute. */
+pub fn images_have_alt_text(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(html_files(slice), r"(?i)<img\b(?![^>]*\balt\s*=)[^>]*>", "s")
+  return block_on_findings(
+    "images_have_alt_text",
+    "Add an alt attribute; use alt=\"\" for purely decorative images that contribute no information.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_HTML_LANG, confidence: 0.84, source_date: "2026-05-09")
+/** Blocks full HTML documents that omit a lang attribute on the root element. */
+pub fn documents_specify_lang(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    html_files(slice),
+    { file -> regex_match(r"(?i)<html\b", file.text, "s") != nil
+      && regex_match(r"(?i)<html\b[^>]*\b(?:xml:)?lang\s*=", file.text, "s") == nil },
+  )
+  return block_on_findings(
+    "documents_specify_lang",
+    "Add a primary language to the root element, e.g. <html lang=\"en\">.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_INLINE_HANDLERS, confidence: 0.82, source_date: "2026-05-09")
+/** Blocks inline event-handler attributes such as onclick, onload, or onerror. */
+pub fn no_inline_event_handlers(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    html_files(slice),
+    r"(?i)<[a-z][a-z0-9-]*\b[^>]*\son[a-z]+\s*=\s*[\"']",
+    "s",
+  )
+  return block_on_findings(
+    "no_inline_event_handlers",
+    "Bind handlers in JavaScript with addEventListener; inline handlers break under strict CSP.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_INLINE_STYLES, confidence: 0.7, source_date: "2026-05-09")
+/** Warns on style attributes set directly on elements in production HTML. */
+pub fn no_inline_styles(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    html_files(slice),
+    r"(?i)<[a-z][a-z0-9-]*\b[^>]*\sstyle\s*=\s*[\"']",
+    "s",
+  )
+  return warn_on_findings(
+    "no_inline_styles",
+    "Move declarations to a stylesheet or scoped class; inline styles defeat caching and strict CSP.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_SEMANTIC, confidence: 0.6, source_date: "2026-05-09")
+/** Warns when divs use class or id names that match HTML5 landmark elements. */
+pub fn prefer_semantic_landmarks(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    html_files(slice),
+    r"(?i)<div\b[^>]*\b(?:class|id)\s*=\s*[\"'][^\"']*\b(?:nav|navbar|navigation|header|main-?content|main|footer|sidebar|article|aside)\b[^\"']*[\"']",
+    "s",
+  )
+  return warn_on_findings(
+    "prefer_semantic_landmarks",
+    "Use <nav>, <header>, <main>, <footer>, <aside>, or <article> instead of a <div> with a landmark-shaped class or id.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_TARGET_BLANK, confidence: 0.84, source_date: "2026-05-09")
+/** Blocks <a target="_blank"> anchors that omit rel="noopener" or rel="noreferrer". */
+pub fn target_blank_uses_rel_noopener(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    html_files(slice),
+    r"(?i)<a\b(?![^>]*\brel\s*=\s*[\"'][^\"']*\b(?:noopener|noreferrer)\b)[^>]*\btarget\s*=\s*[\"']?_blank[\"']?",
+    "s",
+  )
+  return block_on_findings(
+    "target_blank_uses_rel_noopener",
+    "Add rel=\"noopener\" (or rel=\"noreferrer\") to anchors that open new windows; otherwise the new page can navigate the opener.",
+    findings,
+  )
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_FORM_LABELS, confidence: 0.66, source_date: "2026-05-09")
+/** Blocks form controls that lack an accessible name from a label, aria-label, or aria-labelledby. */
+pub fn form_controls_have_accessible_names(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed HTML introduces or modifies a form control such as <input> (other than type=\"hidden\", \"submit\", \"button\", \"reset\", or \"image\" with alt), <select>, or <textarea>, and the control has no associated <label> (wrapping or with for=id), no aria-label, no aria-labelledby pointing at visible text, and no title attribute carrying the name."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: html_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "form_controls_have_accessible_names",
+      "Pair every form control with a <label>, aria-label, or aria-labelledby reference so assistive tech can announce it.",
+      judgement.findings,
+    )
+  }
+  return allow("form_controls_have_accessible_names")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_LINK_PURPOSE, confidence: 0.58, source_date: "2026-05-09")
+/** Blocks generic anchor text such as "click here" or "read more" without disambiguating context. */
+pub fn link_purpose_is_clear(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed HTML introduces an anchor whose visible text is generic placeholder phrasing such as \"click here\", \"here\", \"more\", \"read more\", or \"learn more\", and the anchor lacks a programmatic accessible name from aria-label or aria-labelledby and has no descriptive surrounding text in the same paragraph, list item, table cell, or heading that disambiguates the link target."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: html_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "link_purpose_is_clear",
+      "Replace generic link text with the destination's purpose, or supply context via aria-label or aria-labelledby.",
+      judgement.findings,
+    )
+  }
+  return allow("link_purpose_is_clear")
+}


### PR DESCRIPTION
## Summary

Closes #31.

Six deterministic and two semantic predicates for plain HTML markup, focused on accessibility and safe-navigation defaults that any project can opt into before framework-specific packs land.

| Predicate | Mode | Verdict |
|---|---|---|
| `images_have_alt_text` | deterministic | Block |
| `documents_specify_lang` | deterministic | Block |
| `no_inline_event_handlers` | deterministic | Block |
| `no_inline_styles` | deterministic | Warn |
| `prefer_semantic_landmarks` | deterministic | Warn |
| `target_blank_uses_rel_noopener` | deterministic | Block |
| `form_controls_have_accessible_names` | semantic | Block |
| `link_purpose_is_clear` | semantic | Block |

Evidence draws on MDN, WHATWG HTML Living Standard, W3C WAI tutorials, WCAG 2.2 Understanding documents, and web.dev — at least two independent sources per predicate.

`.html` and `.htm` files are scanned; common build, dependency, and report directories (`node_modules/`, `dist/`, `build/`, `out/`, `coverage/`, `vendor/`, `.next/`, `.nuxt/`, `.svelte-kit/`, `.cache/`, `target/`, `test-results/`) are excluded.

## Test plan

- [ ] CI placeholder jobs pass (evidence-links, fmt, fixture-replay)
- [ ] Manual trace of each deterministic regex against its block/allow fixture (verified during authoring)
- [ ] Top-level README pack list updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)