### PR TITLE
Add R seed predicate pack (#22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ See the Harn Flow design docs for the full predicate language spec.
 - [Kotlin](./kotlin/) — v0 draft predicates for Kotlin JVM, Android, and Multiplatform source.
 - [Markdown](./markdown/) — v0 draft predicates for prose Markdown files used for documentation, READMEs, and design notes.
 - [Python](./python/) — v0 draft predicates for Python application and library code.
+- [R](./r/) — v0 draft predicates for R analysis scripts, R Markdown / Quarto documents, and R packages.
 - [Ruby](./ruby/) — v0 draft predicates for Ruby application and library code.
 - [Rust](./rust/) — v0 draft predicates for Rust application and library code.
 - [SQL](./sql/) — v0 draft predicates for schema, migration, and query safety.

--- a/r/README.md
+++ b/r/README.md
@@ -1,0 +1,64 @@
+# R Seed Predicate Pack
+
+This pack covers the R-specific footguns that an Archivist can catch cheaply on a changed slice: search-path pollution, non-reproducible session state, brittle logical literals, ambiguous assignment direction, off-by-one iteration over empty inputs, code injection through `eval(parse(...))`, mutating package-install side effects, and the classic "loop where a vectorized op would do." Two of the three semantic predicates target reproducibility and namespace discipline — both judgement-heavy enough that a single judge call earns its keep over regex.
+
+## Stack Assumptions
+
+- R source files use `.R`, `.r`, `.Rmd`, `.rmd`, `.qmd`, or `.Rnw` extensions. R Markdown and Quarto files mix prose with code chunks, but the regex predicates fire on full-text matches, so a hit inside a code chunk is treated the same as a hit in a `.R` script.
+- Production paths exclude any path under `tests/`, `testthat/`, `test/`, `inst/extdata/`, `man-roxygen/`, `data-raw/`, or `dev/`.
+- Package source paths are detected by an `R/` directory segment (the canonical layout for an installable R package per *R Packages 2e* and *Writing R Extensions*). The `package_namespace_discipline` predicate restricts itself to those paths because `library()` and unqualified non-base symbols are only a problem in package code; analysis scripts use them routinely.
+- Analysis scripts are R files outside `R/` and outside test directories. The `reproducible_random_seed` predicate scopes there because `set.seed()` inside package source would clobber the caller's RNG state.
+- Deterministic predicates use file-text regex scans because Harn Flow does not yet expose a stable R AST query API; semantic predicates make a single judge call over changed R files.
+
+## Predicate Coverage
+
+| Predicate | Mode | Verdict | Purpose |
+|---|---|---|---|
+| `no_attach` | deterministic | Block | `attach()` splices a database into the search path, shadowing variables and hiding load order from the reader. |
+| `no_setwd_in_scripts` | deterministic | Block | `setwd()` hardcodes a path that breaks on any other contributor's machine and on CI. |
+| `no_rm_list_ls` | deterministic | Block | `rm(list = ls())` only clears user objects from the calling environment; it gives a false sense of reproducibility while leaving loaded packages, options, and graphics state intact. |
+| `use_logical_constants` | deterministic | Warn | `T` and `F` are ordinary symbols that any caller can rebind, silently flipping branches. `TRUE`/`FALSE` are reserved. |
+| `no_right_assign` | deterministic | Warn | `->` and `->>` put the binding target on the right, hiding it from a reader scanning the left margin. |
+| `seq_along_over_one_to_length` | deterministic | Warn | `1:length(x)` evaluates to `c(1, 0)` when `x` is empty, looping twice with invalid indices instead of zero times. |
+| `no_install_or_update_packages` | deterministic | Block | `install.packages()` and `update.packages()` mutate the user's library on import. Pin via `renv` or `DESCRIPTION` instead. |
+| `no_eval_parse_text` | deterministic | Block | `eval(parse(text = ...))` evaluates arbitrary text as code and skips static checks; it is the canonical R injection sink. |
+| `vectorize_over_loops` | semantic | Warn | Element-wise loops in R are typically 10–100× slower than the equivalent vectorized expression and harder to read. |
+| `reproducible_random_seed` | semantic | Warn | Analysis scripts that sample or simulate without `set.seed()` produce a different answer on every run. |
+| `package_namespace_discipline` | semantic | Warn | `library()` inside `R/` mutates the user's search path on package load; unqualified non-base symbols dodge the `DESCRIPTION` Imports declaration and break under `R CMD check`. |
+
+## Evidence
+
+Evidence scanned on 2026-05-10.
+
+- *R Manuals* (CRAN, R Foundation): `attach`, `getwd`/`setwd`, `rm`, `seq`, `eval`, `Random`, `install.packages`, `lapply`, `assignOps`, `logical` reference pages.
+- *Writing R Extensions* (CRAN): namespace and dependency declaration semantics for installable packages.
+- *R Packages, 2e* (Wickham & Bryan, r-pkgs.org): code, dependency mindset, namespace, dependencies-in-practice chapters.
+- *Advanced R, 2e* (Wickham, adv-r.hadley.nz): environments, expressions, control-flow, performance-improve chapters.
+- *R for Data Science, 2e* (Wickham, Çetinkaya-Rundel, Grolemund, r4ds.hadley.nz): iteration, workflow-scripts, and Quarto chapters; workflow-vs-script post on tidyverse.org.
+- *tidyverse style guide* (style.tidyverse.org): syntax — assignment operator, `TRUE`/`FALSE` over `T`/`F`.
+- *Google R style guide* (google.github.io/styleguide/Rguide.html): assignment operator and logical-constant guidance.
+- *here* (here.r-lib.org), *renv* (rstudio.github.io/renv), and *rlang* (rlang.r-lib.org): canonical alternatives to `setwd()`, `install.packages()`, and `eval(parse(text = ...))`.
+
+## Known False Positives
+
+- Regex predicates do not parse R. Strings, comments, and roxygen blocks containing the matched tokens (e.g. an `attach(` literal in a docstring) will trip the deterministic checks. Suppress locally once the predicate runtime supports it.
+- `use_logical_constants` matches `T` and `F` only when they appear in a logical-literal context (after `=`, `,`, `(`, `<-`, `==`, `&&`, `||`, etc.). It still flags `T`/`F` used as user-defined symbols in those contexts; the canon's stance is that single-letter `T`/`F` as a variable name is itself worth flagging. Conversely, `T` inside a string or comment slips through, which is fine.
+- `no_right_assign` looks for `->` followed by an identifier and not preceded by `<` (to avoid `<-`). Right-assigns into chained subscripts (`x[i] -> y`) are caught; `->` inside a string or `#` comment is a residual FP.
+- `seq_along_over_one_to_length` matches the literal `1:length(x)` family. Loops written `seq.int(1, length(x))` or `1L:length(x)` slip through; the rule targets the most common idiom by design.
+- `no_install_or_update_packages` flags any `install.packages(` / `update.packages(` call site, including `renv::install()` wrappers that legitimately call `install.packages` internally — those wrappers should not appear in committed source either, so the FP rate is low in practice.
+- `no_eval_parse_text` only matches `eval(parse(text = ...))`. Equivalent `do.call("eval", list(parse(text = ...)))` rewrites are not caught; they are rare enough that catching them with regex is not worth the brittleness.
+- The semantic predicates restrict their scan to a path-scoped subset (analysis scripts for `reproducible_random_seed`, package source for `package_namespace_discipline`). A repo with no R files in those scopes will allow trivially.
+
+## Fixtures
+
+Each fixture in `fixtures/` contains one blocked or warned example and at least one allowed example for the corresponding predicate. The fixture shape matches the harn-canon convention:
+
+```json
+{
+  "predicate": "name",
+  "cases": [
+    {"expect": "Block", "files": [{"path": "scripts/load.R", "text": "..."}]},
+    {"expect": "Allow", "files": [{"path": "scripts/load.R", "text": "..."}]}
+  ]
+}
+```

--- a/r/fixtures/no_attach.json
+++ b/r/fixtures/no_attach.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "no_attach",
+  "cases": [
+    {
+      "name": "blocks_attach_call",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "scripts/load_iris.R",
+          "text": "data(iris)\nattach(iris)\nplot(Sepal.Length, Petal.Length)\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_explicit_column_access",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "scripts/load_iris.R",
+          "text": "data(iris)\nplot(iris$Sepal.Length, iris$Petal.Length)\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_with_block",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "scripts/load_iris.R",
+          "text": "data(iris)\nwith(iris, plot(Sepal.Length, Petal.Length))\n"
+        }
+      ]
+    }
+  ]
+}

