### PR TITLE
Add Markdown seed predicate pack (#33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ See the Harn Flow design docs for the full predicate language spec.
 - [JavaScript](./javascript/) — v0 draft predicates for plain JavaScript source, async handling, dynamic-code hazards, and untrusted data boundaries.
 - [JSON](./json/) — v0 draft predicates for strict JSON conformance, encoding hygiene, declared-schema respect, and untrusted-data boundaries.
 - [Kotlin](./kotlin/) — v0 draft predicates for Kotlin JVM, Android, and Multiplatform source.
+- [Markdown](./markdown/) — v0 draft predicates for prose Markdown files used for documentation, READMEs, and design notes.
 - [Python](./python/) — v0 draft predicates for Python application and library code.
 - [Ruby](./ruby/) — v0 draft predicates for Ruby application and library code.
 - [Rust](./rust/) — v0 draft predicates for Rust application and library code.

--- a/markdown/README.md
+++ b/markdown/README.md
@@ -1,0 +1,58 @@
+# Markdown Seed Predicate Pack
+
+This pack covers prose Markdown files used for documentation, READMEs, and design notes. Markdown has a smaller surface area than full programming languages, so the pack stays narrow and focuses on review-slice checks with clear correctness, accessibility, or safety impact: untagged code fences, heading-level discipline, single document title, image alt text, dangerous raw HTML, broken internal links, and link-style consistency.
+
+## Stack Assumptions
+
+- Files use `.md` or `.markdown`. MDX (`.mdx`) is intentionally excluded for v0 because its JSX layer needs separate parsing rules.
+- Documents target CommonMark with GitHub Flavored Markdown extensions; predicates do not assume Pandoc-only or Liquid-templated dialects.
+- Production-path checks exclude `node_modules/`, `vendor/`, `third_party/`, `target/`, `dist/`, `build/`, `out/`, `.git/`, and obvious `fixtures/`, `testdata/`, `test/`, and `tests/` paths so vendored docs and intentionally malformed test fixtures do not get flagged.
+- Deterministic predicates run regex scans on changed source text until Harn Flow exposes a Markdown AST query API. Rules with meaningful false-positive risk warn rather than block.
+- Semantic predicates make one cheap judge call and only act when they can cite concrete changed spans.
+
+## Predicate Coverage
+
+| Predicate | Mode | Verdict | Purpose |
+|---|---|---|---|
+| `code_fence_language_specified` | deterministic | Warn | Fenced code blocks should declare a language so highlighters and assistive tech can render them well. |
+| `heading_level_discipline` | deterministic | Warn | Heading levels should not jump (h1 → h3) — accessibility tools depend on monotonic structure. |
+| `single_h1_per_doc` | deterministic | Warn | A document should have one H1 acting as its title, not several. |
+| `image_alt_text_present` | deterministic | Block | Every meaningful image needs alt text; decorative images need an explicit empty alt. |
+| `no_dangerous_inline_html` | deterministic | Block | Raw `<script>`, `<iframe>`, `javascript:` URLs, and inline event handlers are XSS sinks when Markdown renders to HTML. |
+| `no_broken_internal_links` | semantic | Block | Relative links and anchors must resolve to a file or heading that exists in the slice or repo. |
+| `consistent_link_format` | semantic | Warn | A single document should not freely mix inline, reference, and bare-URL link styles. |
+
+## Evidence
+
+Evidence scanned on 2026-05-09.
+
+- CommonMark 0.31.2 specification: fenced code blocks, raw HTML, links.
+- GitHub Flavored Markdown (GFM) specification: fenced code blocks and the disallowed raw HTML extension.
+- markdownlint rule docs: MD040 (fenced-code-language), MD001 (heading-increment), MD025 (single-h1), MD045 (no-alt-text), MD051 (link-fragments), MD054 (link-image-style).
+- W3C WAI tutorials and WCAG 2.2 understanding pages: page structure / headings, images alt text, non-text content (1.1.1), info and relationships (1.3.1), link purpose in context (2.4.4).
+- OWASP Cross-Site Scripting Prevention Cheat Sheet: HTML and URL contexts that motivate the dangerous-HTML predicate.
+- GitHub docs: basic writing and formatting syntax, used as the de-facto rendering reference for repository-hosted docs.
+
+## Known False Positives
+
+- Regex predicates do not parse Markdown. Code samples that demonstrate Markdown syntax can be misread; HTML inside fenced code blocks is treated as regular content.
+- `code_fence_language_specified` flags only when a complete bare opener / bare closer pair is detected; a file with all tagged blocks is allowed even if their closers are bare. It does not yet recognize tilde (`~~~`) fences.
+- `heading_level_discipline` is a file-level approximation: it flags when a level appears without its parent level present in the same document. It will miss intra-document skips (h2 → h4 → h2 → h4) where every parent level appears somewhere, and miss skips inside ATX-only setext-mixed documents.
+- `single_h1_per_doc` flags two ATX-style top-level headings; setext (`===`) H1s are not yet detected.
+- `image_alt_text_present` blocks `![](url)` only. Markdown reference-image syntax (`![][ref]`) is not yet inspected; HTML `<img>` tags without `alt` attributes are also outside the v0 check.
+- `no_dangerous_inline_html` is keyword-based and case-insensitive. It will catch tags that are inside fenced code blocks intended as documentation; once the predicate runtime exposes structured slices, prefer a local suppression over relaxing the rule.
+- `no_broken_internal_links` and `consistent_link_format` depend on the semantic judge recognizing concrete changed spans. They should stay high-threshold and cite exact link spans before acting.
+
+## Fixtures
+
+Each fixture in `fixtures/` contains one blocked or warned example and one allowed example for the corresponding predicate. The fixture shape matches the existing seed packs:
+
+```json
+{
+  "predicate": "name",
+  "cases": [
+    {"expect": "Warn", "files": [{"path": "docs/install.md", "text": "..."}]},
+    {"expect": "Allow", "files": [{"path": "docs/install.md", "text": "..."}]}
+  ]
+}
+```

--- a/markdown/fixtures/code_fence_language_specified.json
+++ b/markdown/fixtures/code_fence_language_specified.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "code_fence_language_specified",
+  "cases": [
+    {
+      "name": "warns_on_bare_fence",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "docs/install.md",
+          "text": "# Install\n\nRun the setup script:\n\n```\n./bin/setup --release\n```\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_tagged_fence",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "docs/install.md",
+          "text": "# Install\n\nRun the setup script:\n\n```bash\n./bin/setup --release\n```\n"
+        }
+      ]
+    }
+  ]
+}

