### PR TITLE
Add Elixir seed predicate pack (#18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ See the Harn Flow design docs for the full predicate language spec.
 - [C#](./csharp/) — v0 draft predicates for plain C# and .NET library or application code.
 - [CSS](./css/) — v0 draft predicates for CSS, Sass, and Less stylesheets covering cascade hygiene, internationalization, and accessibility.
 - [Dockerfile](./dockerfile/) — v0 draft predicates for `Dockerfile` and `Containerfile` build recipes.
+- [Elixir](./elixir/) — v0 draft predicates for Elixir application and library code on the BEAM.
 - [Go](./go/) — v0 draft predicates for Go modules, command packages, and reusable libraries.
 - [GraphQL](./graphql/) — v0 draft predicates for GraphQL schema files and the server wiring that hosts them.
 - [Harn](./harn/) — v0 draft predicates for `.harn` scripts, Flow workflows, and agent-facing Harn modules.

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -1,0 +1,60 @@
+# Elixir Seed Predicate Pack
+
+This pack covers general-purpose Elixir application and library code on top of the BEAM. It targets review-slice issues with clear correctness, debuggability, or convention impact: stray debug helpers committed by accident, unbounded atom creation that can exhaust the BEAM atom table, idiomatic flow-control choices, predicate naming, exception handling that drops stacktraces, pipeline readability, error contract drift, GenServer state-shape leakage, and case/cond bodies that should be function clauses.
+
+## Stack Assumptions
+
+- Source files use the `.ex` and `.exs` extensions.
+- Production paths exclude any path under `test/`, `tests/`, `_build/`, `deps/`, `cover/`, or `.elixir_ls/`, and any file ending in `_test.exs`.
+- Projects target modern Elixir (1.14+) with `dbg/1`, the standard `Logger` API, `String.to_existing_atom/1`, and `reraise/2` available.
+- Deterministic predicates run over changed source text until Flow exposes a stable Elixir AST query API. Rules with meaningful false-positive risk warn rather than block.
+- Semantic predicates make a single judge call over changed Elixir files and stay conservative — they should only fire when they can cite concrete changed spans.
+
+## Predicate Coverage
+
+| Predicate | Mode | Verdict | Purpose |
+|---|---|---|---|
+| `no_io_inspect` | deterministic | Block | `IO.inspect` is debug instrumentation, not production logging; it leaks state and burns IO. |
+| `no_dbg_macro` | deterministic | Block | `dbg/0` and `dbg/1` are interactive-debug helpers and should not appear in shipped code. |
+| `no_iex_pry` | deterministic | Block | `IEx.pry/0` breakpoints only work in an attached IEx shell and stall production processes. |
+| `no_unsafe_to_atom` | deterministic | Block | `String.to_atom/1`, `List.to_atom/1`, and the `:erlang` equivalents create unbounded atoms that the BEAM never garbage-collects. |
+| `unless_with_else` | deterministic | Warn | `unless ... else` inverts reader expectations; flip the condition and use `if`. |
+| `predicate_function_naming` | deterministic | Warn | Predicate functions should end in `?` and not also start with `is_`; the `is_` prefix is reserved for guard-safe macros. |
+| `no_raise_inside_rescue` | deterministic | Block | Raising a fresh exception inside `rescue` discards the original stacktrace; use `reraise` to preserve it. |
+| `pipe_chain_readability` | deterministic | Warn | Long pipelines without intermediate bindings hide intent and make stack traces harder to read. |
+| `tagged_error_tuples` | semantic | Block | Public APIs should return `{:ok, value}` / `{:error, reason}` tuples or a bang variant, not bare atoms or `nil`. |
+| `genserver_callback_boundary` | semantic | Block | GenServer callbacks should not leak fresh internal state shapes or raw implementation types across the process boundary. |
+| `pattern_match_over_conditional` | semantic | Warn | Function bodies that are a single `case` or `cond` over the function's own arguments should be split into function-head clauses. |
+
+## Evidence
+
+Evidence scanned on 2026-05-10.
+
+- Elixir official documentation (HexDocs `main`): code anti-patterns, process anti-patterns, naming conventions, library guidelines, the `IO`, `Kernel`, `String`, `IEx`, `Process`, and `GenServer` modules, and the case/cond/if guide.
+- Credo static analysis checks: `Warning.IoInspect`, `Warning.Dbg`, `Warning.IExPry`, `Warning.UnsafeToAtom`, `Warning.RaiseInsideRescue`, `Refactor.UnlessWithElse`, `Refactor.PipeChainStart`, `Refactor.Nesting`, `Readability.PredicateFunctionNames`.
+
+## Known False Positives
+
+- Regex predicates are source-text checks. Comments, heredocs, string literals, and metaprogramming can fool them until AST-backed matching lands.
+- `no_io_inspect`, `no_dbg_macro`, and `no_iex_pry` may flag intentional production diagnostics. Prefer `Logger` with explicit levels; suppress narrowly once the runtime supports it.
+- `no_dbg_macro` matches `dbg(` after a non-word, non-dot, non-colon character. A local variable accidentally named `dbg` will trip the regex; rename the binding.
+- `no_unsafe_to_atom` blocks every callsite, including ones whose input is statically known. The recommended replacement is an explicit map lookup or `String.to_existing_atom/1`.
+- `unless_with_else` looks for an `else` within ~400 characters of the matching `unless ... do`, which is conservative for long branches; split very large branches before relying on the linter.
+- `predicate_function_naming` flags `defmacro is_foo?` even though the `is_` prefix is correct for guard-safe macros — the trailing `?` is what makes the name violate the convention. Rename to `is_foo` (no trailing `?`) for guard macros.
+- `no_raise_inside_rescue` matches `raise <Identifier>` within ~20 lines of a `rescue` clause and does not catch every layout. It also does not detect re-raising via `Kernel.reraise/2`, which is the intended replacement.
+- `pipe_chain_readability` counts contiguous lines that begin with `|>`. A chain split across `|>` and inline calls on the same line, or a chain that interleaves comments, can read as shorter than it is.
+- Semantic predicates depend on a cheap judge and should stay high-threshold until Flow exposes a structured Elixir AST and behaviour-aware data flow.
+
+## Fixtures
+
+Each fixture in `fixtures/` contains one blocked or warned example and one allowed example for the corresponding predicate. The fixture shape mirrors the existing seed packs:
+
+```json
+{
+  "predicate": "name",
+  "cases": [
+    {"expect": "Block", "files": [{"path": "lib/my_app/service.ex", "text": "..."}]},
+    {"expect": "Allow", "files": [{"path": "lib/my_app/service.ex", "text": "..."}]}
+  ]
+}
+```

--- a/elixir/fixtures/genserver_callback_boundary.json
+++ b/elixir/fixtures/genserver_callback_boundary.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "genserver_callback_boundary",
+  "cases": [
+    {
+      "name": "blocks_callback_returning_internal_state_to_caller",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "lib/my_app/cache.ex",
+          "text": "defmodule MyApp.Cache do\n  use GenServer\n\n  @typedoc \"Public cache value returned to callers.\"\n  @type value :: %{key: String.t(), value: term(), expires_at: DateTime.t()}\n\n  @typedoc \"Internal cache state. Not part of the public contract.\"\n  @type state :: %{table: :ets.tid(), metrics: map(), last_compaction: DateTime.t()}\n\n  def fetch(key), do: GenServer.call(__MODULE__, {:fetch, key})\n\n  @impl true\n  def init(_opts) do\n    {:ok, %{table: :ets.new(:cache, [:set]), metrics: %{}, last_compaction: DateTime.utc_now()}}\n  end\n\n  @impl true\n  def handle_call({:fetch, key}, _from, state) do\n    # Returning the entire internal state to the caller leaks implementation details.\n    {:reply, state, state}\n  end\nend\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_callback_returning_documented_value",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "lib/my_app/cache.ex",
+          "text": "defmodule MyApp.Cache do\n  use GenServer\n\n  @typedoc \"Public cache value returned to callers.\"\n  @type value :: %{key: String.t(), value: term(), expires_at: DateTime.t()}\n\n  @typedoc \"Internal cache state. Not part of the public contract.\"\n  @type state :: %{table: :ets.tid(), metrics: map(), last_compaction: DateTime.t()}\n\n  def fetch(key), do: GenServer.call(__MODULE__, {:fetch, key})\n\n  @impl true\n  def init(_opts) do\n    {:ok, %{table: :ets.new(:cache, [:set]), metrics: %{}, last_compaction: DateTime.utc_now()}}\n  end\n\n  @impl true\n  def handle_call({:fetch, key}, _from, state) do\n    reply =\n      case :ets.lookup(state.table, key) do\n        [{^key, value, expires_at}] -> {:ok, %{key: key, value: value, expires_at: expires_at}}\n        [] -> {:error, :not_found}\n      end\n\n    {:reply, reply, state}\n  end\nend\n"
+        }
+      ]
+    }
+  ]
+}

