### PR TITLE
Add Shell seed predicate pack

### DIFF
--- a/shell/README.md
+++ b/shell/README.md
@@ -1,0 +1,57 @@
+# Shell Seed Predicate Pack
+
+This pack covers POSIX shell, Bash, and other Bourne-family scripts that ship inside repositories: build helpers, deploy scripts, CI glue, and one-off operational tools. It targets the small set of high-signal mistakes that turn shell scripts into latent reliability and security incidents — missing strict-mode flags, parsing `ls`, dynamic `eval`, missing tempfile cleanup, blanket `shellcheck` disables, hardcoded secrets, and leaking sensitive data into logs.
+
+## Stack Assumptions
+
+- Files are detected by extension (`.sh`, `.bash`, `.zsh`, `.ksh`, `.dash`) or by a Bourne-family shebang on line 1 (`sh`, `bash`, `zsh`, `ksh`, `dash`, `ash`).
+- Strict-mode enforcement targets *executable* scripts (those with a shebang). Files without a shebang are assumed to be sourced libraries where `set -e`/`set -u` semantics may be inappropriate.
+- Deterministic predicates run over changed source text until Flow exposes a stable shell AST query API; rules with meaningful false-positive risk warn rather than block.
+- Semantic predicates make one cheap judge call over the changed shell files and rely on the rubric to cite concrete spans before blocking.
+
+## Predicate Coverage
+
+| Predicate | Mode | Verdict | Purpose |
+|---|---|---|---|
+| `set_euo_pipefail` | deterministic | Block | Executable shell scripts must enable `errexit`, `nounset`, and `pipefail`. |
+| `no_parsing_ls` | deterministic | Block | Capturing `ls` output for iteration is unsafe with whitespace, newlines, and globbing. |
+| `no_eval_dynamic_input` | deterministic | Block | `eval` on interpolated variables or command substitutions is shell injection. |
+| `trap_cleanup_on_tempfile` | deterministic | Warn | Scripts that create tempfiles via `mktemp` should remove them with an `EXIT` trap. |
+| `no_blanket_shellcheck_disable` | deterministic | Warn | `# shellcheck disable=all` hides every diagnostic; prefer narrowly scoped SC codes. |
+| `shellcheck_clean` | semantic | Block | Changed shell scripts should pass ShellCheck under its default configuration. |
+| `no_hardcoded_secrets` | semantic | Block | Credentials, tokens, and private keys must not live in shell source. |
+| `no_sensitive_data_in_logs` | semantic | Block | `echo`/`printf`/log lines must not emit credentials or sensitive request data. |
+
+## Evidence
+
+Evidence scanned on 2026-05-09.
+
+- GNU Bash reference manual: `set` builtin (errexit, nounset, pipefail) and `trap` builtin.
+- Google Shell Style Guide: shell selection, strict-mode guidance, and `eval` usage.
+- ShellCheck wiki: SC2086 (quote expansions), SC2045 (parsing `ls`), SC2294 (`eval` on arrays/variables), SC2064 (single-quote `trap` arguments), and the `Directive`/`Ignore` pages for `# shellcheck disable=` syntax.
+- Greg's Wiki (`mywiki.wooledge.org`): `ParsingLs`, `BashFAQ/048` (eval pitfalls), and `SignalTrap`.
+- OWASP cheat sheets: Secrets Management and Logging guidance; GitHub secret-scanning documentation for the hardcoded-credential surface area.
+
+## Known False Positives
+
+- Regex predicates do not parse shell. Heredocs, single-quoted literals, and string interpolation can fool them until a real shell AST is wired in.
+- `set_euo_pipefail` only inspects files with a Bourne-family shebang. Sourced libraries (no shebang) are skipped because they typically inherit the caller's options.
+- `no_parsing_ls` blocks all `$(ls …)` and backtick `ls …` capture, including the rare cases where the output is intentionally formatted for human display. Reroute through `find -print0` or array globbing, or suppress with a justification once `# harn` directives land.
+- `no_eval_dynamic_input` blocks `eval` lines that contain `$` or backticks anywhere on the line. Fully literal `eval` (rare) is allowed; in-string `$` literals (e.g. inside single quotes) may trigger a false positive.
+- `trap_cleanup_on_tempfile` is conservative at file granularity. Multi-script pipelines that delegate cleanup to a parent script will warn until suppressions land.
+- `no_blanket_shellcheck_disable` only flags `disable=all`; narrower disables and missing-justification cases are left to code review.
+- Semantic predicates depend on the judge recognizing concrete changed spans. They should stay high-threshold until Flow exposes structured shell data-flow signals.
+
+## Fixtures
+
+Each fixture in `fixtures/` contains at least one blocked or warned example and one allowed example for the corresponding predicate. The fixture shape matches the existing seed packs:
+
+```json
+{
+  "predicate": "name",
+  "cases": [
+    {"expect": "Block", "files": [{"path": "scripts/deploy.sh", "text": "..."}]},
+    {"expect": "Allow", "files": [{"path": "scripts/deploy.sh", "text": "..."}]}
+  ]
+}
+```