--- a/r/fixtures/no_eval_parse_text.json
+++ b/r/fixtures/no_eval_parse_text.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "no_eval_parse_text",
+  "cases": [
+    {
+      "name": "blocks_eval_parse_text_with_user_input",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "R/dispatcher.R",
+          "text": "run_user_expr <- function(user_expr) {\n  eval(parse(text = user_expr))\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_rlang_expr",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "R/dispatcher.R",
+          "text": "run_user_expr <- function(value) {\n  eval(rlang::expr(.x * 2), list(.x = value))\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_bquote",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "R/dispatcher.R",
+          "text": "run_user_expr <- function(value) {\n  eval(bquote(.(value) * 2))\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/r/fixtures/no_install_or_update_packages.json
+++ b/r/fixtures/no_install_or_update_packages.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "no_install_or_update_packages",
+  "cases": [
+    {
+      "name": "blocks_install_packages_in_script",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "scripts/setup.R",
+          "text": "install.packages(c(\"dplyr\", \"ggplot2\"))\nlibrary(dplyr)\n"
+        }
+      ]
+    },
+    {
+      "name": "blocks_update_packages",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "scripts/refresh.R",
+          "text": "update.packages(ask = FALSE)\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_renv_restore_via_doc",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "scripts/setup.R",
+          "text": "# Run renv::restore() once after cloning to install pinned deps from renv.lock\nlibrary(dplyr)\n"
+        }
+      ]
+    }
+  ]
+}