--- a/elixir/fixtures/no_dbg_macro.json
+++ b/elixir/fixtures/no_dbg_macro.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_dbg_macro",
+  "cases": [
+    {
+      "name": "blocks_dbg_in_pipeline",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "lib/my_app/checkout.ex",
+          "text": "defmodule MyApp.Checkout do\n  def total(cart) do\n    cart\n    |> Map.fetch!(:items)\n    |> Enum.map(& &1.price)\n    |> Enum.sum()\n    |> dbg()\n  end\nend\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_clean_pipeline",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "lib/my_app/checkout.ex",
+          "text": "defmodule MyApp.Checkout do\n  def total(cart) do\n    cart\n    |> Map.fetch!(:items)\n    |> Enum.map(& &1.price)\n    |> Enum.sum()\n  end\nend\n"
+        }
+      ]
+    }
+  ]
+}

--- a/elixir/fixtures/no_iex_pry.json
+++ b/elixir/fixtures/no_iex_pry.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_iex_pry",
+  "cases": [
+    {
+      "name": "blocks_iex_pry_breakpoint",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "lib/my_app/router.ex",
+          "text": "defmodule MyApp.Router do\n  require IEx\n\n  def dispatch(conn) do\n    IEx.pry()\n    handle(conn)\n  end\nend\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_clean_dispatch",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "lib/my_app/router.ex",
+          "text": "defmodule MyApp.Router do\n  def dispatch(conn) do\n    handle(conn)\n  end\nend\n"
+        }
+      ]
+    }
+  ]
+}