--- a/shell/fixtures/no_blanket_shellcheck_disable.json
+++ b/shell/fixtures/no_blanket_shellcheck_disable.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_blanket_shellcheck_disable",
+  "cases": [
+    {
+      "name": "warns_on_disable_all",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "scripts/legacy.sh",
+          "text": "#!/usr/bin/env bash\n# shellcheck disable=all\nset -euo pipefail\nrun_legacy_thing\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_specific_disable_codes",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "scripts/legacy.sh",
+          "text": "#!/usr/bin/env bash\nset -euo pipefail\n# shellcheck disable=SC2086,SC2046\nrun_legacy_thing $args\n"
+        }
+      ]
+    }
+  ]
+}

--- a/shell/fixtures/no_eval_dynamic_input.json
+++ b/shell/fixtures/no_eval_dynamic_input.json
@@ -1,0 +1,45 @@
+{
+  "predicate": "no_eval_dynamic_input",
+  "cases": [
+    {
+      "name": "blocks_eval_on_variable",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "scripts/run.sh",
+          "text": "#!/usr/bin/env bash\nset -euo pipefail\ncmd=\"$1\"\neval \"$cmd\"\n"
+        }
+      ]
+    },
+    {
+      "name": "blocks_eval_on_command_substitution",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "scripts/configure.sh",
+          "text": "#!/usr/bin/env bash\nset -euo pipefail\neval \"$(./generate-config)\"\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_static_command",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "scripts/run.sh",
+          "text": "#!/usr/bin/env bash\nset -euo pipefail\nrun_step \"$1\"\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_array_dispatch",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "scripts/dispatch.sh",
+          "text": "#!/usr/bin/env bash\nset -euo pipefail\ncase \"$1\" in\n  build) make build ;;\n  test) make test ;;\n  *) echo \"unknown\"; exit 1 ;;\nesac\n"
+        }
+      ]
+    }
+  ]
+}

--- a/shell/fixtures/no_hardcoded_secrets.json
+++ b/shell/fixtures/no_hardcoded_secrets.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_hardcoded_secrets",
+  "cases": [
+    {
+      "name": "blocks_hardcoded_aws_secret",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "scripts/upload.sh",
+          "text": "#!/usr/bin/env bash\nset -euo pipefail\nexport AWS_ACCESS_KEY_ID=\"AKIAIOSFODNN7EXAMPLE\"\nexport AWS_SECRET_ACCESS_KEY=\"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\"\naws s3 cp build/ s3://artifacts/ --recursive\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_secrets_loaded_from_env",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "scripts/upload.sh",
+          "text": "#!/usr/bin/env bash\nset -euo pipefail\n: \"${AWS_ACCESS_KEY_ID:?required}\"\n: \"${AWS_SECRET_ACCESS_KEY:?required}\"\naws s3 cp build/ s3://artifacts/ --recursive\n"
+        }
+      ]
+    }
+  ]
+}