--- a/r/fixtures/no_right_assign.json
+++ b/r/fixtures/no_right_assign.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "no_right_assign",
+  "cases": [
+    {
+      "name": "warns_on_right_assign",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "scripts/transform.R",
+          "text": "mtcars |>\n  subset(mpg > 20) |>\n  nrow() -> efficient_count\n"
+        }
+      ]
+    },
+    {
+      "name": "warns_on_super_right_assign",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "R/state.R",
+          "text": "init_counter <- function() {\n  0 ->> .counter\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_left_assign",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "scripts/transform.R",
+          "text": "efficient_count <- nrow(subset(mtcars, mpg > 20))\n"
+        }
+      ]
+    }
+  ]
+}

--- a/r/fixtures/no_rm_list_ls.json
+++ b/r/fixtures/no_rm_list_ls.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "no_rm_list_ls",
+  "cases": [
+    {
+      "name": "blocks_rm_list_ls_at_top",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "scripts/fit_model.R",
+          "text": "rm(list = ls())\nlibrary(stats)\nfit <- lm(mpg ~ wt, data = mtcars)\n"
+        }
+      ]
+    },
+    {
+      "name": "blocks_rm_list_ls_no_spaces",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "scripts/fit_model.R",
+          "text": "rm(list=ls())\nfit <- lm(mpg ~ wt, data = mtcars)\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_targeted_rm",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "scripts/fit_model.R",
+          "text": "tmp <- 1\nrm(tmp)\nfit <- lm(mpg ~ wt, data = mtcars)\n"
+        }
+      ]
+    }
+  ]
+}

--- a/r/fixtures/no_setwd_in_scripts.json
+++ b/r/fixtures/no_setwd_in_scripts.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_setwd_in_scripts",
+  "cases": [
+    {
+      "name": "blocks_setwd_to_user_home",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "scripts/run_pipeline.R",
+          "text": "setwd(\"/Users/alex/projects/analysis\")\nsource(\"steps/clean.R\")\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_here_package",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "scripts/run_pipeline.R",
+          "text": "library(here)\nsource(here(\"steps\", \"clean.R\"))\n"
+        }
+      ]
+    }
+  ]
+}