--- a/elixir/fixtures/no_io_inspect.json
+++ b/elixir/fixtures/no_io_inspect.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "no_io_inspect",
+  "cases": [
+    {
+      "name": "blocks_io_inspect_in_pipeline",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "lib/my_app/orders.ex",
+          "text": "defmodule MyApp.Orders do\n  def total(items) do\n    items\n    |> Enum.map(& &1.amount)\n    |> IO.inspect(label: \"amounts\")\n    |> Enum.sum()\n  end\nend\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_logger_debug",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "lib/my_app/orders.ex",
+          "text": "defmodule MyApp.Orders do\n  require Logger\n\n  def total(items) do\n    Logger.debug(fn -> [\"computing total for \", inspect(length(items)), \" items\"] end)\n    items |> Enum.map(& &1.amount) |> Enum.sum()\n  end\nend\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_io_inspect_in_test",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "test/my_app/orders_test.exs",
+          "text": "defmodule MyApp.OrdersTest do\n  use ExUnit.Case\n\n  test \"prints intermediate state for diagnosis\" do\n    [1, 2, 3] |> IO.inspect(label: \"items\") |> Enum.sum()\n  end\nend\n"
+        }
+      ]
+    }
+  ]
+}

--- a/elixir/fixtures/no_raise_inside_rescue.json
+++ b/elixir/fixtures/no_raise_inside_rescue.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_raise_inside_rescue",
+  "cases": [
+    {
+      "name": "blocks_raise_inside_rescue",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "lib/my_app/external.ex",
+          "text": "defmodule MyApp.External do\n  def fetch(url) do\n    HTTP.get!(url)\n  rescue\n    error in [HTTP.Error] ->\n      Logger.error(\"upstream failure: #{inspect(error)}\")\n      raise MyApp.UpstreamError, \"failed to reach #{url}\"\n  end\nend\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_reraise_to_preserve_stacktrace",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "lib/my_app/external.ex",
+          "text": "defmodule MyApp.External do\n  def fetch(url) do\n    HTTP.get!(url)\n  rescue\n    error in [HTTP.Error] ->\n      Logger.error(\"upstream failure: #{inspect(error)}\")\n      reraise error, __STACKTRACE__\n  end\nend\n"
+        }
+      ]
+    }
+  ]
+}