--- a/shell/fixtures/no_parsing_ls.json
+++ b/shell/fixtures/no_parsing_ls.json
@@ -1,0 +1,45 @@
+{
+  "predicate": "no_parsing_ls",
+  "cases": [
+    {
+      "name": "blocks_for_in_dollar_ls",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "scripts/cleanup.sh",
+          "text": "#!/usr/bin/env bash\nset -euo pipefail\nfor f in $(ls /var/log); do\n  rm -- \"/var/log/$f\"\ndone\n"
+        }
+      ]
+    },
+    {
+      "name": "blocks_backtick_ls",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "scripts/legacy.sh",
+          "text": "#!/bin/sh\nfor f in `ls /tmp`; do\n  echo \"$f\"\ndone\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_glob_iteration",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "scripts/cleanup.sh",
+          "text": "#!/usr/bin/env bash\nset -euo pipefail\nshopt -s nullglob\nfor f in /var/log/*; do\n  rm -- \"$f\"\ndone\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_find_print0",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "scripts/cleanup.sh",
+          "text": "#!/usr/bin/env bash\nset -euo pipefail\nfind /var/log -type f -print0 | xargs -0 rm --\n"
+        }
+      ]
+    }
+  ]
+}

--- a/shell/fixtures/no_sensitive_data_in_logs.json
+++ b/shell/fixtures/no_sensitive_data_in_logs.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_sensitive_data_in_logs",
+  "cases": [
+    {
+      "name": "blocks_echoing_password",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "scripts/login.sh",
+          "text": "#!/usr/bin/env bash\nset -euo pipefail\nuser=\"$1\"\npassword=\"$2\"\necho \"logging in $user with password $password\" >> /var/log/login.log\nperform_login \"$user\" \"$password\"\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_redacted_diagnostic_logs",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "scripts/login.sh",
+          "text": "#!/usr/bin/env bash\nset -euo pipefail\nuser=\"$1\"\npassword=\"$2\"\necho \"login attempt for user=$user\" >> /var/log/login.log\nperform_login \"$user\" \"$password\"\n"
+        }
+      ]
+    }
+  ]
+}

--- a/shell/fixtures/set_euo_pipefail.json
+++ b/shell/fixtures/set_euo_pipefail.json
@@ -1,0 +1,45 @@
+{
+  "predicate": "set_euo_pipefail",
+  "cases": [
+    {
+      "name": "blocks_script_missing_strict_flags",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "scripts/deploy.sh",
+          "text": "#!/usr/bin/env bash\n\necho \"deploying $1\"\ncp -r build/ /var/www/\n"
+        }
+      ]
+    },
+    {
+      "name": "blocks_script_with_only_errexit",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "scripts/release.sh",
+          "text": "#!/bin/bash\nset -e\n\nrun_release\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_script_with_strict_mode",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "scripts/deploy.sh",
+          "text": "#!/usr/bin/env bash\nset -euo pipefail\n\necho \"deploying $1\"\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_long_form_strict_mode",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "scripts/release.sh",
+          "text": "#!/bin/bash\nset -o errexit\nset -o nounset\nset -o pipefail\n\nrun_release\n"
+        }
+      ]
+    }
+  ]
+}

--- a/shell/fixtures/shellcheck_clean.json
+++ b/shell/fixtures/shellcheck_clean.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "shellcheck_clean",
+  "cases": [
+    {
+      "name": "blocks_unquoted_word_split",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "scripts/copy.sh",
+          "text": "#!/usr/bin/env bash\nset -euo pipefail\nfiles=$1\ncp $files /tmp/dest/\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_quoted_clean_script",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "scripts/copy.sh",
+          "text": "#!/usr/bin/env bash\nset -euo pipefail\nsrc=\"$1\"\ndest=\"$2\"\ncp -- \"$src\" \"$dest\"\n"
+        }
+      ]
+    }
+  ]
+}

