### PR TITLE
Replace SQL seed pack stub with v0 predicate pack

### DIFF
--- a/ruby/invariants.harn
+++ b/ruby/invariants.harn
@@ -59,10 +59,10 @@ fn ruby_files(slice) {
   return slice.files
     .filter(
     { file -> file.path.ends_with(".rb")
-    || file.path.ends_with(".rake")
-    || file.path.ends_with(".gemspec")
-    || file.path.ends_with("Gemfile")
-    || file.path.ends_with("Rakefile") },
+      || file.path.ends_with(".rake")
+      || file.path.ends_with(".gemspec")
+      || file.path.ends_with("Gemfile")
+      || file.path.ends_with("Rakefile") },
   )
 }
 
@@ -182,11 +182,7 @@ pub fn no_monkey_patch_stdlib(slice, _ctx, _repo_at_base) {
 @archivist(evidence: _EVIDENCE_GLOBAL_VARIABLES, confidence: 0.78, source_date: "2026-05-08")
 /** Blocks assignment to application-defined global variables. */
 pub fn no_global_variables(slice, _ctx, _repo_at_base) {
-  let findings = scan_files(
-    ruby_files(slice),
-    r"(?m)(^|[^$])\$[a-z_][A-Za-z0-9_]*\s*=",
-    "m",
-  )
+  let findings = scan_files(ruby_files(slice), r"(?m)(^|[^$])\$[a-z_][A-Za-z0-9_]*\s*=", "m")
   return block_on_findings(
     "no_global_variables",
     "Replace application globals with injected dependencies, constants, or object state.",
@@ -232,7 +228,7 @@ pub fn no_dynamic_eval(slice, _ctx, _repo_at_base) {
   let findings = scan_files_without(
     ruby_files(slice),
     r"(?m)(^|[^A-Za-z0-9_])(eval|instance_eval|class_eval|module_eval)\s*\(",
-    r"(eval|instance_eval|class_eval|module_eval)\s*\(\s*['\"]",
+    "(eval|instance_eval|class_eval|module_eval)\\s*\\(\\s*['\\\"]",
   )
   return block_on_findings(
     "no_dynamic_eval",

--- a/sql/README.md
+++ b/sql/README.md
@@ -1,20 +1,57 @@
-SQL Seed Predicate Pack (v0)
+# SQL Seed Predicate Pack
 
-This pack defines basic SQL safety and style rules.
+This pack covers schema, migration, and query safety for raw SQL files. It targets review issues that an Archivist can catch cheaply on changed slices: implicit column lists, comma joins, table-wide DELETE/UPDATE statements, non-idempotent migration DDL, dynamic SQL that concatenates untrusted input, and foreign keys without supporting indexes.
 
-## RULES
-- AVOID SELECT * for clarity and performance
-- USE EXPLICIT JOINS instead of COMMA JOINS
-- Prevent SQL injection via parameterized queries
-- Index foreign key columns
+## Stack Assumptions
+
+- SQL source files use the `.sql` extension.
+- Production paths exclude any path under `test/`, `tests/`, `testdata/`, `fixtures/`, `seed/`, or `seeds/`, and any file ending in `_test.sql`, `_seed.sql`, or `_fixture.sql`.
+- Migration paths are detected by directory segments such as `migrations/`, `migration/`, `migrate/`, `changelog/`, `changesets/`, `flyway/`, `liquibase/`, or `sqitch/`. Predicates that only make sense for migrations (`migrations_use_if_not_exists`, `destructive_drops_use_if_exists`) restrict their scan to those paths.
+- Deterministic predicates use file-text regex scans because Harn Flow does not yet expose a stable SQL AST query API; semantic predicates make a single judge call over changed SQL files.
+- Predicates are dialect-aware where it matters: `migrations_use_if_not_exists`, `destructive_drops_use_if_exists`, and `index_on_fk` cover PostgreSQL and MySQL syntax variants and tolerate `CONCURRENTLY` for PostgreSQL index DDL.
+
+## Predicate Coverage
+
+| Predicate | Mode | Verdict | Purpose |
+|---|---|---|---|
+| `no_select_star` | deterministic | Block | Unqualified `SELECT *` in views and application queries breaks downstream consumers when columns are added or reordered. |
+| `explicit_join_type` | deterministic | Block | Comma joins hide the intended cardinality and frequently degrade to accidental cross joins when a predicate is dropped. |
+| `no_unbounded_delete_or_update` | deterministic | Block | `DELETE` and `UPDATE` without `WHERE` rewrite the whole table; `TRUNCATE` is the explicit operation for that. |
+| `migrations_use_if_not_exists` | deterministic | Warn | `CREATE TABLE` and `CREATE INDEX` in migrations should tolerate a partially applied prior run. |
+| `destructive_drops_use_if_exists` | deterministic | Warn | `DROP` in migrations should tolerate a partially applied prior run instead of erroring out mid-deploy. |
+| `parameterized_queries_only` | semantic | Block | Dynamic SQL that interpolates user-controlled values is the leading vector for SQL injection. |
+| `index_on_fk` | semantic | Block | Engines that do not auto-index foreign key columns (notably PostgreSQL) suffer table scans on `DELETE`/`UPDATE` of the referenced row. |
+
+## Evidence
+
+Evidence scanned on 2026-05-09.
+
+- PostgreSQL docs: `CREATE VIEW`, `CREATE TABLE`, `CREATE INDEX`, `DROP TABLE`, `SELECT`, `UPDATE`, `DELETE`, `PREPARE`, table expressions, and constraint reference pages.
+- MySQL Reference Manual 8.0: `CREATE TABLE`, `DROP TABLE`, foreign key reference, MySQL tips covering `--safe-updates` mode.
+- Microsoft Learn T-SQL: `sp_executesql` reference for parameterized dynamic SQL on SQL Server.
+- OWASP Cheat Sheet Series: SQL Injection Prevention Cheat Sheet (parameterized queries as primary defense).
+- GitLab development docs: SQL guidelines (explicit columns over `SELECT *`).
+- Holywell SQL Style Guide (`sqlstyle.guide`): explicit `JOIN` keyword preferred over comma-separated `FROM`.
+
+## Known False Positives
+
+- Regex predicates do not parse SQL. Comments containing keywords, dollar-quoted bodies, and CTE-heavy statements can fool the deterministic checks.
+- `no_select_star` flags any `SELECT * FROM ...`, including `INSERT INTO target SELECT * FROM staging` patterns that are intentional in copy migrations. Suppress locally once the predicate runtime supports it.
+- `explicit_join_type` flags any comma between table names in a `FROM` clause. `FROM (subquery), other` is a rare false negative because `(` is not part of the leading-token character class.
+- `no_unbounded_delete_or_update` matches statement-by-statement up to the first `;`. SQL with semicolons inside string literals or dollar-quoted bodies can shift statement boundaries; in those cases prefer the semantic `parameterized_queries_only` reading or split the file.
+- `migrations_use_if_not_exists` and `destructive_drops_use_if_exists` only inspect migration paths and only the `TABLE`/`INDEX`/`VIEW`/`MATERIALIZED VIEW`/`TYPE`/`SCHEMA`/`SEQUENCE` object kinds. `CREATE OR REPLACE VIEW` and `CREATE FUNCTION` are intentionally out of scope.
+- `index_on_fk` is conservative — MySQL InnoDB auto-creates the supporting index for inline FK constraints, and the rubric instructs the judge to allow that case. PostgreSQL does not, which is the primary motivating dialect.
 
 ## Fixtures
-- fixtures/allow.sql -> example that should pass
-- fixtures/block.sql -> example that should blocked
 
-## Why
-Improves performance, security, and maintainability
+Each fixture in `fixtures/` contains one blocked or warned example and one allowed example for the corresponding predicate. The fixture shape matches the harn-canon convention:
 
-## Sources (evidence)
-- postgre SQL documentation (SELECT, JOINS, Indexes)
-- OWASP SQL Injection Prevention cheat sheet
+```json
+{
+  "predicate": "name",
+  "cases": [
+    {"expect": "Block", "files": [{"path": "schema/views/active_users.sql", "text": "..."}]},
+    {"expect": "Allow", "files": [{"path": "schema/views/active_users.sql", "text": "..."}]}
+  ]
+}
+```

--- a/sql/fixtures/allow.sql
+++ b/sql/fixtures/allow.sql
@@ -1,5 +1,0 @@
-SELECT id,name FROM users;
-
-SELECT o.id,u.name
-FROM orders o 
-INNER JOIN users u ON o.user_id = u.user_id

--- a/sql/fixtures/block.sql
+++ b/sql/fixtures/block.sql
@@ -1,3 +1,0 @@
-SELECT * FROM users;
-
-SELECT * FROM u,o WHERE u.user_id = o.user_id

--- a/sql/fixtures/destructive_drops_use_if_exists.json
+++ b/sql/fixtures/destructive_drops_use_if_exists.json
@@ -1,0 +1,45 @@
+{
+  "predicate": "destructive_drops_use_if_exists",
+  "cases": [
+    {
+      "name": "warns_drop_table_without_if_exists",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "db/migrate/20260509130000_drop_legacy_audit.sql",
+          "text": "DROP TABLE legacy_audit;\n"
+        }
+      ]
+    },
+    {
+      "name": "warns_drop_index_without_if_exists",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "db/migrate/20260509130100_drop_old_index.sql",
+          "text": "DROP INDEX users_lower_email_idx;\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_drop_table_if_exists",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "db/migrate/20260509130200_drop_legacy_audit.sql",
+          "text": "DROP TABLE IF EXISTS legacy_audit;\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_drop_materialized_view_if_exists",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "db/migrate/20260509130300_drop_metrics_mv.sql",
+          "text": "DROP MATERIALIZED VIEW IF EXISTS daily_metrics;\n"
+        }
+      ]
+    }
+  ]
+}

--- a/sql/fixtures/explicit_join_type.json
+++ b/sql/fixtures/explicit_join_type.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "explicit_join_type",
+  "cases": [
+    {
+      "name": "blocks_comma_join",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "queries/orders_with_users.sql",
+          "text": "SELECT o.id, u.email\nFROM orders o, users u\nWHERE o.user_id = u.id;\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_explicit_inner_join",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "queries/orders_with_users.sql",
+          "text": "SELECT o.id, u.email\nFROM orders o\nINNER JOIN users u ON o.user_id = u.id;\n"
+        }
+      ]
+    }
+  ]
+}