--- a/elixir/fixtures/no_unsafe_to_atom.json
+++ b/elixir/fixtures/no_unsafe_to_atom.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_unsafe_to_atom",
+  "cases": [
+    {
+      "name": "blocks_string_to_atom_on_user_input",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "lib/my_app/feature_flags.ex",
+          "text": "defmodule MyApp.FeatureFlags do\n  def lookup(name) when is_binary(name) do\n    flags()[String.to_atom(name)]\n  end\n\n  defp flags, do: %{billing: true, search: false}\nend\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_string_to_existing_atom",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "lib/my_app/feature_flags.ex",
+          "text": "defmodule MyApp.FeatureFlags do\n  def lookup(name) when is_binary(name) do\n    case fetch_atom(name) do\n      {:ok, key} -> flags()[key]\n      :error -> nil\n    end\n  end\n\n  defp fetch_atom(name) do\n    {:ok, String.to_existing_atom(name)}\n  rescue\n    ArgumentError -> :error\n  end\n\n  defp flags, do: %{billing: true, search: false}\nend\n"
+        }
+      ]
+    }
+  ]
+}

--- a/elixir/fixtures/pattern_match_over_conditional.json
+++ b/elixir/fixtures/pattern_match_over_conditional.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "pattern_match_over_conditional",
+  "cases": [
+    {
+      "name": "warns_on_case_over_function_argument",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "lib/my_app/payments.ex",
+          "text": "defmodule MyApp.Payments do\n  def describe(status) do\n    case status do\n      :pending -> \"awaiting capture\"\n      :captured -> \"captured\"\n      :refunded -> \"refunded\"\n      :failed -> \"failed\"\n    end\n  end\nend\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_function_head_pattern_matching",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "lib/my_app/payments.ex",
+          "text": "defmodule MyApp.Payments do\n  def describe(:pending), do: \"awaiting capture\"\n  def describe(:captured), do: \"captured\"\n  def describe(:refunded), do: \"refunded\"\n  def describe(:failed), do: \"failed\"\nend\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_case_over_intermediate_value",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "lib/my_app/payments.ex",
+          "text": "defmodule MyApp.Payments do\n  def describe(charge) do\n    case classify(charge) do\n      {:terminal, label} -> label\n      {:transient, retry_after} -> \"retry in #{retry_after}s\"\n    end\n  end\n\n  defp classify(%{status: :captured}), do: {:terminal, \"captured\"}\n  defp classify(%{status: :failed, retry_after: retry}), do: {:transient, retry}\nend\n"
+        }
+      ]
+    }
+  ]
+}

--- a/elixir/fixtures/pipe_chain_readability.json
+++ b/elixir/fixtures/pipe_chain_readability.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "pipe_chain_readability",
+  "cases": [
+    {
+      "name": "warns_on_seven_stage_pipeline",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "lib/my_app/reports.ex",
+          "text": "defmodule MyApp.Reports do\n  def daily(events) do\n    events\n    |> Enum.filter(&relevant?/1)\n    |> Enum.map(&normalize/1)\n    |> Enum.group_by(& &1.bucket)\n    |> Enum.map(fn {bucket, rows} -> {bucket, summarize(rows)} end)\n    |> Enum.sort_by(& elem(&1, 0))\n    |> Enum.map(&format_row/1)\n    |> Enum.join(\"\\n\")\n  end\nend\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_short_pipeline",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "lib/my_app/reports.ex",
+          "text": "defmodule MyApp.Reports do\n  def daily(events) do\n    events\n    |> Enum.filter(&relevant?/1)\n    |> Enum.map(&normalize/1)\n    |> summarize_buckets()\n  end\nend\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_pipeline_split_with_intermediate_binding",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "lib/my_app/reports.ex",
+          "text": "defmodule MyApp.Reports do\n  def daily(events) do\n    grouped =\n      events\n      |> Enum.filter(&relevant?/1)\n      |> Enum.map(&normalize/1)\n      |> Enum.group_by(& &1.bucket)\n\n    grouped\n    |> Enum.map(fn {bucket, rows} -> {bucket, summarize(rows)} end)\n    |> Enum.sort_by(&elem(&1, 0))\n    |> Enum.map(&format_row/1)\n    |> Enum.join(\"\\n\")\n  end\nend\n"
+        }
+      ]
+    }
+  ]
+}