--- a/markdown/fixtures/consistent_link_format.json
+++ b/markdown/fixtures/consistent_link_format.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "consistent_link_format",
+  "cases": [
+    {
+      "name": "warns_on_mixed_link_styles_in_one_doc",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "docs/links.md",
+          "text": "# Links\n\nWe use the [official spec](https://spec.commonmark.org/), and the [GFM extension][gfm], plus https://github.github.com/gfm/ for the rendered version, and the shortcut form [CommonMark][].\n\n[gfm]: https://github.github.com/gfm/\n[CommonMark]: https://commonmark.org/\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_consistent_inline_links",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "docs/links.md",
+          "text": "# Links\n\nWe use the [CommonMark spec](https://spec.commonmark.org/) and the [GFM extension](https://github.github.com/gfm/) as our authoritative references.\n"
+        }
+      ]
+    }
+  ]
+}

--- a/markdown/fixtures/heading_level_discipline.json
+++ b/markdown/fixtures/heading_level_discipline.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "heading_level_discipline",
+  "cases": [
+    {
+      "name": "warns_on_h1_to_h3_skip",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "docs/runbook.md",
+          "text": "# Runbook\n\nIntro paragraph.\n\n### Step one\n\nDetails.\n\n### Step two\n\nMore details.\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_monotonic_levels",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "docs/runbook.md",
+          "text": "# Runbook\n\nIntro paragraph.\n\n## Steps\n\n### Step one\n\nDetails.\n\n### Step two\n\nMore details.\n"
+        }
+      ]
+    }
+  ]
+}