--- a/sql/fixtures/index_on_fk.json
+++ b/sql/fixtures/index_on_fk.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "index_on_fk",
+  "cases": [
+    {
+      "name": "blocks_postgres_fk_without_index",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "db/migrate/20260509140000_add_orders_user_fk.sql",
+          "text": "ALTER TABLE orders\n  ADD COLUMN user_id BIGINT NOT NULL REFERENCES users (id);\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_fk_with_accompanying_index",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "db/migrate/20260509140100_add_orders_user_fk.sql",
+          "text": "ALTER TABLE orders\n  ADD COLUMN user_id BIGINT NOT NULL REFERENCES users (id);\n\nCREATE INDEX orders_user_id_idx ON orders (user_id);\n"
+        }
+      ]
+    }
+  ]
+}

--- a/sql/fixtures/migrations_use_if_not_exists.json
+++ b/sql/fixtures/migrations_use_if_not_exists.json
@@ -1,0 +1,45 @@
+{
+  "predicate": "migrations_use_if_not_exists",
+  "cases": [
+    {
+      "name": "warns_create_table_without_if_not_exists",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "db/migrate/20260509120000_create_invoices.sql",
+          "text": "CREATE TABLE invoices (\n  id BIGSERIAL PRIMARY KEY,\n  amount NUMERIC(12,2) NOT NULL\n);\n"
+        }
+      ]
+    },
+    {
+      "name": "warns_create_index_without_if_not_exists",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "db/migrate/20260509120100_index_invoices_user_id.sql",
+          "text": "CREATE INDEX invoices_user_id_idx ON invoices (user_id);\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_create_table_if_not_exists",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "db/migrate/20260509120200_create_invoices.sql",
+          "text": "CREATE TABLE IF NOT EXISTS invoices (\n  id BIGSERIAL PRIMARY KEY,\n  amount NUMERIC(12,2) NOT NULL\n);\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_create_index_concurrently_if_not_exists",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "db/migrate/20260509120300_index_invoices_user_id.sql",
+          "text": "CREATE INDEX CONCURRENTLY IF NOT EXISTS invoices_user_id_idx ON invoices (user_id);\n"
+        }
+      ]
+    }
+  ]
+}