--- a/elixir/fixtures/predicate_function_naming.json
+++ b/elixir/fixtures/predicate_function_naming.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "predicate_function_naming",
+  "cases": [
+    {
+      "name": "warns_on_is_prefix_with_question_mark",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "lib/my_app/users.ex",
+          "text": "defmodule MyApp.Users do\n  def is_admin?(user) do\n    user.role == :admin\n  end\nend\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_question_mark_only",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "lib/my_app/users.ex",
+          "text": "defmodule MyApp.Users do\n  def admin?(user) do\n    user.role == :admin\n  end\nend\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_guard_macro_is_prefix",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "lib/my_app/guards.ex",
+          "text": "defmodule MyApp.Guards do\n  defguard is_admin(user) when is_map(user) and :erlang.map_get(:role, user) == :admin\nend\n"
+        }
+      ]
+    }
+  ]
+}

--- a/elixir/fixtures/tagged_error_tuples.json
+++ b/elixir/fixtures/tagged_error_tuples.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "tagged_error_tuples",
+  "cases": [
+    {
+      "name": "blocks_bare_error_atom_return",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "lib/my_app/billing.ex",
+          "text": "defmodule MyApp.Billing do\n  @doc \"Charge a customer for the given invoice.\"\n  def charge(%{customer_id: id, amount: amount}) when is_integer(amount) and amount > 0 do\n    case Stripe.charge(id, amount) do\n      {:ok, charge} -> {:ok, charge}\n      {:error, _reason} -> :error\n    end\n  end\n\n  @doc \"Refund a previously charged invoice.\"\n  def refund(charge_id) do\n    case Stripe.refund(charge_id) do\n      {:ok, refund} -> {:ok, refund}\n      {:error, _reason} -> :error\n    end\n  end\nend\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_consistent_tagged_error_tuples",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "lib/my_app/billing.ex",
+          "text": "defmodule MyApp.Billing do\n  @doc \"Charge a customer for the given invoice.\"\n  def charge(%{customer_id: id, amount: amount}) when is_integer(amount) and amount > 0 do\n    case Stripe.charge(id, amount) do\n      {:ok, charge} -> {:ok, charge}\n      {:error, reason} -> {:error, {:upstream, reason}}\n    end\n  end\n\n  @doc \"Refund a previously charged invoice.\"\n  def refund(charge_id) do\n    case Stripe.refund(charge_id) do\n      {:ok, refund} -> {:ok, refund}\n      {:error, reason} -> {:error, {:upstream, reason}}\n    end\n  end\nend\n"
+        }
+      ]
+    }
+  ]
+}

--- a/elixir/fixtures/unless_with_else.json
+++ b/elixir/fixtures/unless_with_else.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "unless_with_else",
+  "cases": [
+    {
+      "name": "warns_on_unless_else_pair",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "lib/my_app/access.ex",
+          "text": "defmodule MyApp.Access do\n  def check(user) do\n    unless allowed?(user) do\n      raise \"forbidden\"\n    else\n      proceed(user)\n    end\n  end\nend\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_if_else_form",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "lib/my_app/access.ex",
+          "text": "defmodule MyApp.Access do\n  def check(user) do\n    if allowed?(user) do\n      proceed(user)\n    else\n      raise \"forbidden\"\n    end\n  end\nend\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_unless_without_else",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "lib/my_app/access.ex",
+          "text": "defmodule MyApp.Access do\n  def warn_if_locked(user) do\n    unless user.active? do\n      Logger.warning(\"locked user #{user.id}\")\n    end\n  end\nend\n"
+        }
+      ]
+    }
+  ]
+}