--- a/r/fixtures/package_namespace_discipline.json
+++ b/r/fixtures/package_namespace_discipline.json
@@ -1,0 +1,45 @@
+{
+  "predicate": "package_namespace_discipline",
+  "cases": [
+    {
+      "name": "warns_on_library_in_package_source",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "R/cleaners.R",
+          "text": "library(dplyr)\n\nclean_orders <- function(orders) {\n  orders |> filter(status == \"paid\") |> arrange(created_at)\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "warns_on_unqualified_external_symbol",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "R/cleaners.R",
+          "text": "clean_orders <- function(orders) {\n  orders |> filter(status == \"paid\") |> arrange(created_at)\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_qualified_calls",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "R/cleaners.R",
+          "text": "clean_orders <- function(orders) {\n  orders |> dplyr::filter(status == \"paid\") |> dplyr::arrange(created_at)\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_importFrom_roxygen",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "R/cleaners.R",
+          "text": "#' @importFrom dplyr filter arrange\nclean_orders <- function(orders) {\n  orders |> filter(status == \"paid\") |> arrange(created_at)\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/r/fixtures/reproducible_random_seed.json
+++ b/r/fixtures/reproducible_random_seed.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "reproducible_random_seed",
+  "cases": [
+    {
+      "name": "warns_on_sample_without_seed",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "analysis/bootstrap.R",
+          "text": "n <- 1000\nsamples <- replicate(500, mean(sample(rnorm(n), n, replace = TRUE)))\nhist(samples)\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_set_seed_before_randomness",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "analysis/bootstrap.R",
+          "text": "set.seed(20260510)\nn <- 1000\nsamples <- replicate(500, mean(sample(rnorm(n), n, replace = TRUE)))\nhist(samples)\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_function_only_definition",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "analysis/helpers.R",
+          "text": "draw <- function(n, seed) {\n  set.seed(seed)\n  rnorm(n)\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/r/fixtures/seq_along_over_one_to_length.json
+++ b/r/fixtures/seq_along_over_one_to_length.json
@@ -1,0 +1,45 @@
+{
+  "predicate": "seq_along_over_one_to_length",
+  "cases": [
+    {
+      "name": "warns_on_one_to_length",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "scripts/iterate.R",
+          "text": "process_each <- function(items) {\n  for (i in 1:length(items)) {\n    cat(i, items[[i]], \"\\n\")\n  }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "warns_on_one_to_nrow",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "scripts/rows.R",
+          "text": "summarize_rows <- function(df) {\n  for (i in 1:nrow(df)) {\n    print(df[i, ])\n  }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_seq_along",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "scripts/iterate.R",
+          "text": "process_each <- function(items) {\n  for (i in seq_along(items)) {\n    cat(i, items[[i]], \"\\n\")\n  }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_seq_len_nrow",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "scripts/rows.R",
+          "text": "summarize_rows <- function(df) {\n  for (i in seq_len(nrow(df))) {\n    print(df[i, ])\n  }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/r/fixtures/use_logical_constants.json
+++ b/r/fixtures/use_logical_constants.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "use_logical_constants",
+  "cases": [
+    {
+      "name": "warns_on_T_as_default",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "scripts/format.R",
+          "text": "format_number <- function(x, pretty = T) {\n  if (pretty) format(x, big.mark = \",\") else as.character(x)\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "warns_on_F_in_comparison",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "scripts/check.R",
+          "text": "should_skip <- function(flag) {\n  if (flag == F) return(\"skip\")\n  return(\"run\")\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_TRUE_FALSE",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "scripts/format.R",
+          "text": "format_number <- function(x, pretty = TRUE) {\n  if (isTRUE(pretty)) format(x, big.mark = \",\") else as.character(x)\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/r/fixtures/vectorize_over_loops.json
+++ b/r/fixtures/vectorize_over_loops.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "vectorize_over_loops",
+  "cases": [
+    {
+      "name": "warns_on_elementwise_loop",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "R/scale.R",
+          "text": "scale_prices <- function(prices, factor) {\n  out <- numeric(length(prices))\n  for (i in seq_along(prices)) {\n    out[i] <- prices[i] * factor\n  }\n  out\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_vectorized_form",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "R/scale.R",
+          "text": "scale_prices <- function(prices, factor) {\n  prices * factor\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_loop_with_inter_iteration_state",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "R/cumulate.R",
+          "text": "running_total <- function(values, threshold) {\n  total <- 0\n  for (v in values) {\n    if (total + v > threshold) break\n    total <- total + v\n  }\n  total\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/r/invariants.harn
+++ b/r/invariants.harn
@@ -1,0 +1,344 @@
+let _EVIDENCE_ATTACH = [
+  "https://stat.ethz.ch/R-manual/R-devel/library/base/html/attach.html",
+  "https://adv-r.hadley.nz/environments.html",
+  "https://r-pkgs.org/code.html",
+]
+
+let _EVIDENCE_SETWD = [
+  "https://stat.ethz.ch/R-manual/R-devel/library/base/html/getwd.html",
+  "https://here.r-lib.org/articles/here.html",
+  "https://www.tidyverse.org/blog/2017/12/workflow-vs-script/",
+]
+
+let _EVIDENCE_RM_LIST_LS = [
+  "https://stat.ethz.ch/R-manual/R-devel/library/base/html/rm.html",
+  "https://www.tidyverse.org/blog/2017/12/workflow-vs-script/",
+  "https://r4ds.hadley.nz/workflow-scripts.html",
+]
+
+let _EVIDENCE_LOGICAL_CONSTANTS = [
+  "https://stat.ethz.ch/R-manual/R-devel/library/base/html/logical.html",
+  "https://style.tidyverse.org/syntax.html",
+  "https://google.github.io/styleguide/Rguide.html",
+]
+
+let _EVIDENCE_RIGHT_ASSIGN = [
+  "https://stat.ethz.ch/R-manual/R-devel/library/base/html/assignOps.html",
+  "https://style.tidyverse.org/syntax.html",
+  "https://google.github.io/styleguide/Rguide.html",
+]
+
+let _EVIDENCE_SEQ_ALONG = [
+  "https://stat.ethz.ch/R-manual/R-devel/library/base/html/seq.html",
+  "https://adv-r.hadley.nz/control-flow.html",
+  "https://r4ds.hadley.nz/iteration.html",
+]
+
+let _EVIDENCE_INSTALL_PACKAGES = [
+  "https://stat.ethz.ch/R-manual/R-devel/library/utils/html/install.packages.html",
+  "https://r-pkgs.org/dependencies-mindset-background.html",
+  "https://rstudio.github.io/renv/articles/renv.html",
+]
+
+let _EVIDENCE_EVAL_PARSE = [
+  "https://stat.ethz.ch/R-manual/R-devel/library/base/html/eval.html",
+  "https://adv-r.hadley.nz/expressions.html",
+  "https://rlang.r-lib.org/reference/eval_tidy.html",
+]
+
+let _EVIDENCE_VECTORIZE = [
+  "https://adv-r.hadley.nz/perf-improve.html",
+  "https://stat.ethz.ch/R-manual/R-devel/library/base/html/lapply.html",
+  "https://r4ds.hadley.nz/iteration.html",
+]
+
+let _EVIDENCE_RANDOM_SEED = [
+  "https://stat.ethz.ch/R-manual/R-devel/library/base/html/Random.html",
+  "https://rstudio.github.io/renv/articles/reproducibility.html",
+  "https://r4ds.hadley.nz/quarto.html",
+]
+
+let _EVIDENCE_NAMESPACE = [
+  "https://r-pkgs.org/dependencies-in-practice.html",
+  "https://r-pkgs.org/namespace.html",
+  "https://cran.r-project.org/doc/manuals/r-release/R-exts.html",
+]
+
+fn is_r_source_path(path) {
+  return path.ends_with(".R")
+    || path.ends_with(".r")
+    || path.ends_with(".Rmd")
+    || path.ends_with(".rmd")
+    || path.ends_with(".qmd")
+    || path.ends_with(".Rnw")
+}
+
+fn is_test_path(path) {
+  return path.contains("/tests/")
+    || path.contains("/testthat/")
+    || path.contains("/test/")
+    || path.contains("/inst/extdata/")
+    || path.contains("/man-roxygen/")
+    || path.contains("/data-raw/")
+    || path.contains("/dev/")
+}
+
+fn is_package_source_path(path) {
+  return (path.contains("/R/") || path.starts_with("R/"))
+    && !is_test_path(path)
+}
+
+fn is_analysis_script_path(path) {
+  return is_r_source_path(path)
+    && !is_package_source_path(path)
+    && !is_test_path(path)
+}
+
+fn r_files(slice) {
+  return slice.files.filter({ file -> is_r_source_path(file.path) })
+}
+
+fn production_r_files(slice) {
+  return r_files(slice).filter({ file -> !is_test_path(file.path) })
+}
+
+fn package_source_files(slice) {
+  return r_files(slice).filter({ file -> is_package_source_path(file.path) })
+}
+
+fn analysis_script_files(slice) {
+  return r_files(slice).filter({ file -> is_analysis_script_path(file.path) })
+}
+
+fn scan_files(files, pattern, flags) {
+  var findings = []
+  for file in files {
+    if regex_match(pattern, file.text, flags) != nil {
+      findings = findings.push({path: file.path, pattern: pattern})
+    }
+  }
+  return findings
+}
+
+fn scan_files_if(files, predicate) {
+  var findings = []
+  for file in files {
+    if predicate(file) {
+      findings = findings.push({path: file.path})
+    }
+  }
+  return findings
+}
+
+fn allow(rule) {
+  return {verdict: "Allow", rule: rule, findings: [], remediation: ""}
+}
+
+fn warn(rule, remediation, findings) {
+  return {verdict: "Warn", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block(rule, remediation, findings) {
+  return {verdict: "Block", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return block(rule, remediation, findings)
+}
+
+fn warn_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return warn(rule, remediation, findings)
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_ATTACH, confidence: 0.78, source_date: "2026-05-10")
+/** Blocks calls to attach() that splice a database into the search path. */
+pub fn no_attach(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_r_files(slice),
+    r"(?m)(^|[^A-Za-z0-9_.$@])attach\s*\(",
+    "m",
+  )
+  return block_on_findings(
+    "no_attach",
+    "Reference columns explicitly with df$col, with(df, ...), or dplyr verbs; attach() pollutes the search path and shadows variables.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_SETWD, confidence: 0.78, source_date: "2026-05-10")
+/** Blocks setwd() calls that hardcode the working directory in committed source. */
+pub fn no_setwd_in_scripts(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_r_files(slice),
+    r"(?m)(^|[^A-Za-z0-9_.$@])setwd\s*\(",
+    "m",
+  )
+  return block_on_findings(
+    "no_setwd_in_scripts",
+    "Use here::here() or project-relative paths so the script runs from any working directory and on any contributor's machine.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_RM_LIST_LS, confidence: 0.8, source_date: "2026-05-10")
+/** Blocks rm(list = ls()) idioms that wipe the calling environment. */
+pub fn no_rm_list_ls(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_r_files(slice),
+    r"\brm\s*\(\s*list\s*=\s*ls\s*\(",
+    "s",
+  )
+  return block_on_findings(
+    "no_rm_list_ls",
+    "Restart the R session for a clean slate instead of rm(list = ls()); the latter only clears user objects and gives a false sense of reproducibility.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_LOGICAL_CONSTANTS, confidence: 0.55, source_date: "2026-05-10")
+/** Warns on T or F used as logical literals; both are reassignable identifiers. */
+pub fn use_logical_constants(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_r_files(slice),
+    r"(?m)(?:[=,(]|<-|<<-|==|!=|&&|\|\||&|\|)\s*[TF](?:\s*[,)\s;&|]|$)",
+    "m",
+  )
+  return warn_on_findings(
+    "use_logical_constants",
+    "Write TRUE and FALSE explicitly; T and F are ordinary symbols that any caller (or earlier line) can rebind, silently flipping branches.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_RIGHT_ASSIGN, confidence: 0.66, source_date: "2026-05-10")
+/** Warns on right-assign operators -> and ->>; reading order obscures the assignment target. */
+pub fn no_right_assign(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_r_files(slice),
+    r"(?m)(^|[^<\-])->>?\s*[A-Za-z_.]",
+    "m",
+  )
+  return warn_on_findings(
+    "no_right_assign",
+    "Use <- for assignment so the target name appears on the left; -> and ->> hide the binding and are easy to miss in review.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_SEQ_ALONG, confidence: 0.74, source_date: "2026-05-10")
+/** Warns on 1:length(x), 1:nrow(x), 1:ncol(x) idioms that iterate c(1, 0) when the input is empty. */
+pub fn seq_along_over_one_to_length(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_r_files(slice),
+    r"\b1\s*:\s*(?:length|nrow|ncol|NROW|NCOL)\s*\(",
+    "s",
+  )
+  return warn_on_findings(
+    "seq_along_over_one_to_length",
+    "Use seq_along(x) or seq_len(nrow(x)); 1:length(x) silently iterates twice when x has length zero, hitting both ends of the empty input bug.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_INSTALL_PACKAGES, confidence: 0.78, source_date: "2026-05-10")
+/** Blocks install.packages() and update.packages() calls in committed source. */
+pub fn no_install_or_update_packages(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_r_files(slice),
+    r"(?m)(^|[^A-Za-z0-9_.$@])(?:install|update)\.packages\s*\(",
+    "m",
+  )
+  return block_on_findings(
+    "no_install_or_update_packages",
+    "Pin dependencies with renv, DESCRIPTION Imports, or a setup script the contributor opts into; never mutate the user's library on import.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_EVAL_PARSE, confidence: 0.74, source_date: "2026-05-10")
+/** Blocks eval(parse(text = ...)) which evaluates arbitrary text as R code. */
+pub fn no_eval_parse_text(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_r_files(slice),
+    r"\beval\s*\(\s*parse\s*\(\s*text\s*=",
+    "s",
+  )
+  return block_on_findings(
+    "no_eval_parse_text",
+    "Build expressions with rlang::expr / bquote / substitute and evaluate them with eval(); eval(parse(text = ...)) is an injection sink and skips static checks.",
+    findings,
+  )
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_VECTORIZE, confidence: 0.55, source_date: "2026-05-10")
+/** Warns on for loops over vectors or rows that perform a simple element-wise computation a vectorized op would express directly. */
+pub fn vectorize_over_loops(slice, ctx, _repo_at_base) {
+  let rubric = "Warn only when a changed R for loop iterates over a vector, list, or row indices and computes a result that maps cleanly onto a built-in vectorized operation (arithmetic on whole vectors, ifelse, pmin/pmax, rowSums/colSums, sweep, apply/lapply/vapply/sapply/map_*) without inter-iteration state. Allow loops that mutate external resources, accumulate dependent state across iterations, recurse, or break/next on a non-trivial condition."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: r_files(slice)})
+  if judgement.verdict == "Warn" {
+    return warn(
+      "vectorize_over_loops",
+      "Replace the loop with a vectorized expression or apply/map family call; element-wise loops in R are typically 10-100x slower and harder to read.",
+      judgement.findings,
+    )
+  }
+  return allow("vectorize_over_loops")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_RANDOM_SEED, confidence: 0.62, source_date: "2026-05-10")
+/** Warns when an analysis script invokes randomness without an explicit set.seed() upstream. */
+pub fn reproducible_random_seed(slice, ctx, _repo_at_base) {
+  let rubric = "Warn only when a changed R analysis script (.R, .Rmd, or .qmd outside R/ package source and outside test directories) calls a stochastic function such as sample, runif, rnorm, rbinom, rpois, rgamma, rbeta, rexp, rweibull, rt, rchisq, rmultinom, or simulate, AND the same script does not call set.seed() with a literal integer earlier in the file. Allow files where set.seed() is called before the first stochastic call, files that only define functions to be called by other code, and package R/ source where setting the seed would clobber the caller's RNG state."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: analysis_script_files(slice)})
+  if judgement.verdict == "Warn" {
+    return warn(
+      "reproducible_random_seed",
+      "Call set.seed(<integer>) at the top of the script so reruns reproduce; in package code, expose a seed argument instead.",
+      judgement.findings,
+    )
+  }
+  return allow("reproducible_random_seed")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_NAMESPACE, confidence: 0.62, source_date: "2026-05-10")
+/** Warns when package R/ source loads dependencies via library()/require() or uses unqualified non-base symbols without an importFrom roxygen tag. */
+pub fn package_namespace_discipline(slice, ctx, _repo_at_base) {
+  let rubric = "Warn only when a changed file under a package's R/ directory either (a) calls library(), require(), requireNamespace() purely for side-effect attachment, or (b) uses a symbol from a non-base, non-recommended package without either a pkg:: prefix or an @importFrom roxygen tag elsewhere in the file. Allow conditional requireNamespace(..., quietly = TRUE) checks that gate optional behavior, allow base/recommended packages (base, stats, utils, graphics, grDevices, methods, tools), and allow files that only contain comments, roxygen, or data definitions."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: package_source_files(slice)})
+  if judgement.verdict == "Warn" {
+    return warn(
+      "package_namespace_discipline",
+      "Declare dependencies in DESCRIPTION Imports and reference them with pkg::fn() or @importFrom; library() inside R/ alters the user's search path on load.",
+      judgement.findings,
+    )
+  }
+  return allow("package_namespace_discipline")
+}


### PR DESCRIPTION
## Summary

Drafts the v0 R seed predicate pack under `r/`. Eight deterministic and three semantic predicates target the R-specific footguns that an Archivist can catch cheaply on a changed slice.

**Deterministic (8):**
- `no_attach` (Block) — `attach()` splices a database into the search path, shadowing variables.
- `no_setwd_in_scripts` (Block) — `setwd()` hardcodes a per-machine working directory.
- `no_rm_list_ls` (Block) — `rm(list = ls())` only clears user objects; restart the session for a real reset.
- `use_logical_constants` (Warn) — `T`/`F` are reassignable identifiers, not reserved words.
- `no_right_assign` (Warn) — covers the `no_assignment_arrow_ambiguity` ask; flags `->` and `->>`.
- `seq_along_over_one_to_length` (Warn) — `1:length(x)` evaluates to `c(1, 0)` when `x` is empty.
- `no_install_or_update_packages` (Block) — pin via `renv` / `DESCRIPTION` instead of mutating the user's library on import.
- `no_eval_parse_text` (Block) — `eval(parse(text = ...))` is the canonical R injection sink.

**Semantic (3):**
- `vectorize_over_loops` (Warn) — element-wise loops that map cleanly onto a vectorized op or apply/map family call.
- `reproducible_random_seed` (Warn) — analysis scripts that sample/simulate without `set.seed()` upstream; scoped to non-package, non-test paths so package code does not get told to clobber the caller's RNG state.
- `package_namespace_discipline` (Warn) — `library()`/`require()` inside `R/` package source, or unqualified non-base symbols without an `@importFrom` tag.

Evidence is sourced from R Core Manuals (CRAN), *Writing R Extensions*, *R Packages 2e*, *Advanced R 2e*, *R for Data Science 2e*, the tidyverse style guide, Google's R style guide, and the `here` / `renv` / `rlang` package docs. Each predicate ships with one or more block/warn fixtures and at least one allow fixture.

Closes #22.

## Test plan

- [ ] CI placeholder jobs pass (evidence-link / fmt / fixture-replay are still stubs in this repo).
- [ ] Once Harn Flow's predicate runtime lands, fixtures should replay deterministically: each `Block`/`Warn` case produces the expected verdict, each `Allow` case returns `Allow`.
- [ ] Manual scan: regex predicates were tuned without lookbehind/lookahead so they match the rest of the canon's portability constraints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)