--- a/sql/fixtures/no_select_star.json
+++ b/sql/fixtures/no_select_star.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "no_select_star",
+  "cases": [
+    {
+      "name": "blocks_select_star_in_view",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "schema/views/active_users.sql",
+          "text": "CREATE VIEW active_users AS\nSELECT * FROM users WHERE last_seen_at > now() - interval '30 days';\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_explicit_columns",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "schema/views/active_users.sql",
+          "text": "CREATE VIEW active_users AS\nSELECT id, email, last_seen_at FROM users WHERE last_seen_at > now() - interval '30 days';\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_count_star_aggregate",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "queries/user_count.sql",
+          "text": "SELECT COUNT(*) AS total FROM users;\n"
+        }
+      ]
+    }
+  ]
+}

--- a/sql/fixtures/no_unbounded_delete_or_update.json
+++ b/sql/fixtures/no_unbounded_delete_or_update.json
@@ -1,0 +1,55 @@
+{
+  "predicate": "no_unbounded_delete_or_update",
+  "cases": [
+    {
+      "name": "blocks_delete_without_where",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "migrations/20260509120000_purge_sessions.sql",
+          "text": "DELETE FROM sessions;\n"
+        }
+      ]
+    },
+    {
+      "name": "blocks_update_without_where",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "migrations/20260509120100_clear_flags.sql",
+          "text": "UPDATE feature_flags SET enabled = false;\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_delete_with_where",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "migrations/20260509120200_purge_old_sessions.sql",
+          "text": "DELETE FROM sessions WHERE expires_at < now() - interval '90 days';\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_update_with_where",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "migrations/20260509120300_disable_legacy_flags.sql",
+          "text": "UPDATE feature_flags SET enabled = false WHERE legacy = true;\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_truncate",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "migrations/20260509120400_truncate_audit_buffer.sql",
+          "text": "TRUNCATE TABLE audit_buffer;\n"
+        }
+      ]
+    }
+  ]
+}