--- a/elixir/invariants.harn
+++ b/elixir/invariants.harn
@@ -1,0 +1,307 @@
+let _EVIDENCE_DEBUG_HELPERS = [
+  "https://hexdocs.pm/credo/Credo.Check.Warning.IoInspect.html",
+  "https://hexdocs.pm/elixir/IO.html",
+]
+
+let _EVIDENCE_DBG_MACRO = [
+  "https://hexdocs.pm/credo/Credo.Check.Warning.Dbg.html",
+  "https://hexdocs.pm/elixir/Kernel.html#dbg/2",
+]
+
+let _EVIDENCE_IEX_PRY = [
+  "https://hexdocs.pm/credo/Credo.Check.Warning.IExPry.html",
+  "https://hexdocs.pm/iex/IEx.html#pry/0",
+]
+
+let _EVIDENCE_DYNAMIC_ATOMS = [
+  "https://hexdocs.pm/elixir/main/code-anti-patterns.html",
+  "https://hexdocs.pm/credo/Credo.Check.Warning.UnsafeToAtom.html",
+  "https://hexdocs.pm/elixir/String.html#to_existing_atom/1",
+]
+
+let _EVIDENCE_UNLESS_WITH_ELSE = [
+  "https://hexdocs.pm/credo/Credo.Check.Refactor.UnlessWithElse.html",
+  "https://hexdocs.pm/elixir/Kernel.html#unless/2",
+]
+
+let _EVIDENCE_PREDICATE_NAMING = [
+  "https://hexdocs.pm/credo/Credo.Check.Readability.PredicateFunctionNames.html",
+  "https://hexdocs.pm/elixir/main/naming-conventions.html",
+]
+
+let _EVIDENCE_RAISE_INSIDE_RESCUE = [
+  "https://hexdocs.pm/credo/Credo.Check.Warning.RaiseInsideRescue.html",
+  "https://hexdocs.pm/elixir/Kernel.html#reraise/2",
+]
+
+let _EVIDENCE_PIPE_READABILITY = [
+  "https://hexdocs.pm/credo/Credo.Check.Refactor.PipeChainStart.html",
+  "https://hexdocs.pm/credo/Credo.Check.Refactor.Nesting.html",
+  "https://hexdocs.pm/elixir/main/code-anti-patterns.html",
+]
+
+let _EVIDENCE_TAGGED_ERROR_TUPLES = [
+  "https://hexdocs.pm/elixir/main/naming-conventions.html",
+  "https://hexdocs.pm/elixir/main/library-guidelines.html",
+]
+
+let _EVIDENCE_GENSERVER_BOUNDARY = [
+  "https://hexdocs.pm/elixir/GenServer.html",
+  "https://hexdocs.pm/elixir/main/process-anti-patterns.html",
+]
+
+let _EVIDENCE_PATTERN_MATCH = [
+  "https://hexdocs.pm/elixir/main/code-anti-patterns.html",
+  "https://hexdocs.pm/elixir/case-cond-and-if.html",
+]
+
+fn is_elixir_path(path) {
+  return path.ends_with(".ex") || path.ends_with(".exs")
+}
+
+fn is_test_path(path) {
+  return regex_match(r"(^|/)tests?/", path, "") != nil
+    || path.ends_with("_test.exs")
+}
+
+fn is_generated_path(path) {
+  return regex_match(r"(^|/)(_build|deps|cover|\.elixir_ls)/", path, "") != nil
+}
+
+fn elixir_files(slice) {
+  return slice.files.filter({ file -> is_elixir_path(file.path) })
+}
+
+fn production_elixir_files(slice) {
+  return elixir_files(slice)
+    .filter({ file -> !is_test_path(file.path) && !is_generated_path(file.path) })
+}
+
+fn scan_files(files, pattern, flags) {
+  var findings = []
+  for file in files {
+    if regex_match(pattern, file.text, flags) != nil {
+      findings = findings.push({path: file.path, pattern: pattern})
+    }
+  }
+  return findings
+}
+
+fn scan_files_if(files, predicate) {
+  var findings = []
+  for file in files {
+    if predicate(file) {
+      findings = findings.push({path: file.path})
+    }
+  }
+  return findings
+}
+
+fn allow(rule) {
+  return {verdict: "Allow", rule: rule, findings: [], remediation: ""}
+}
+
+fn warn(rule, remediation, findings) {
+  return {verdict: "Warn", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block(rule, remediation, findings) {
+  return {verdict: "Block", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return block(rule, remediation, findings)
+}
+
+fn warn_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return warn(rule, remediation, findings)
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_DEBUG_HELPERS, confidence: 0.86, source_date: "2026-05-10")
+/** Blocks IO.inspect calls left in production Elixir source. */
+pub fn no_io_inspect(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(production_elixir_files(slice), r"\bIO\.inspect\b", "s")
+  return block_on_findings(
+    "no_io_inspect",
+    "Replace IO.inspect with Logger.debug or remove the call; reserve IO.inspect for live debugging.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_DBG_MACRO, confidence: 0.84, source_date: "2026-05-10")
+/** Blocks dbg/0 and dbg/1 calls left in production Elixir source. */
+pub fn no_dbg_macro(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_elixir_files(slice),
+    r"(?m)(^|[^\w\.:])dbg\s*\(",
+    "m",
+  )
+  return block_on_findings(
+    "no_dbg_macro",
+    "Remove dbg/0 and dbg/1 calls before merging; they are interactive-debug tooling, not production logging.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_IEX_PRY, confidence: 0.86, source_date: "2026-05-10")
+/** Blocks IEx.pry breakpoints in production Elixir source. */
+pub fn no_iex_pry(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_elixir_files(slice),
+    r"\bIEx\.pry\s*\(\s*\)|\brequire\s+IEx\b",
+    "s",
+  )
+  return block_on_findings(
+    "no_iex_pry",
+    "Remove IEx.pry breakpoints and the matching require IEx before merging; they only work in an attached IEx shell.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_DYNAMIC_ATOMS, confidence: 0.84, source_date: "2026-05-10")
+/** Blocks unbounded atom creation that can exhaust the BEAM atom table. */
+pub fn no_unsafe_to_atom(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_elixir_files(slice),
+    r"\bString\.to_atom\s*\(|\bList\.to_atom\s*\(|:erlang\.binary_to_atom\s*\(|:erlang\.list_to_atom\s*\(",
+    "s",
+  )
+  return block_on_findings(
+    "no_unsafe_to_atom",
+    "Use String.to_existing_atom/1, an explicit atom map, or keep the value as a binary; atoms are not garbage collected.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_UNLESS_WITH_ELSE, confidence: 0.82, source_date: "2026-05-10")
+/** Warns when unless is paired with else, which inverts reader expectations. */
+pub fn unless_with_else(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_elixir_files(slice),
+    r"(?m)^\s*unless\s+[^\n]+?\bdo\b[\s\S]{0,400}?^\s*else\b",
+    "m",
+  )
+  return warn_on_findings(
+    "unless_with_else",
+    "Flip the condition and use if ... else; unless ... else reads backwards.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_PREDICATE_NAMING, confidence: 0.78, source_date: "2026-05-10")
+/** Warns when a function is named with both the is_ prefix and a trailing question mark. */
+pub fn predicate_function_naming(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_elixir_files(slice),
+    r"(?m)^\s*defp?\s+is_[A-Za-z0-9_]+\?",
+    "m",
+  )
+  return warn_on_findings(
+    "predicate_function_naming",
+    "Pick one form: end the name with ? for runtime predicates, or use the is_ prefix for guard-safe macros, but not both.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_RAISE_INSIDE_RESCUE, confidence: 0.74, source_date: "2026-05-10")
+/** Blocks raise inside a rescue clause, which discards the original stacktrace. */
+pub fn no_raise_inside_rescue(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_elixir_files(slice),
+    r"(?ms)\brescue\b[^\n]*\n(?:[^\n]*\n){0,20}?[^\n]*\braise\s+[A-Za-z_]",
+    "m",
+  )
+  return block_on_findings(
+    "no_raise_inside_rescue",
+    "Use reraise to preserve the original stacktrace, or rebind the rescued exception and reraise after handling it.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_PIPE_READABILITY, confidence: 0.66, source_date: "2026-05-10")
+/** Warns on pipe chains longer than five stages without an intermediate binding. */
+pub fn pipe_chain_readability(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_elixir_files(slice),
+    r"(?m)(?:^[ \t]*\|>[^\n]*\n){6,}",
+    "m",
+  )
+  return warn_on_findings(
+    "pipe_chain_readability",
+    "Break long pipelines with a named intermediate or a small private function so the steps remain greppable and debuggable.",
+    findings,
+  )
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_TAGGED_ERROR_TUPLES, confidence: 0.64, source_date: "2026-05-10")
+/** Blocks public functions that signal failure with bare atoms or strings instead of tagged error tuples. */
+pub fn tagged_error_tuples(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when a public Elixir function (def, not defp) added or changed in this slice signals fallible outcomes by returning :error, an arbitrary atom, a string, or nil where the rest of the module's public API uses {:ok, value} and {:error, reason} tuples or a bang variant. Allow boolean predicates ending in ?, functions whose contract is documented as returning :ok or an atom enum, callbacks that must conform to a behaviour, and bang functions that intentionally raise."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: production_elixir_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "tagged_error_tuples",
+      "Return {:ok, value} or {:error, reason} for fallible operations, or expose a bang variant; keep the failure shape consistent across the module.",
+      judgement.findings,
+    )
+  }
+  return allow("tagged_error_tuples")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_GENSERVER_BOUNDARY, confidence: 0.6, source_date: "2026-05-10")
+/** Blocks GenServer callbacks that leak fresh internal state types across the call boundary. */
+pub fn genserver_callback_boundary(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed Elixir code defines a GenServer callback (init/1, handle_call/3, handle_cast/2, handle_info/2, handle_continue/2, terminate/2, code_change/3) that returns a state value whose shape disagrees with the module's documented or @type-declared state, introduces a fresh ad hoc tuple or map shape that other callbacks in the same module would not pattern-match, or returns implementation-specific internal types as the reply that the caller is meant to consume directly. Allow callbacks whose state shape matches the declared type, callbacks that wrap reply values in well-known tuples, and modules that explicitly document a richer reply contract."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: production_elixir_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "genserver_callback_boundary",
+      "Keep GenServer callback state and replies aligned with the module's declared state type and stable public contract.",
+      judgement.findings,
+    )
+  }
+  return allow("genserver_callback_boundary")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_PATTERN_MATCH, confidence: 0.62, source_date: "2026-05-10")
+/** Warns when a function body is a single case or cond that could be replaced by function-head pattern matching. */
+pub fn pattern_match_over_conditional(slice, ctx, _repo_at_base) {
+  let rubric = "Warn only when an added or changed Elixir function body is a single case or cond expression that branches directly on the function's own arguments, where each branch could be expressed as a separate function clause with pattern matching or guards over the same arguments. Allow case or cond statements that branch on intermediate computations, that need shared setup before the branching, that share substantial code across branches, or that benefit from a default catch-all in one place."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: production_elixir_files(slice)})
+  if judgement.verdict == "Warn" {
+    return warn(
+      "pattern_match_over_conditional",
+      "Replace the body-level case or cond with multiple function-head clauses that pattern-match on the arguments directly.",
+      judgement.findings,
+    )
+  }
+  return allow("pattern_match_over_conditional")
+}


### PR DESCRIPTION
## Summary
- Adds `elixir/` v0 seed predicate pack: 8 deterministic + 3 semantic predicates with fixtures and README, per [#18](https://github.com/burin-labs/harn-canon/issues/18).
- Predicates cover debug-helper hygiene (`IO.inspect`, `dbg`, `IEx.pry`), unbounded atom creation, idiomatic control flow (`unless`/`else`, predicate naming, `raise` inside `rescue`), pipeline readability, error-contract consistency, GenServer callback-boundary state-shape leakage, and pattern-match-over-conditional refactors.
- Evidence cites HexDocs Elixir official guides (`code-anti-patterns`, `process-anti-patterns`, `naming-conventions`, `library-guidelines`, `case-cond-and-if`, `IO`/`Kernel`/`String`/`IEx`/`GenServer` modules) and Credo 1.7.18 check pages, scanned 2026-05-10.

## Test plan
- [x] `invariants.harn` follows the established Harn syntax used in sibling packs (sql, ruby, kotlin, terraform, markdown).
- [x] Each predicate has a matching `fixtures/<name>.json` with at least one violation case and one allow case; semantic predicates carry their decision rubric inline.
- [x] Production-path filter handles top-level `test/` directories (regex `(^|/)tests?/`) and `_test.exs` files; `_build/`, `deps/`, `cover/`, and `.elixir_ls/` excluded.
- [x] `pipe_chain_readability` regex counts contiguous `|>` lines (≥6) and breaks correctly on intermediate bindings.
- [x] `\braise\b` correctly skips `reraise` due to word-boundary semantics; rescue-clause matching is bounded to ~20 lines to limit false positives.
- [x] Root `README.md` packs list updated alphabetically with the new entry.

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)