--- a/shell/fixtures/trap_cleanup_on_tempfile.json
+++ b/shell/fixtures/trap_cleanup_on_tempfile.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "trap_cleanup_on_tempfile",
+  "cases": [
+    {
+      "name": "warns_on_mktemp_without_trap",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "scripts/build.sh",
+          "text": "#!/usr/bin/env bash\nset -euo pipefail\ntmp=$(mktemp -d)\ncp -r src/ \"$tmp/\"\nrun_build \"$tmp\"\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_mktemp_with_exit_trap",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "scripts/build.sh",
+          "text": "#!/usr/bin/env bash\nset -euo pipefail\ntmp=$(mktemp -d)\ntrap 'rm -rf -- \"$tmp\"' EXIT\ncp -r src/ \"$tmp/\"\nrun_build \"$tmp\"\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_script_without_tempfiles",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "scripts/run.sh",
+          "text": "#!/usr/bin/env bash\nset -euo pipefail\necho \"hello\"\n"
+        }
+      ]
+    }
+  ]
+}

--- a/shell/invariants.harn
+++ b/shell/invariants.harn
@@ -1,0 +1,248 @@
+let _EVIDENCE_STRICT_MODE = [
+  "https://www.gnu.org/software/bash/manual/bash.html#The-Set-Builtin",
+  "https://google.github.io/styleguide/shellguide.html",
+  "https://www.shellcheck.net/wiki/SC2086",
+]
+
+let _EVIDENCE_PARSING_LS = [
+  "https://mywiki.wooledge.org/ParsingLs",
+  "https://www.shellcheck.net/wiki/SC2045",
+  "https://google.github.io/styleguide/shellguide.html#s6.7-arrays",
+]
+
+let _EVIDENCE_EVAL = [
+  "https://www.shellcheck.net/wiki/SC2294",
+  "https://mywiki.wooledge.org/BashFAQ/048",
+  "https://google.github.io/styleguide/shellguide.html#s6.6-eval",
+]
+
+let _EVIDENCE_TRAP_CLEANUP = [
+  "https://www.gnu.org/software/bash/manual/bash.html#index-trap",
+  "https://www.shellcheck.net/wiki/SC2064",
+  "https://mywiki.wooledge.org/SignalTrap",
+]
+
+let _EVIDENCE_SHELLCHECK_DIRECTIVE = [
+  "https://www.shellcheck.net/wiki/Directive",
+  "https://www.shellcheck.net/wiki/Ignore",
+]
+
+let _EVIDENCE_SHELLCHECK = [
+  "https://www.shellcheck.net/wiki/Home",
+  "https://github.com/koalaman/shellcheck",
+  "https://google.github.io/styleguide/shellguide.html#which-shell-to-use",
+]
+
+let _EVIDENCE_SECRETS = [
+  "https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html",
+  "https://docs.github.com/code-security/secret-scanning/about-secret-scanning",
+]
+
+let _EVIDENCE_SENSITIVE_LOGS = [
+  "https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html",
+  "https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html",
+]
+
+fn has_shell_extension(path) {
+  return path.ends_with(".sh")
+    || path.ends_with(".bash")
+    || path.ends_with(".zsh")
+    || path.ends_with(".ksh")
+    || path.ends_with(".dash")
+}
+
+fn has_shell_shebang(file) {
+  return regex_match(r"\A#![^\n]*\b(sh|bash|zsh|ksh|dash|ash)\b", file.text, "") != nil
+}
+
+fn shell_files(slice) {
+  return slice.files
+    .filter({ file -> has_shell_extension(file.path) || has_shell_shebang(file) })
+}
+
+fn executable_shell_files(slice) {
+  return shell_files(slice).filter({ file -> has_shell_shebang(file) })
+}
+
+fn scan_files(files, pattern, flags) {
+  var findings = []
+  for file in files {
+    if regex_match(pattern, file.text, flags) != nil {
+      findings = findings.push({path: file.path, pattern: pattern})
+    }
+  }
+  return findings
+}
+
+fn scan_files_if(files, predicate) {
+  var findings = []
+  for file in files {
+    if predicate(file) {
+      findings = findings.push({path: file.path})
+    }
+  }
+  return findings
+}
+
+fn allow(rule) {
+  return {verdict: "Allow", rule: rule, findings: [], remediation: ""}
+}
+
+fn warn(rule, remediation, findings) {
+  return {verdict: "Warn", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block(rule, remediation, findings) {
+  return {verdict: "Block", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return block(rule, remediation, findings)
+}
+
+fn warn_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return warn(rule, remediation, findings)
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_STRICT_MODE, confidence: 0.78, source_date: "2026-05-09")
+/** Blocks executable shell scripts that omit errexit, nounset, or pipefail. */
+pub fn set_euo_pipefail(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    executable_shell_files(slice),
+    { file -> regex_match(r"(?m)^\s*set\b[^#\n]*(\s-[a-zA-Z]*e[a-zA-Z]*\b|\berrexit\b)", file.text, "m") == nil
+      || regex_match(r"(?m)^\s*set\b[^#\n]*(\s-[a-zA-Z]*u[a-zA-Z]*\b|\bnounset\b)", file.text, "m") == nil
+      || regex_match(r"(?m)^\s*set\b[^#\n]*\bpipefail\b", file.text, "m") == nil },
+  )
+  return block_on_findings(
+    "set_euo_pipefail",
+    "Add `set -euo pipefail` near the top of executable shell scripts so failures, unset variables, and broken pipes stop the script.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_PARSING_LS, confidence: 0.82, source_date: "2026-05-09")
+/** Blocks parsing the output of ls in shell scripts. */
+pub fn no_parsing_ls(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    shell_files(slice),
+    r"(\$\(\s*ls\b|`\s*ls\b)",
+    "s",
+  )
+  return block_on_findings(
+    "no_parsing_ls",
+    "Iterate with shell globs, arrays, or `find ... -print0 | xargs -0`; ls output is not safe to parse.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_EVAL, confidence: 0.74, source_date: "2026-05-09")
+/** Blocks eval calls whose argument contains a variable or command substitution. */
+pub fn no_eval_dynamic_input(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    shell_files(slice),
+    r"(?m)^[^#\n]*\beval\b\s+[^\n]*(\$|`)",
+    "m",
+  )
+  return block_on_findings(
+    "no_eval_dynamic_input",
+    "Replace dynamic eval with explicit dispatch, arrays, or `printf -v`; eval on interpolated text is shell injection.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_TRAP_CLEANUP, confidence: 0.66, source_date: "2026-05-09")
+/** Warns when a script creates temp files via mktemp without an EXIT trap. */
+pub fn trap_cleanup_on_tempfile(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    shell_files(slice),
+    { file -> regex_match(r"\bmktemp\b", file.text, "s") != nil
+      && regex_match(r"(?m)^[^#\n]*\btrap\b[^\n]*\bEXIT\b", file.text, "m") == nil },
+  )
+  return warn_on_findings(
+    "trap_cleanup_on_tempfile",
+    "Pair `mktemp` with `trap 'rm -rf -- \"$tmpdir\"' EXIT` so tempfiles are removed on success and failure paths.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_SHELLCHECK_DIRECTIVE, confidence: 0.84, source_date: "2026-05-09")
+/** Warns on blanket ShellCheck disables that hide every diagnostic in a file. */
+pub fn no_blanket_shellcheck_disable(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    shell_files(slice),
+    r"(?m)^\s*#\s*shellcheck\s+disable\s*=\s*all\b",
+    "m",
+  )
+  return warn_on_findings(
+    "no_blanket_shellcheck_disable",
+    "Disable specific SC codes with a comment explaining why, instead of `# shellcheck disable=all`.",
+    findings,
+  )
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_SHELLCHECK, confidence: 0.62, source_date: "2026-05-09")
+/** Blocks changed shell scripts that would fail ShellCheck under default configuration. */
+pub fn shellcheck_clean(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed shell scripts contain issues ShellCheck would flag at error or warning severity under its default configuration, such as unquoted word-split expansions, missing `set` strict-mode flags on executables, parsing `ls`, eval on interpolated input, or unsafe redirections. Allow scripts that pass ShellCheck or whose only issues are localized info/style notes."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: shell_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "shellcheck_clean",
+      "Run ShellCheck on the changed scripts and resolve the reported errors and warnings, or add narrowly scoped `# shellcheck disable=SCxxxx` directives with a justification.",
+      judgement.findings,
+    )
+  }
+  return allow("shellcheck_clean")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_SECRETS, confidence: 0.66, source_date: "2026-05-09")
+/** Blocks hardcoded credentials, tokens, and private keys in shell sources. */
+pub fn no_hardcoded_secrets(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed shell source embeds a credential, API token, private key, signing secret, database password, production connection string, or long-lived service credential as a literal value instead of reading it from a secret manager, scoped environment variable, or restricted-permission credential file."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: shell_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "no_hardcoded_secrets",
+      "Move secrets to a secret manager or scoped environment variable and rotate any value that was ever committed.",
+      judgement.findings,
+    )
+  }
+  return allow("no_hardcoded_secrets")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_SENSITIVE_LOGS, confidence: 0.6, source_date: "2026-05-09")
+/** Blocks shell scripts that echo or print secrets and sensitive request data. */
+pub fn no_sensitive_data_in_logs(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed shell scripts echo, printf, log, or otherwise emit credentials, authorization headers, session tokens, passwords, signed URLs, or sensitive personal data without redaction. Allow benign diagnostic output and explicit dry-run prints that mask sensitive values."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: shell_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "no_sensitive_data_in_logs",
+      "Redact secrets and sensitive identifiers before printing; log stable, non-sensitive identifiers instead.",
+      judgement.findings,
+    )
+  }
+  return allow("no_sensitive_data_in_logs")
+}