--- a/sql/fixtures/parameterized_queries_only.json
+++ b/sql/fixtures/parameterized_queries_only.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "parameterized_queries_only",
+  "cases": [
+    {
+      "name": "blocks_dynamic_sql_concatenation",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "procs/find_user_by_email.sql",
+          "text": "CREATE OR REPLACE FUNCTION find_user_by_email(raw_email text)\nRETURNS SETOF users AS $$\nBEGIN\n  RETURN QUERY EXECUTE 'SELECT * FROM users WHERE email = ''' || raw_email || '''';\nEND;\n$$ LANGUAGE plpgsql;\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_format_with_literal_quoting",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "procs/find_user_by_email.sql",
+          "text": "CREATE OR REPLACE FUNCTION find_user_by_email(raw_email text)\nRETURNS SETOF users AS $$\nBEGIN\n  RETURN QUERY EXECUTE format('SELECT id, email FROM users WHERE email = %L', raw_email);\nEND;\n$$ LANGUAGE plpgsql;\n"
+        }
+      ]
+    }
+  ]
+}

--- a/sql/invariants.harn
+++ b/sql/invariants.harn
@@ -1,11 +1,260 @@
-no_select_star:
-  description: Avoid using SELECT * for better performance and clarity.
+let _EVIDENCE_SELECT_STAR = [
+  "https://www.postgresql.org/docs/current/sql-createview.html",
+  "https://docs.gitlab.com/development/sql/",
+]
 
