### PR TITLE
Add Terraform seed predicate pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ See the Harn Flow design docs for the full predicate language spec.
 - [Rust](./rust/) — v0 draft predicates for Rust application and library code.
 - [SQL](./sql/) — v0 draft predicates for schema, migration, and query safety.
 - [Swift](./swift/) — v0 draft predicates for Swift application and UI code.
+- [Terraform](./terraform/) — v0 draft predicates for Terraform configurations across AWS, Azure, and GCP providers.
 - [TOML](./toml/) — v0 draft predicates for TOML configuration documents (`Cargo.toml`, `pyproject.toml`, tool configs).
 - [TypeScript](./typescript/) — v0 draft predicates for TypeScript and TSX code.
 - [XML](./xml/) — v0 draft predicates for XML payloads, XSD schemas, XSLT stylesheets, and related XML-shaped formats.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,62 @@
+# Terraform Seed Predicate Pack
+
+This pack covers Terraform configurations (`.tf` files) for AWS, Azure, GCP, and other providers. Terraform's surface area is small enough that a v0 pack can target the highest-signal review issues directly: tagging hygiene, variable typing, remote state, version pinning, sensitive output handling, hardcoded secrets, and over-broad IAM grants.
+
+## Stack Assumptions
+
+- Source checks target HCL `.tf` files; `.tf.json`, `.tfvars`, override files, and `.terraform.lock.hcl` are out of scope for v0.
+- Production paths exclude `examples/`, `test/`, `tests/`, `testdata/`, and `.terraform/` working directories.
+- Projects target Terraform 1.x (or OpenTofu 1.x), so the modern `terraform { required_providers { ... = { source, version } } }` form is assumed; legacy bare-string provider declarations are not recognized.
+- Child modules conventionally live under a `modules/` path. The backend predicate uses that convention to scope itself to root-module files.
+- Deterministic predicates operate over changed source text until Flow exposes a stable HCL AST query API. Regex-based matching is intentionally conservative.
+- Semantic predicates may block only when the judge can cite a concrete changed span and the issue is not reliably expressible as a syntactic check.
+
+## Predicate Coverage
+
+| Predicate | Mode | Verdict | Purpose |
+|---|---|---|---|
+| `required_tags_on_resources` | deterministic | Warn | Cloud resources should carry `Owner`, `Env` (or `Environment`), and `CostCenter` tags via the resource tag map or provider `default_tags`. |
+| `variable_type_constraints_explicit` | deterministic | Warn | Every `variable` block should declare an explicit `type` constraint. |
+| `remote_state_backend_configured` | deterministic | Warn | Root-module files that declare `required_providers` should also configure a remote state backend. |
+| `module_registry_version_pinned` | deterministic | Block | Registry-sourced modules must pin a `version` constraint. |
+| `provider_versions_pinned` | deterministic | Block | Every `required_providers` entry must declare an explicit `version` constraint. |
+| `outputs_with_secret_names_marked_sensitive` | deterministic | Block | Outputs whose names suggest secrets, tokens, keys, or credentials must set `sensitive = true`. |
+| `no_hardcoded_secrets` | semantic | Block | Credentials, API keys, tokens, private keys, and production connection strings must not live in source. |
+| `iam_policies_avoid_wildcard_grants` | semantic | Block | IAM policy documents must not grant `Action = "*"` or `Resource = "*"` in unrestricted Allow statements. |
+
+## Evidence
+
+Evidence scanned on 2026-05-09.
+
+- HashiCorp Terraform language docs: input variables, type constraints, backends, remote state, module syntax and sources, expression version constraints, provider requirements, outputs, sensitive data in state, and provider configuration (including AWS `default_tags`).
+- HashiCorp Terraform Cloud recommended practices for shared remote state and version pinning.
+- AWS tagging best-practices whitepaper for `Owner` / `Env` / `CostCenter` style operational tag schemes.
+- Microsoft Azure Cloud Adoption Framework resource-tagging guidance.
+- Google Cloud Resource Manager tags overview.
+- OWASP Secrets Management Cheat Sheet and GitHub secret scanning documentation for hardcoded-credential risk.
+- AWS IAM, Microsoft Entra, and Google Cloud IAM least-privilege guidance for wildcard-grant avoidance.
+
+## Known False Positives
+
+- Regex predicates do not parse HCL. Multi-block files where some blocks satisfy a check and others do not may slip past file-scoped predicates until AST-level matching lands.
+- `required_tags_on_resources` is a Warn-level word-boundary check. Files that mention "owner", "env", or "costcenter" outside of tags (variable names, comments, locals) will silence the warning. Orgs with different tag standards should override this predicate locally.
+- `variable_type_constraints_explicit` warns at file granularity. A file with one untyped variable alongside several typed ones will not warn.
+- `remote_state_backend_configured` skips files under `/modules/` paths but cannot fully distinguish root from child modules in unconventional layouts. Configurations that split `terraform { required_providers }` and `terraform { backend }` across sibling files will warn on the providers file when it is changed alone.
+- `module_registry_version_pinned` recognizes the canonical registry source shape (`<NAMESPACE>/<NAME>/<PROVIDER>` or `<HOST>/<NAMESPACE>/<NAME>/<PROVIDER>`). Files that mix registry and local sources can mask a missing pin on the registry module.
+- `provider_versions_pinned` assumes the modern source/version map syntax. Legacy bare-string provider declarations (`aws = "~> 4.0"`) are not recognized.
+- `outputs_with_secret_names_marked_sensitive` is keyword-driven on output names. An output named neutrally that nonetheless leaks a secret is not caught here — the semantic `no_hardcoded_secrets` predicate complements this case.
+- The semantic predicates depend on a cheap judge. They should stay high-threshold and cite concrete changed spans before blocking.
+
+## Fixtures
+
+Each fixture in `fixtures/` contains one blocked or warned example and one allowed example for the corresponding predicate. The fixture shape matches the current harn-canon convention:
+
+```json
+{
+  "predicate": "name",
+  "cases": [
+    {"expect": "Block", "files": [{"path": "main.tf", "text": "..."}]},
+    {"expect": "Allow", "files": [{"path": "main.tf", "text": "..."}]}
+  ]
+}
+```