### PR DESCRIPTION
## Summary

- Adds a v0 Shell seed predicate pack at `shell/` covering POSIX shell, Bash, and other Bourne-family scripts
- 5 deterministic predicates (strict mode, no parsing ls, no dynamic eval, tempfile cleanup, no blanket shellcheck disables) and 3 semantic predicates (shellcheck cleanliness, hardcoded secrets, sensitive data in logs)
- Each predicate ships with allow/block fixtures and is backed by ≥2 evidence URLs (Bash manual, Google Shell Style Guide, ShellCheck wiki, Greg's Wiki, OWASP cheat sheets)

## Predicate coverage

| Predicate | Mode | Verdict |
|---|---|---|
| `set_euo_pipefail` | deterministic | Block |
| `no_parsing_ls` | deterministic | Block |
| `no_eval_dynamic_input` | deterministic | Block |
| `trap_cleanup_on_tempfile` | deterministic | Warn |
| `no_blanket_shellcheck_disable` | deterministic | Warn |
| `shellcheck_clean` | semantic | Block |
| `no_hardcoded_secrets` | semantic | Block |
| `no_sensitive_data_in_logs` | semantic | Block |

Strict-mode enforcement is scoped to scripts with a Bourne-family shebang so sourced libraries are not penalized for inheriting their caller's options.

Closes #35

## Test plan

- [ ] CI status rollup passes (placeholder evidence-link, fmt, fixture-replay jobs)
- [ ] Spot-check that the chosen ShellCheck SC codes and style-guide anchors resolve to authoritative pages (verified locally with curl: all evidence URLs returned 200)
- [ ] Manual read-through of fixtures to confirm Block/Allow expectations match the regex semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)