--- a/markdown/fixtures/image_alt_text_present.json
+++ b/markdown/fixtures/image_alt_text_present.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "image_alt_text_present",
+  "cases": [
+    {
+      "name": "blocks_image_without_alt_text",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "docs/architecture.md",
+          "text": "# Architecture\n\nSee the diagram below.\n\n![](./diagrams/system.png)\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_image_with_descriptive_alt",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "docs/architecture.md",
+          "text": "# Architecture\n\nSee the diagram below.\n\n![Request flow from gateway to scheduler to worker pool](./diagrams/system.png)\n"
+        }
+      ]
+    }
+  ]
+}

--- a/markdown/fixtures/no_broken_internal_links.json
+++ b/markdown/fixtures/no_broken_internal_links.json
@@ -1,0 +1,43 @@
+{
+  "predicate": "no_broken_internal_links",
+  "cases": [
+    {
+      "name": "blocks_link_to_missing_file",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "docs/index.md",
+          "text": "# Index\n\nSee the [installation guide](./install.md) for setup.\n"
+        }
+      ]
+    },
+    {
+      "name": "blocks_anchor_with_no_matching_heading",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "docs/index.md",
+          "text": "# Index\n\nJump to [advanced setup](./guide.md#advanced-cluster-mode) for production.\n"
+        },
+        {
+          "path": "docs/guide.md",
+          "text": "# Guide\n\n## Basic setup\n\nSteps.\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_link_to_existing_file_and_anchor",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "docs/index.md",
+          "text": "# Index\n\nSee the [installation guide](./install.md#prerequisites) for setup.\n"
+        },
+        {
+          "path": "docs/install.md",
+          "text": "# Install\n\n## Prerequisites\n\nYou need Rust and Node.\n"
+        }
+      ]
+    }
+  ]
+}

--- a/markdown/fixtures/no_dangerous_inline_html.json
+++ b/markdown/fixtures/no_dangerous_inline_html.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "no_dangerous_inline_html",
+  "cases": [
+    {
+      "name": "blocks_inline_script_tag",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "docs/widget.md",
+          "text": "# Widget\n\nDrop this on the page:\n\n<script>alert('xss')</script>\n\nDone.\n"
+        }
+      ]
+    },
+    {
+      "name": "blocks_javascript_url",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "docs/links.md",
+          "text": "# Links\n\n[Click me](javascript:alert(1))\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_safe_html_table",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "docs/data.md",
+          "text": "# Data\n\n<table>\n  <tr><th>Key</th><th>Value</th></tr>\n  <tr><td>a</td><td>1</td></tr>\n</table>\n"
+        }
+      ]
+    }
+  ]
+}

--- a/markdown/fixtures/single_h1_per_doc.json
+++ b/markdown/fixtures/single_h1_per_doc.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "single_h1_per_doc",
+  "cases": [
+    {
+      "name": "warns_on_two_h1_headings",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "docs/overview.md",
+          "text": "# Overview\n\nFirst section.\n\n# Architecture\n\nSecond section.\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_single_h1_with_h2_siblings",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "docs/overview.md",
+          "text": "# Overview\n\nFirst section.\n\n## Architecture\n\nSecond section.\n\n## Deployment\n\nThird section.\n"
+        }
+      ]
+    }
+  ]
+}