--- a/terraform/fixtures/iam_policies_avoid_wildcard_grants.json
+++ b/terraform/fixtures/iam_policies_avoid_wildcard_grants.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "iam_policies_avoid_wildcard_grants",
+  "cases": [
+    {
+      "name": "blocks_unrestricted_wildcard_action_and_resource",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "iam.tf",
+          "text": "data \"aws_iam_policy_document\" \"admin\" {\n  statement {\n    effect    = \"Allow\"\n    actions   = [\"*\"]\n    resources = [\"*\"]\n  }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_scoped_actions_and_resources",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "iam.tf",
+          "text": "data \"aws_iam_policy_document\" \"reader\" {\n  statement {\n    effect    = \"Allow\"\n    actions   = [\"s3:GetObject\", \"s3:ListBucket\"]\n    resources = [\n      aws_s3_bucket.logs.arn,\n      \"${aws_s3_bucket.logs.arn}/*\",\n    ]\n  }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/terraform/fixtures/module_registry_version_pinned.json
+++ b/terraform/fixtures/module_registry_version_pinned.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "module_registry_version_pinned",
+  "cases": [
+    {
+      "name": "blocks_registry_module_without_version",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "main.tf",
+          "text": "module \"vpc\" {\n  source = \"terraform-aws-modules/vpc/aws\"\n\n  name = \"acme-vpc\"\n  cidr = \"10.0.0.0/16\"\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_registry_module_with_pinned_version",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "main.tf",
+          "text": "module \"vpc\" {\n  source  = \"terraform-aws-modules/vpc/aws\"\n  version = \"~> 5.8\"\n\n  name = \"acme-vpc\"\n  cidr = \"10.0.0.0/16\"\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/terraform/fixtures/no_hardcoded_secrets.json
+++ b/terraform/fixtures/no_hardcoded_secrets.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_hardcoded_secrets",
+  "cases": [
+    {
+      "name": "blocks_hardcoded_provider_credential",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "providers.tf",
+          "text": "provider \"aws\" {\n  region     = \"us-east-1\"\n  access_key = \"AKIAIOSFODNN7EXAMPLE\"\n  secret_key = \"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY\"\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_credentials_via_sensitive_variable",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "providers.tf",
+          "text": "variable \"aws_access_key\" {\n  type      = string\n  sensitive = true\n}\n\nvariable \"aws_secret_key\" {\n  type      = string\n  sensitive = true\n}\n\nprovider \"aws\" {\n  region     = \"us-east-1\"\n  access_key = var.aws_access_key\n  secret_key = var.aws_secret_key\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/terraform/fixtures/outputs_with_secret_names_marked_sensitive.json
+++ b/terraform/fixtures/outputs_with_secret_names_marked_sensitive.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "outputs_with_secret_names_marked_sensitive",
+  "cases": [
+    {
+      "name": "blocks_secret_named_output_without_sensitive",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "outputs.tf",
+          "text": "output \"db_password\" {\n  value = aws_db_instance.main.password\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_secret_named_output_with_sensitive_true",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "outputs.tf",
+          "text": "output \"db_password\" {\n  value     = aws_db_instance.main.password\n  sensitive = true\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/terraform/fixtures/provider_versions_pinned.json
+++ b/terraform/fixtures/provider_versions_pinned.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "provider_versions_pinned",
+  "cases": [
+    {
+      "name": "blocks_required_providers_without_version",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "versions.tf",
+          "text": "terraform {\n  required_providers {\n    aws = {\n      source = \"hashicorp/aws\"\n    }\n  }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_required_providers_with_version",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "versions.tf",
+          "text": "terraform {\n  required_providers {\n    aws = {\n      source  = \"hashicorp/aws\"\n      version = \"~> 5.40\"\n    }\n  }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/terraform/fixtures/remote_state_backend_configured.json
+++ b/terraform/fixtures/remote_state_backend_configured.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "remote_state_backend_configured",
+  "cases": [
+    {
+      "name": "warns_when_root_module_lacks_backend",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "versions.tf",
+          "text": "terraform {\n  required_version = \">= 1.5\"\n\n  required_providers {\n    aws = {\n      source  = \"hashicorp/aws\"\n      version = \"~> 5.40\"\n    }\n  }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_when_backend_is_configured",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "versions.tf",
+          "text": "terraform {\n  required_version = \">= 1.5\"\n\n  required_providers {\n    aws = {\n      source  = \"hashicorp/aws\"\n      version = \"~> 5.40\"\n    }\n  }\n\n  backend \"s3\" {\n    bucket         = \"acme-tfstate\"\n    key            = \"prod/terraform.tfstate\"\n    region         = \"us-east-1\"\n    dynamodb_table = \"acme-tfstate-locks\"\n  }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/terraform/fixtures/required_tags_on_resources.json
+++ b/terraform/fixtures/required_tags_on_resources.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "required_tags_on_resources",
+  "cases": [
+    {
+      "name": "warns_when_resource_lacks_owner_env_costcenter",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "main.tf",
+          "text": "resource \"aws_s3_bucket\" \"logs\" {\n  bucket = \"acme-logs\"\n\n  tags = {\n    Service = \"billing\"\n  }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_when_required_tag_keys_present",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "main.tf",
+          "text": "resource \"aws_s3_bucket\" \"logs\" {\n  bucket = \"acme-logs\"\n\n  tags = {\n    Owner      = \"platform\"\n    Env        = \"prod\"\n    CostCenter = \"1234\"\n  }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/terraform/fixtures/variable_type_constraints_explicit.json
+++ b/terraform/fixtures/variable_type_constraints_explicit.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "variable_type_constraints_explicit",
+  "cases": [
+    {
+      "name": "warns_when_variable_block_omits_type",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "variables.tf",
+          "text": "variable \"region\" {\n  description = \"AWS region for the deployment.\"\n  default     = \"us-east-1\"\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_when_variable_block_declares_type",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "variables.tf",
+          "text": "variable \"region\" {\n  description = \"AWS region for the deployment.\"\n  type        = string\n  default     = \"us-east-1\"\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/terraform/invariants.harn
+++ b/terraform/invariants.harn
@@ -1,0 +1,266 @@
+let _EVIDENCE_TAGGING = [
+  "https://docs.aws.amazon.com/whitepapers/latest/tagging-best-practices/tagging-best-practices.html",
+  "https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/resource-tagging",
+  "https://cloud.google.com/resource-manager/docs/tags/tags-overview",
+  "https://developer.hashicorp.com/terraform/language/providers/configuration",
+]
+
+let _EVIDENCE_VAR_TYPES = [
+  "https://developer.hashicorp.com/terraform/language/values/variables",
+  "https://developer.hashicorp.com/terraform/language/expressions/types",
+]
+
+let _EVIDENCE_BACKEND = [
+  "https://developer.hashicorp.com/terraform/language/backend",
+  "https://developer.hashicorp.com/terraform/language/state/remote",
+  "https://developer.hashicorp.com/terraform/cloud-docs/recommended-practices/part1",
+]
+
+let _EVIDENCE_MODULE_VERSION = [
+  "https://developer.hashicorp.com/terraform/language/modules/syntax",
+  "https://developer.hashicorp.com/terraform/language/modules/sources",
+  "https://developer.hashicorp.com/terraform/language/expressions/version-constraints",
+]
+
+let _EVIDENCE_PROVIDER_VERSION = [
+  "https://developer.hashicorp.com/terraform/language/providers/requirements",
+  "https://developer.hashicorp.com/terraform/language/expressions/version-constraints",
+]
+
+let _EVIDENCE_OUTPUT_SENSITIVE = [
+  "https://developer.hashicorp.com/terraform/language/values/outputs",
+  "https://developer.hashicorp.com/terraform/language/state/sensitive-data",
+]
+
+let _EVIDENCE_SECRETS = [
+  "https://developer.hashicorp.com/terraform/language/state/sensitive-data",
+  "https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html",
+  "https://docs.github.com/code-security/secret-scanning/about-secret-scanning",
+]
+
+let _EVIDENCE_IAM_LEAST_PRIV = [
+  "https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html",
+  "https://learn.microsoft.com/en-us/entra/identity-platform/secure-least-privileged-access",
+  "https://cloud.google.com/iam/docs/using-iam-securely",
+]
+
+fn is_tf_path(path) {
+  return path.ends_with(".tf")
+}
+
+fn is_test_path(path) {
+  return contains(path, "/examples/")
+    || contains(path, "/example/")
+    || contains(path, "/test/")
+    || contains(path, "/tests/")
+    || contains(path, "/testdata/")
+    || contains(path, "/.terraform/")
+}
+
+fn tf_files(slice) {
+  return slice.files.filter({ file -> is_tf_path(file.path) })
+}
+
+fn production_tf_files(slice) {
+  return tf_files(slice).filter({ file -> !is_test_path(file.path) })
+}
+
+fn scan_files(files, pattern) {
+  var findings = []
+  for file in files {
+    if regex_match(pattern, file.text, "s") != nil {
+      findings = findings.push({path: file.path, pattern: pattern})
+    }
+  }
+  return findings
+}
+
+fn scan_files_if(files, predicate) {
+  var findings = []
+  for file in files {
+    if predicate(file.text) {
+      findings = findings.push({path: file.path})
+    }
+  }
+  return findings
+}
+
+fn allow(rule) {
+  return {verdict: "Allow", rule: rule, findings: [], remediation: ""}
+}
+
+fn warn(rule, remediation, findings) {
+  return {verdict: "Warn", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block(rule, remediation, findings) {
+  return {verdict: "Block", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return block(rule, remediation, findings)
+}
+
+fn warn_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return warn(rule, remediation, findings)
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_TAGGING, confidence: 0.6, source_date: "2026-05-09")
+/** Warns when changed Terraform files declare cloud resources without Owner, Env, and CostCenter tags. */
+pub fn required_tags_on_resources(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    production_tf_files(slice),
+    { text -> regex_match(r'(?m)^\s*resource\s+"(aws_|azurerm_|google_)', text, "m") != nil
+      && (regex_match(r"(?i)\bowner\b", text, "s") == nil
+      || regex_match(r"(?i)\b(env|environment)\b", text, "s") == nil
+      || regex_match(r"(?i)\b(costcenter|cost[_-]?center)\b", text, "s") == nil) },
+  )
+  return warn_on_findings(
+    "required_tags_on_resources",
+    "Tag cloud resources with Owner, Env, and CostCenter via the resource tags map or provider default_tags.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_VAR_TYPES, confidence: 0.74, source_date: "2026-05-09")
+/** Warns when changed Terraform files declare variable blocks without an explicit type constraint. */
+pub fn variable_type_constraints_explicit(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    production_tf_files(slice),
+    { text -> regex_match(r'(?m)^\s*variable\s+"[^"]+"\s*\{', text, "m") != nil
+      && regex_match(r"(?m)^\s*type\s*=", text, "m") == nil },
+  )
+  return warn_on_findings(
+    "variable_type_constraints_explicit",
+    "Declare an explicit type for each variable block, for example type = string or type = object({ ... }).",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_BACKEND, confidence: 0.6, source_date: "2026-05-09")
+/** Warns when a root-module file declares required_providers without configuring a remote state backend. */
+pub fn remote_state_backend_configured(slice, _ctx, _repo_at_base) {
+  var findings = []
+  for file in production_tf_files(slice) {
+    if !contains(file.path, "/modules/")
+      && regex_match(r"required_providers\s*\{", file.text, "s") != nil
+      && regex_match(r'(?m)^\s*backend\s+"[^"]+"\s*\{', file.text, "m") == nil {
+      findings = findings.push({path: file.path})
+    }
+  }
+  return warn_on_findings(
+    "remote_state_backend_configured",
+    "Configure a remote state backend (S3, GCS, Azure RM, HCP Terraform, etc.) for shared state and locking.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_MODULE_VERSION, confidence: 0.78, source_date: "2026-05-09")
+/** Blocks module blocks that pull from a registry source without pinning a version constraint. */
+pub fn module_registry_version_pinned(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    production_tf_files(slice),
+    { text -> regex_match(r'(?m)^\s*module\s+"[^"]+"\s*\{', text, "m") != nil
+      && regex_match(r'source\s*=\s*"[A-Za-z0-9_-][A-Za-z0-9_.-]*(?:/[A-Za-z0-9_.-]+){2,3}"', text, "s")
+      != nil
+      && regex_match(
+      r'source\s*=\s*"(?:\./|\.\./|git::|s3::|gcs::|hg::|github\.com/|bitbucket\.org/|gitlab\.com/|https?://)',
+      text,
+      "s",
+    )
+      == nil
+      && regex_match(r"(?m)^\s*version\s*=", text, "m") == nil },
+  )
+  return block_on_findings(
+    "module_registry_version_pinned",
+    "Pin registry-sourced modules with a version constraint such as version = \"~> 1.2\" to keep upgrades intentional.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_PROVIDER_VERSION, confidence: 0.74, source_date: "2026-05-09")
+/** Blocks required_providers declarations that omit a version constraint for at least one provider. */
+pub fn provider_versions_pinned(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    production_tf_files(slice),
+    { text -> regex_match(r"required_providers\s*\{", text, "s") != nil
+      && regex_match(r"(?m)^\s*version\s*=", text, "m") == nil },
+  )
+  return block_on_findings(
+    "provider_versions_pinned",
+    "Pin every required_providers entry with a version constraint to keep provider upgrades reviewable.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_OUTPUT_SENSITIVE, confidence: 0.74, source_date: "2026-05-09")
+/** Blocks output blocks whose names suggest secrets when sensitive = true is missing. */
+pub fn outputs_with_secret_names_marked_sensitive(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    production_tf_files(slice),
+    { text -> regex_match(
+      r'(?im)^\s*output\s+"[A-Za-z0-9_-]*(?:password|secret|token|api[_-]?key|private[_-]?key|credential)[A-Za-z0-9_-]*"\s*\{',
+      text,
+      "m",
+    )
+      != nil
+      && regex_match(r"sensitive\s*=\s*true", text, "s") == nil },
+  )
+  return block_on_findings(
+    "outputs_with_secret_names_marked_sensitive",
+    "Mark outputs that carry secrets, tokens, or keys with sensitive = true so values stay redacted.",
+    findings,
+  )
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_SECRETS, confidence: 0.66, source_date: "2026-05-09")
+/** Blocks hardcoded credentials, tokens, and private keys in Terraform source. */
+pub fn no_hardcoded_secrets(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed Terraform embeds a credential, API key, token, private key, signing secret, password, or production connection string instead of reading it from a sensitive variable, AWS Secrets Manager, HashiCorp Vault, GCP Secret Manager, Azure Key Vault, or scoped environment lookup."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: tf_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "no_hardcoded_secrets",
+      "Move secrets to a managed secret source and reference them via sensitive variables or data sources.",
+      judgement.findings,
+    )
+  }
+  return allow("no_hardcoded_secrets")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_IAM_LEAST_PRIV, confidence: 0.62, source_date: "2026-05-09")
+/** Blocks IAM policy documents that grant unscoped wildcard actions or resources without justification. */
+pub fn iam_policies_avoid_wildcard_grants(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed Terraform IAM policy documents (aws_iam_policy_document, aws_iam_policy, aws_iam_role_policy, azurerm_role_definition, google_project_iam_*, google_organization_iam_*) allow Action = \"*\" or Resource = \"*\" or equivalent unrestricted wildcards in an Allow statement, with no narrowing Condition or service-scoped wildcard."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: tf_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "iam_policies_avoid_wildcard_grants",
+      "Scope IAM Action and Resource to specific service operations and ARNs, or add a narrow Condition.",
+      judgement.findings,
+    )
+  }
+  return allow("iam_policies_avoid_wildcard_grants")
+}


### PR DESCRIPTION
## Summary

- Adds a v0 Terraform seed predicate pack with 6 deterministic and 2 semantic predicates covering tagging, variable typing, remote state, version pinning, sensitive outputs, hardcoded secrets, and over-broad IAM grants.
- Documents Terraform stack assumptions, evidence sources, predicate coverage table, and known false positives.
- Adds allow/block (or allow/warn) fixtures for every predicate and links the pack from the repo README.

Closes #27

## Verification

- `python3 -c "import json; [json.load(open(p)) for p in glob.glob('terraform/fixtures/*.json')]"` — all fixtures parse as valid JSON.
- Local Python re-implementation of every deterministic predicate replayed against each fixture: every Block/Warn/Allow case produced the expected verdict.
- `curl -sIL` HEAD-check against every URL in `terraform/invariants.harn`: all 20 evidence URLs return 200.
- `git diff --check origin/main..HEAD` clean; rebased on the latest `origin/main` after CSS/JSON/TOML/XML packs landed.

## Notes

- `module_version_pinned` from the issue spec is implemented as `module_registry_version_pinned`. The narrower name reflects the rule: only registry-sourced modules require a `version =` argument; local, git, and protocol-prefixed sources should not be flagged. README documents the false-negative case where a file mixes registry and local modules.
- Predicate `provider_versions_pinned` is added to enforce the `required_providers { ... = { source, version } }` modern syntax. Legacy bare-string provider declarations are intentionally not recognized; the README calls this out under known false positives.
- `remote_state_backend_configured` skips files under `/modules/` paths to avoid false positives on child modules that legitimately declare `required_providers` without a backend.
- The repo's CI checks for evidence-link, fmt, and fixture replay are placeholder jobs, so this PR was verified locally with the methods above.