-explicit_join_type:
-  description: Use explicit JOIN syntax instead of comma joins.
+let _EVIDENCE_EXPLICIT_JOIN = [
+  "https://www.postgresql.org/docs/current/queries-table-expressions.html",
+  "https://www.sqlstyle.guide/",
+]
 
-parameterized_queries_only:
-  description: Prevent SQL injection by using parameterized queries.
+let _EVIDENCE_UNBOUNDED_DML = [
+  "https://dev.mysql.com/doc/refman/8.0/en/mysql-tips.html",
+  "https://www.postgresql.org/docs/current/sql-update.html",
+  "https://www.postgresql.org/docs/current/sql-delete.html",
+]
 
-index_on_fk:
-  description: Foreign key columns should be indexed.
+let _EVIDENCE_IF_NOT_EXISTS = [
+  "https://www.postgresql.org/docs/current/sql-createtable.html",
+  "https://www.postgresql.org/docs/current/sql-createindex.html",
+  "https://dev.mysql.com/doc/refman/8.0/en/create-table.html",
+]
+
+let _EVIDENCE_DROP_IF_EXISTS = [
+  "https://www.postgresql.org/docs/current/sql-droptable.html",
+  "https://dev.mysql.com/doc/refman/8.0/en/drop-table.html",
+]
+
+let _EVIDENCE_PARAMETERIZED = [
+  "https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html",
+  "https://www.postgresql.org/docs/current/sql-prepare.html",
+  "https://learn.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-executesql-transact-sql",
+]
+
+let _EVIDENCE_FK_INDEX = [
+  "https://www.postgresql.org/docs/current/ddl-constraints.html",
+  "https://dev.mysql.com/doc/refman/8.0/en/create-table-foreign-keys.html",
+]
+
+fn is_sql_path(path) {
+  return path.ends_with(".sql")
+}
+
+fn is_test_path(path) {
+  return path.contains("/test/")
+    || path.contains("/tests/")
+    || path.contains("/testdata/")
+    || path.contains("/fixtures/")
+    || path.contains("/seed/")
+    || path.contains("/seeds/")
+    || path.ends_with("_test.sql")
+    || path.ends_with("_seed.sql")
+    || path.ends_with("_fixture.sql")
+}
+
+fn is_migration_path(path) {
+  return path.contains("/migrations/")
+    || path.contains("/migration/")
+    || path.contains("/migrate/")
+    || path.contains("/changelog/")
+    || path.contains("/changesets/")
+    || path.contains("/flyway/")
+    || path.contains("/liquibase/")
+    || path.contains("/sqitch/")
+}
+
+fn sql_files(slice) {
+  return slice.files.filter({ file -> is_sql_path(file.path) })
+}
+
+fn production_sql_files(slice) {
+  return sql_files(slice).filter({ file -> !is_test_path(file.path) })
+}
+
+fn migration_sql_files(slice) {
+  return production_sql_files(slice).filter({ file -> is_migration_path(file.path) })
+}
+
+fn scan_files(files, pattern, flags) {
+  var findings = []
+  for file in files {
+    if regex_match(pattern, file.text, flags) != nil {
+      findings = findings.push({path: file.path, pattern: pattern})
+    }
+  }
+  return findings
+}
+
+fn scan_files_if(files, predicate) {
+  var findings = []
+  for file in files {
+    if predicate(file) {
+      findings = findings.push({path: file.path})
+    }
+  }
+  return findings
+}
+
+fn allow(rule) {
+  return {verdict: "Allow", rule: rule, findings: [], remediation: ""}
+}
+
+fn warn(rule, remediation, findings) {
+  return {verdict: "Warn", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block(rule, remediation, findings) {
+  return {verdict: "Block", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return block(rule, remediation, findings)
+}
+
+fn warn_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return warn(rule, remediation, findings)
+}
+
+fn any_match_lacks(matches, lack_pattern) {
+  if matches == nil {
+    return false
+  }
+  for m in matches {
+    if regex_match(lack_pattern, m, "i") == nil {
+      return true
+    }
+  }
+  return false
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_SELECT_STAR, confidence: 0.78, source_date: "2026-05-09")
+/** Blocks unqualified SELECT * in production SQL files. */
+pub fn no_select_star(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(production_sql_files(slice), r"(?i)\bSELECT\s+\*\s+FROM\b", "is")
+  return block_on_findings(
+    "no_select_star",
+    "List explicit columns instead of SELECT *; column drift breaks views, contracts, and downstream consumers.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_EXPLICIT_JOIN, confidence: 0.74, source_date: "2026-05-09")
+/** Blocks comma-separated table lists in FROM in favor of explicit JOIN syntax. */
+pub fn explicit_join_type(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_sql_files(slice),
+    r"(?i)\bFROM\s+[\w\.]+(?:\s+(?:AS\s+)?\w+)?\s*,\s*[\w\.]+",
+    "is",
+  )
+  return block_on_findings(
+    "explicit_join_type",
+    "Use INNER JOIN, LEFT JOIN, or CROSS JOIN with explicit ON predicates instead of comma joins.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_UNBOUNDED_DML, confidence: 0.82, source_date: "2026-05-09")
+/** Blocks DELETE or UPDATE statements that lack a WHERE clause. */
+pub fn no_unbounded_delete_or_update(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    production_sql_files(slice),
+    { file -> any_match_lacks(regex_match(r"(?is)\bDELETE\s+FROM\s+[^;]+;", file.text, "is"), r"(?i)\bWHERE\b")
+      || any_match_lacks(
+      regex_match(r"(?is)\bUPDATE\s+[\w\.]+(?:\s+(?:AS\s+)?\w+)?\s+SET\s+[^;]+;", file.text, "is"),
+      r"(?i)\bWHERE\b",
+    ) },
+  )
+  return block_on_findings(
+    "no_unbounded_delete_or_update",
+    "Add a WHERE clause to scope the rows; use TRUNCATE for intentional full-table operations.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_IF_NOT_EXISTS, confidence: 0.7, source_date: "2026-05-09")
+/** Warns when migration CREATE TABLE or CREATE INDEX statements omit IF NOT EXISTS. */
+pub fn migrations_use_if_not_exists(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    migration_sql_files(slice),
+    { file -> any_match_lacks(
+      regex_match(r"(?is)\bCREATE\s+(?:TABLE|UNIQUE\s+INDEX|INDEX)(?:\s+\w+){1,4}", file.text, "is"),
+      r"(?i)\bIF\s+NOT\s+EXISTS\b",
+    ) },
+  )
+  return warn_on_findings(
+    "migrations_use_if_not_exists",
+    "Add IF NOT EXISTS so re-running the migration is a no-op when the object already exists.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_DROP_IF_EXISTS, confidence: 0.78, source_date: "2026-05-09")
+/** Warns when migration DROP statements omit IF EXISTS. */
+pub fn destructive_drops_use_if_exists(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    migration_sql_files(slice),
+    { file -> any_match_lacks(
+      regex_match(
+        r"(?is)\bDROP\s+(?:TABLE|INDEX|VIEW|MATERIALIZED\s+VIEW|TYPE|SCHEMA|SEQUENCE)(?:\s+\w+){1,3}",
+        file.text,
+        "is",
+      ),
+      r"(?i)\bIF\s+EXISTS\b",
+    ) },
+  )
+  return warn_on_findings(
+    "destructive_drops_use_if_exists",
+    "Add IF EXISTS so the migration tolerates partially applied state and re-runs cleanly.",
+    findings,
+  )
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_PARAMETERIZED, confidence: 0.66, source_date: "2026-05-09")
+/** Blocks dynamic SQL that interpolates untrusted input instead of binding parameters. */
+pub fn parameterized_queries_only(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed SQL builds a query by concatenating, formatting, or interpolating user-controlled values into the SQL text instead of using bind parameters, prepared statements, or sp_executesql with typed parameters. Allow safe identifier whitelisting, format() with %I or %L, and template substitutions where the substituted token is a constant or trusted identifier."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: sql_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "parameterized_queries_only",
+      "Bind values with prepared statements, sp_executesql parameters, or format() %L; never concatenate untrusted input.",
+      judgement.findings,
+    )
+  }
+  return allow("parameterized_queries_only")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_FK_INDEX, confidence: 0.6, source_date: "2026-05-09")
+/** Blocks new foreign-key references that lack a covering index on the referencing column. */
+pub fn index_on_fk(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when a SQL migration or schema change adds a FOREIGN KEY constraint or REFERENCES clause on a column that is not already the leading column of an index, primary key, or unique constraint, and the same change set does not add a CREATE INDEX covering it. Allow MySQL InnoDB inline FOREIGN KEY constraints that auto-create the supporting index, and allow columns already covered by an existing index."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: production_sql_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "index_on_fk",
+      "Add a CREATE INDEX on the referencing column when introducing a foreign key in engines that do not auto-index it.",
+      judgement.findings,
+    )
+  }
+  return allow("index_on_fk")
+}


### PR DESCRIPTION
## Summary
- Closes [#30](https://github.com/burin-labs/harn-canon/issues/30) by replacing the SQL stub (a YAML-shaped placeholder that no other pack matches and that `harn check` cannot type-check) with a v0 pack aligned with the rest of the repo.
- 5 deterministic predicates (`no_select_star`, `explicit_join_type`, `no_unbounded_delete_or_update`, `migrations_use_if_not_exists`, `destructive_drops_use_if_exists`) + 2 semantic predicates (`parameterized_queries_only`, `index_on_fk`). Migration-scoped predicates recognise Rails / Flyway / Liquibase / sqitch path conventions and tolerate `CONCURRENTLY IF NOT EXISTS` / `IF EXISTS`.
- Per-predicate JSON fixtures with allow/block/warn cases following the Java and Go pack convention; README mirrors the structure of those packs (stack assumptions, predicate coverage table, evidence, known false positives).
- Drive-by: `ruby/invariants.harn:235` used a `r"...['\"]"` raw-string literal. Harn raw strings do not process escapes, so the first inner `"` terminated the string and the file failed `harn check`. Converted to a regular string with proper escaping. Five other packs (graphql, html, protobuf, terraform, xml) have similar parse errors plus a regex-lookahead issue and have been split into a separate cleanup task to keep this PR focused.

## Test plan
- [x] `harn check sql/invariants.harn` and `harn check ruby/invariants.harn` both report `ok`.
- [x] `harn fmt --check` and `harn lint` pass for both modified `.harn` files.
- [x] All 7 SQL fixture files parse as valid JSON.
- [x] Inline harness exercising the five deterministic predicates produces the expected verdicts for each fixture case (15 cases — every Block/Warn/Allow lines up).
- [x] Edge cases verified manually: `_test.sql` and `/fixtures/`-rooted SQL skipped by production scope; migration-only predicates do not fire on non-migration paths; `CREATE OR REPLACE FUNCTION` is correctly out of scope; multi-statement files with one safe and one unsafe `CREATE TABLE` warn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)