--- a/markdown/invariants.harn
+++ b/markdown/invariants.harn
@@ -1,0 +1,232 @@
+let _EVIDENCE_FENCE_LANGUAGE = [
+  "https://github.github.com/gfm/#fenced-code-blocks",
+  "https://spec.commonmark.org/0.31.2/#fenced-code-blocks",
+  "https://github.com/DavidAnson/markdownlint/blob/main/doc/md040.md",
+]
+
+let _EVIDENCE_HEADING_LEVELS = [
+  "https://github.com/DavidAnson/markdownlint/blob/main/doc/md001.md",
+  "https://www.w3.org/WAI/tutorials/page-structure/headings/",
+  "https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html",
+]
+
+let _EVIDENCE_SINGLE_H1 = [
+  "https://github.com/DavidAnson/markdownlint/blob/main/doc/md025.md",
+  "https://www.w3.org/WAI/tutorials/page-structure/headings/",
+]
+
+let _EVIDENCE_IMAGE_ALT = [
+  "https://github.com/DavidAnson/markdownlint/blob/main/doc/md045.md",
+  "https://www.w3.org/WAI/tutorials/images/",
+  "https://www.w3.org/WAI/WCAG22/Understanding/non-text-content.html",
+]
+
+let _EVIDENCE_DANGEROUS_HTML = [
+  "https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html",
+  "https://github.github.com/gfm/#disallowed-raw-html-extension-",
+  "https://spec.commonmark.org/0.31.2/#raw-html",
+]
+
+let _EVIDENCE_BROKEN_LINKS = [
+  "https://spec.commonmark.org/0.31.2/#links",
+  "https://github.com/DavidAnson/markdownlint/blob/main/doc/md051.md",
+  "https://www.w3.org/WAI/WCAG22/Understanding/link-purpose-in-context.html",
+]
+
+let _EVIDENCE_LINK_STYLE = [
+  "https://github.com/DavidAnson/markdownlint/blob/main/doc/md054.md",
+  "https://spec.commonmark.org/0.31.2/#links",
+  "https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax",
+]
+
+fn is_markdown_path(path) {
+  return path.ends_with(".md") || path.ends_with(".markdown")
+}
+
+fn is_vendored_path(path) {
+  return regex_match(
+    r"(^|/)(node_modules|vendor|third_party|target|dist|build|out|\.git)(/|$)",
+    path,
+    "",
+  ) != nil
+}
+
+fn is_fixture_path(path) {
+  return regex_match(r"(^|/)(fixtures?|testdata|tests?)(/|$)", path, "") != nil
+}
+
+fn markdown_files(slice) {
+  return slice.files.filter({ file -> is_markdown_path(file.path) })
+}
+
+fn production_markdown_files(slice) {
+  return markdown_files(slice)
+    .filter({ file -> !is_vendored_path(file.path) && !is_fixture_path(file.path) })
+}
+
+fn scan_files_if(files, predicate) {
+  var findings = []
+  for file in files {
+    if predicate(file) {
+      findings = findings.push({path: file.path})
+    }
+  }
+  return findings
+}
+
+fn allow(rule) {
+  return {verdict: "Allow", rule: rule, findings: [], remediation: ""}
+}
+
+fn warn(rule, remediation, findings) {
+  return {verdict: "Warn", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block(rule, remediation, findings) {
+  return {verdict: "Block", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return block(rule, remediation, findings)
+}
+
+fn warn_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return warn(rule, remediation, findings)
+}
+
+fn has_heading_level_skip(file) {
+  let h2 = regex_match(r"(?m)^## \S", file.text, "m") != nil
+  let h3 = regex_match(r"(?m)^### \S", file.text, "m") != nil
+  let h4 = regex_match(r"(?m)^#### \S", file.text, "m") != nil
+  let h5 = regex_match(r"(?m)^##### \S", file.text, "m") != nil
+  let h6 = regex_match(r"(?m)^###### \S", file.text, "m") != nil
+  return (h3 && !h2) || (h4 && !h3) || (h5 && !h4) || (h6 && !h5)
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_FENCE_LANGUAGE, confidence: 0.74, source_date: "2026-05-09")
+/** Warns when fenced code blocks open without a language tag. */
+pub fn code_fence_language_specified(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    production_markdown_files(slice),
+    { file -> regex_match(
+      r"(?m)^[ ]{0,3}```[ \t]*\n(?:(?![ ]{0,3}```)[^\n]*\n)+[ ]{0,3}```[ \t]*$",
+      file.text,
+      "m",
+    ) != nil },
+  )
+  return warn_on_findings(
+    "code_fence_language_specified",
+    "Tag fenced code blocks with a language (```ts, ```bash, ```text) so highlighters and screen readers can do their jobs.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_HEADING_LEVELS, confidence: 0.7, source_date: "2026-05-09")
+/** Warns on documents that use a heading level without the parent level present. */
+pub fn heading_level_discipline(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    production_markdown_files(slice),
+    { file -> has_heading_level_skip(file) },
+  )
+  return warn_on_findings(
+    "heading_level_discipline",
+    "Increment heading levels one at a time so screen readers and outlines stay coherent.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_SINGLE_H1, confidence: 0.78, source_date: "2026-05-09")
+/** Warns on documents that contain more than one top-level H1. */
+pub fn single_h1_per_doc(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    production_markdown_files(slice),
+    { file -> regex_match(r"(?m)^# [^\n]+\n[\s\S]*?\n# [^\n]+", file.text, "m") != nil },
+  )
+  return warn_on_findings(
+    "single_h1_per_doc",
+    "Use a single H1 as the document title; promote sibling sections to H2.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_IMAGE_ALT, confidence: 0.86, source_date: "2026-05-09")
+/** Blocks Markdown images that omit alternate text. */
+pub fn image_alt_text_present(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    production_markdown_files(slice),
+    { file -> regex_match(r"!\[[ \t]*\]\(", file.text, "") != nil },
+  )
+  return block_on_findings(
+    "image_alt_text_present",
+    "Add descriptive alt text inside the brackets, or use an empty alt only for purely decorative images that an assistive technology should skip.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_DANGEROUS_HTML, confidence: 0.82, source_date: "2026-05-09")
+/** Blocks raw HTML constructs that are common XSS sinks when Markdown is rendered without sanitization. */
+pub fn no_dangerous_inline_html(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    production_markdown_files(slice),
+    { file -> regex_match(
+      r"(?i)<\s*(script|iframe|object|embed|form)\b|\bjavascript:|\bon(click|load|error|focus|blur|submit|change|input|key[a-z]+|mouse[a-z]+)\s*=",
+      file.text,
+      "is",
+    ) != nil },
+  )
+  return block_on_findings(
+    "no_dangerous_inline_html",
+    "Drop raw <script>, <iframe>, javascript: URLs, and event handlers from Markdown; use links, code samples, or a vetted shortcode instead.",
+    findings,
+  )
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_BROKEN_LINKS, confidence: 0.66, source_date: "2026-05-09")
+/** Blocks changed Markdown that introduces relative links or anchors with no resolvable target. */
+pub fn no_broken_internal_links(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed Markdown introduces or modifies a relative path link, image reference, or fragment anchor whose target cannot be resolved against the slice plus repo_at_base. Anchor checks must compare the fragment to the rendered heading slugs in the destination Markdown file. Allow external URLs, mailto links, and links whose target is created in the same slice."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: markdown_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "no_broken_internal_links",
+      "Point the link at an existing path or heading anchor, or add the target file in the same change.",
+      judgement.findings,
+    )
+  }
+  return allow("no_broken_internal_links")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_LINK_STYLE, confidence: 0.6, source_date: "2026-05-09")
+/** Warns when a single document mixes inline, reference, and bare-URL link styles in ways that hurt readability. */
+pub fn consistent_link_format(slice, ctx, _repo_at_base) {
+  let rubric = "Warn only when a single changed Markdown document mixes inline links, full reference-style links, collapsed/shortcut reference links, and bare autolinks in ways that materially hurt readability. Do not flag single-style documents, code samples that show alternative syntaxes intentionally, or short-form patterns inside link tables."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: markdown_files(slice)})
+  if judgement.verdict == "Warn" {
+    return warn(
+      "consistent_link_format",
+      "Pick one link style per document and use it consistently; convert ad hoc bare URLs to titled inline or reference links.",
+      judgement.findings,
+    )
+  }
+  return allow("consistent_link_format")
+}


### PR DESCRIPTION
## Summary

- Adds the `markdown/` v0 seed predicate pack: 5 deterministic + 2 semantic predicates targeting prose Markdown files (`.md`, `.markdown`).
- Predicates: `code_fence_language_specified`, `heading_level_discipline`, `single_h1_per_doc`, `image_alt_text_present`, `no_dangerous_inline_html`, `no_broken_internal_links` (semantic), `consistent_link_format` (semantic).
- Each predicate carries an allow + block/warn fixture and an `@archivist` evidence bundle drawn from CommonMark 0.31.2, GFM, markdownlint rule docs, W3C WAI / WCAG 2.2, the OWASP XSS prevention cheat sheet, and the GitHub writing docs.

Closes #33.

## Test plan

- [ ] `evidence-links` placeholder CI job passes (no link checker yet).
- [ ] `fmt` placeholder CI job passes (no harn fmt yet).
- [ ] `fixture-replay` placeholder CI job passes (no runtime yet).
- [ ] Once a predicate runtime lands, replay each fixture and confirm Block/Warn/Allow expectations match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)