### PR TITLE
Add Lua seed predicate pack (#21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ See the Harn Flow design docs for the full predicate language spec.
 - [JavaScript](./javascript/) — v0 draft predicates for plain JavaScript source, async handling, dynamic-code hazards, and untrusted data boundaries.
 - [JSON](./json/) — v0 draft predicates for strict JSON conformance, encoding hygiene, declared-schema respect, and untrusted-data boundaries.
 - [Kotlin](./kotlin/) — v0 draft predicates for Kotlin JVM, Android, and Multiplatform source.
+- [Lua](./lua/) — v0 draft predicates for general-purpose Lua application and library code targeting Lua 5.2+ and LuaJIT.
 - [Markdown](./markdown/) — v0 draft predicates for prose Markdown files used for documentation, READMEs, and design notes.
 - [Python](./python/) — v0 draft predicates for Python application and library code.
 - [Ruby](./ruby/) — v0 draft predicates for Ruby application and library code.

--- a/lua/README.md
+++ b/lua/README.md
@@ -1,0 +1,63 @@
+# Lua Seed Predicate Pack
+
+This pack covers general-purpose Lua application and library code targeting modern Lua (5.2+, including LuaJIT). It focuses on review-slice checks with clear correctness, maintenance, or security impact: implicit globals, dynamic source loading, removed-API usage (`setfenv`/`getfenv`), shell-execution hygiene, module-return convention, `require` binding style, tail-call recursion, metatable-boundary documentation, and hardcoded secrets.
+
+## Stack Assumptions
+
+- Files use the `.lua` extension. LuaRocks `.rockspec` files are intentionally excluded — they are written as bare-name globals (a Lua-as-DSL pattern) and would trip the implicit-globals heuristic.
+- Projects target Lua 5.2 or newer (or LuaJIT) — `setfenv` and `getfenv` were removed in Lua 5.2 and `loadstring` was folded into `load`. Code that needs Lua 5.1 compatibility should suppress the affected predicates locally.
+- Production-path checks exclude obvious `spec/`, `test/`, `tests/`, `bin/`, `script/`, `scripts/`, `examples/` paths and files ending in `_spec.lua` or `_test.lua`.
+- `module_returns_value` further excludes files that begin with a `#!` shebang, treating those as scripts rather than modules.
+- Deterministic predicates run over changed source text until Flow exposes a stable Lua AST query API. Rules with meaningful false-positive risk (`no_implicit_globals`, `module_returns_value`, `require_assigned_to_local`) warn rather than block.
+- Semantic predicates use one cheap judge call and should block only when they can cite concrete changed spans.
+
+## Predicate Coverage
+
+| Predicate | Mode | Verdict | Purpose |
+|---|---|---|---|
+| `no_global_function_definition` | deterministic | Block | Top-level `function name(...)` creates an implicit global; modules should declare `local function` or attach to a module table. |
+| `no_implicit_globals` | deterministic | Warn | Top-level bare-name assignments leak through `_G`; they should be `local` or written through `_G.` to make intent explicit. |
+| `no_loadstring_or_loadfile` | deterministic | Block | Compiling caller-supplied Lua source is the equivalent of `eval` and is the leading injection vector in scripted hosts. |
+| `no_setfenv_or_getfenv` | deterministic | Block | Both functions were removed in Lua 5.2 and are unavailable on modern runtimes; use the `_ENV` upvalue instead. |
+| `no_unsafe_os_command` | deterministic | Block | `os.execute` and `io.popen` invoke a shell; non-literal arguments are command-injection risks. |
+| `module_returns_value` | deterministic | Warn | Lua modules should end with `return M` so `require` consumers receive the module table. |
+| `require_assigned_to_local` | deterministic | Warn | `require` results should be bound to a local; bare top-level `require` calls only side-effect through `package.loaded`. |
+| `tail_call_recursion` | semantic | Warn | Recursive functions should keep the recursive call in tail position to avoid unbounded stack growth. |
+| `metatable_boundary_documented` | semantic | Block | Mutating metatable fields changes table behavior in a non-local way; the change should explain the new contract. |
+| `no_hardcoded_secrets` | semantic | Block | Credentials and tokens should come from a secret manager or scoped environment, not embedded literals. |
+
+## Evidence
+
+Evidence scanned on 2026-05-10.
+
+- Lua 5.4 reference manual: assignments (§3.3.3), function definitions (§3.4.11), proper tail calls (§3.4.10), metatables (§2.4), modules (§6.3), and the `load`, `loadfile`, `dofile`, `require`, `os.execute`, and `io.popen` standard library entries.
+- Lua 5.2 reference manual incompatibilities (§8.1) — `setfenv`/`getfenv` removal.
+- Programming in Lua (Lua.org): chapters on local variables and blocks (6.2), tail calls (6.3), metatables (13), modules and packages (15), and `require` (15.1).
+- Luacheck documentation: warning catalogue for non-local globals and unused values.
+- Lua-users wiki tutorials: `ScopeTutorial`, `ModulesTutorial`, `MetatablesTutorial`, and the Lua 5.2 migration page.
+- OWASP cheat sheets and GitHub secret scanning documentation: code injection, OS command injection, secrets management, and hardcoded credential risk.
+
+## Known False Positives
+
+- Regex predicates are source-text checks. Comments, string literals, multiline strings (`[[ ... ]]`), and metaprogramming can fool them until AST-backed matching lands.
+- `no_global_function_definition` flags any `function name(` at the start of a line; the column-zero heuristic misses functions defined inside a `do ... end` block (false negative) and may flag `function name(` lines inside long-strings (false positive).
+- `no_implicit_globals` matches column-zero bare-name assignments (`foo = ...` or `foo, bar = ...`) and cannot tell a deliberate `_ENV` reassignment apart from a forgotten `local`. Indented assignments inside functions are not inspected — the rule is about top-level binding hygiene.
+- `no_loadstring_or_loadfile` and `no_unsafe_os_command` allow literal-string arguments and block dynamic ones; if a single file mixes both, only the block triggers (file-global heuristic). They cannot prove a variable is trusted.
+- `no_setfenv_or_getfenv` will flag the legitimate Lua 5.1 compatibility shim `local setfenv = setfenv or function(...) ... end`. Projects that genuinely target 5.1 should suppress the rule for that file.
+- `module_returns_value` checks only that a column-zero `return` statement appears anywhere in the file, so files that early-return inside a guarded `if` block but never reach a final `return` will still pass. The rule excludes test, script, and example paths and files starting with a `#!` shebang. Side-effect-only modules (e.g., a strict-mode patch loaded for its registration) should add a trailing `return true` to silence it.
+- `require_assigned_to_local` flags any top-level `require` not preceded by `local NAME =`. Side-effect-only `require` calls (e.g., loading a logger that registers itself) trigger the warn until they are wrapped in `local _ = require(...)`.
+- Semantic predicates depend on a cheap judge and should stay high-threshold until Flow exposes structured Lua data-flow.
+
+## Fixtures
+
+Each fixture in `fixtures/` contains one blocked or warned example and one allowed example for the corresponding predicate. The fixture shape mirrors the existing seed packs:
+
+```json
+{
+  "predicate": "name",
+  "cases": [
+    {"expect": "Block", "files": [{"path": "src/server.lua", "text": "..."}]},
+    {"expect": "Allow", "files": [{"path": "src/server.lua", "text": "..."}]}
+  ]
+}
+```

--- a/lua/fixtures/metatable_boundary_documented.json
+++ b/lua/fixtures/metatable_boundary_documented.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "metatable_boundary_documented",
+  "cases": [
+    {
+      "name": "blocks_undocumented_index_metamethod",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/store.lua",
+          "text": "local Store = {}\nlocal mt = {}\nmt.__index = function(t, k)\n  return rawget(Store, k) or rawget(t, k) or nil\nend\nsetmetatable(Store, mt)\n\nreturn Store\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_documented_metatable_assignment",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/store.lua",
+          "text": "local Store = {}\nlocal mt = {}\n-- Store: route missing keys to Store's class table so instances inherit methods.\nmt.__index = Store\nsetmetatable(Store, mt)\n\nreturn Store\n"
+        }
+      ]
+    }
+  ]
+}

--- a/lua/fixtures/module_returns_value.json
+++ b/lua/fixtures/module_returns_value.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "module_returns_value",
+  "cases": [
+    {
+      "name": "warns_on_module_without_return",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/util.lua",
+          "text": "local M = {}\n\nfunction M.add(a, b)\n  return a + b\nend\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_module_with_trailing_return",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/util.lua",
+          "text": "local M = {}\n\nfunction M.add(a, b)\n  return a + b\nend\n\nreturn M\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_shebang_script_without_return",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "bin/migrate.lua",
+          "text": "#!/usr/bin/env lua\n\nlocal db = require('db')\ndb.migrate()\n"
+        }
+      ]
+    }
+  ]
+}

--- a/lua/fixtures/no_global_function_definition.json
+++ b/lua/fixtures/no_global_function_definition.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_global_function_definition",
+  "cases": [
+    {
+      "name": "blocks_top_level_global_function",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/handlers.lua",
+          "text": "function handle_request(req)\n  return req.body\nend\n\nreturn { handle_request = handle_request }\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_local_function",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/handlers.lua",
+          "text": "local M = {}\n\nlocal function handle_request(req)\n  return req.body\nend\n\nfunction M.dispatch(req)\n  return handle_request(req)\nend\n\nreturn M\n"
+        }
+      ]
+    }
+  ]
+}

--- a/lua/fixtures/no_hardcoded_secrets.json
+++ b/lua/fixtures/no_hardcoded_secrets.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_hardcoded_secrets",
+  "cases": [
+    {
+      "name": "blocks_hardcoded_api_token",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/client.lua",
+          "text": "local M = {}\n\nlocal API_TOKEN = 'sk-live-9f8a2c1b4d6e7f0a1b2c3d4e5f6a7b8c'\n\nfunction M.headers()\n  return { Authorization = 'Bearer ' .. API_TOKEN }\nend\n\nreturn M\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_token_from_environment",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/client.lua",
+          "text": "local M = {}\n\nlocal function token()\n  return assert(os.getenv('SERVICE_API_TOKEN'), 'SERVICE_API_TOKEN must be set')\nend\n\nfunction M.headers()\n  return { Authorization = 'Bearer ' .. token() }\nend\n\nreturn M\n"
+        }
+      ]
+    }
+  ]
+}

--- a/lua/fixtures/no_implicit_globals.json
+++ b/lua/fixtures/no_implicit_globals.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_implicit_globals",
+  "cases": [
+    {
+      "name": "warns_on_top_level_bare_assignment",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/config.lua",
+          "text": "DEFAULT_TIMEOUT = 30\nMAX_RETRIES = 5\n\nreturn { timeout = DEFAULT_TIMEOUT, retries = MAX_RETRIES }\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_local_and_explicit_global",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/config.lua",
+          "text": "local DEFAULT_TIMEOUT = 30\n_G.LEGACY_FLAG = true\n\nreturn { timeout = DEFAULT_TIMEOUT }\n"
+        }
+      ]
+    }
+  ]
+}

--- a/lua/fixtures/no_loadstring_or_loadfile.json
+++ b/lua/fixtures/no_loadstring_or_loadfile.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_loadstring_or_loadfile",
+  "cases": [
+    {
+      "name": "blocks_dynamic_load_of_user_input",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/rules.lua",
+          "text": "local M = {}\n\nfunction M.run(source)\n  local chunk = load(source)\n  return chunk()\nend\n\nreturn M\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_literal_load",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/rules.lua",
+          "text": "local M = {}\n\nfunction M.bootstrap()\n  local chunk = load('return 42')\n  return chunk()\nend\n\nreturn M\n"
+        }
+      ]
+    }
+  ]
+}

--- a/lua/fixtures/no_setfenv_or_getfenv.json
+++ b/lua/fixtures/no_setfenv_or_getfenv.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_setfenv_or_getfenv",
+  "cases": [
+    {
+      "name": "blocks_setfenv_call",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/sandbox.lua",
+          "text": "local function run_in(env, fn)\n  setfenv(fn, env)\n  return fn()\nend\n\nreturn run_in\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_env_upvalue",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/sandbox.lua",
+          "text": "local function run_in(env, source)\n  local chunk = load(source, 'sandbox', 't', env)\n  return chunk and chunk()\nend\n\nreturn run_in\n"
+        }
+      ]
+    }
+  ]
+}

--- a/lua/fixtures/no_unsafe_os_command.json
+++ b/lua/fixtures/no_unsafe_os_command.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_unsafe_os_command",
+  "cases": [
+    {
+      "name": "blocks_dynamic_os_execute",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/runner.lua",
+          "text": "local M = {}\n\nfunction M.run(cmd)\n  return os.execute(cmd)\nend\n\nreturn M\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_literal_os_execute",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/runner.lua",
+          "text": "local M = {}\n\nfunction M.healthcheck()\n  return os.execute('uptime')\nend\n\nreturn M\n"
+        }
+      ]
+    }
+  ]
+}

--- a/lua/fixtures/require_assigned_to_local.json
+++ b/lua/fixtures/require_assigned_to_local.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "require_assigned_to_local",
+  "cases": [
+    {
+      "name": "warns_on_bare_top_level_require",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/init.lua",
+          "text": "require('logger')\nrequire 'metrics'\n\nreturn true\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_local_bound_require",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/init.lua",
+          "text": "local logger = require('logger')\nlocal metrics = require('metrics')\n\nreturn { logger = logger, metrics = metrics }\n"
+        }
+      ]
+    }
+  ]
+}

--- a/lua/fixtures/tail_call_recursion.json
+++ b/lua/fixtures/tail_call_recursion.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "tail_call_recursion",
+  "cases": [
+    {
+      "name": "warns_on_non_tail_recursion",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/math.lua",
+          "text": "local M = {}\n\nfunction M.factorial(n)\n  if n <= 1 then return 1 end\n  return n * M.factorial(n - 1)\nend\n\nreturn M\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_tail_recursive_helper",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/math.lua",
+          "text": "local M = {}\n\nlocal function go(n, acc)\n  if n <= 1 then return acc end\n  return go(n - 1, n * acc)\nend\n\nfunction M.factorial(n)\n  return go(n, 1)\nend\n\nreturn M\n"
+        }
+      ]
+    }
+  ]
+}

--- a/lua/invariants.harn
+++ b/lua/invariants.harn
@@ -1,0 +1,314 @@
+let _EVIDENCE_GLOBAL_FUNCTION = [
+  "https://www.lua.org/manual/5.4/manual.html#3.4.11",
+  "https://www.lua.org/pil/6.2.html",
+  "https://luacheck.readthedocs.io/en/stable/warnings.html",
+]
+
+let _EVIDENCE_IMPLICIT_GLOBALS = [
+  "https://www.lua.org/manual/5.4/manual.html#3.3.3",
+  "https://luacheck.readthedocs.io/en/stable/warnings.html",
+  "http://lua-users.org/wiki/ScopeTutorial",
+]
+
+let _EVIDENCE_LOAD_FAMILY = [
+  "https://www.lua.org/manual/5.4/manual.html#pdf-load",
+  "https://www.lua.org/manual/5.4/manual.html#pdf-loadfile",
+  "https://www.lua.org/manual/5.4/manual.html#pdf-dofile",
+  "https://cheatsheetseries.owasp.org/cheatsheets/Code_Injection_Prevention_Cheat_Sheet.html",
+]
+
+let _EVIDENCE_SETFENV_GETFENV = [
+  "https://www.lua.org/manual/5.2/manual.html#8.1",
+  "https://www.lua.org/manual/5.4/manual.html#6.1",
+  "http://lua-users.org/wiki/LuaFiveTwo",
+]
+
+let _EVIDENCE_OS_COMMAND = [
+  "https://www.lua.org/manual/5.4/manual.html#pdf-os.execute",
+  "https://www.lua.org/manual/5.4/manual.html#pdf-io.popen",
+  "https://cheatsheetseries.owasp.org/cheatsheets/OS_Command_Injection_Defense_Cheat_Sheet.html",
+]
+
+let _EVIDENCE_MODULE_RETURN = [
+  "https://www.lua.org/manual/5.4/manual.html#6.3",
+  "https://www.lua.org/pil/15.html",
+  "http://lua-users.org/wiki/ModulesTutorial",
+]
+
+let _EVIDENCE_REQUIRE_LOCAL = [
+  "https://www.lua.org/manual/5.4/manual.html#pdf-require",
+  "https://www.lua.org/pil/15.1.html",
+  "http://lua-users.org/wiki/ModulesTutorial",
+]
+
+let _EVIDENCE_TAIL_CALLS = [
+  "https://www.lua.org/manual/5.4/manual.html#3.4.10",
+  "https://www.lua.org/pil/6.3.html",
+]
+
+let _EVIDENCE_METATABLES = [
+  "https://www.lua.org/manual/5.4/manual.html#2.4",
+  "https://www.lua.org/pil/13.html",
+  "http://lua-users.org/wiki/MetatablesTutorial",
+]
+
+let _EVIDENCE_SECRETS = [
+  "https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html",
+  "https://docs.github.com/code-security/secret-scanning/about-secret-scanning",
+]
+
+fn is_lua_path(path) {
+  return path.ends_with(".lua")
+}
+
+fn is_test_path(path) {
+  return path.contains("/spec/")
+    || path.contains("/test/")
+    || path.contains("/tests/")
+    || path.ends_with("_spec.lua")
+    || path.ends_with("_test.lua")
+}
+
+fn is_script_path(path) {
+  return path.contains("/bin/")
+    || path.contains("/scripts/")
+    || path.contains("/script/")
+    || path.contains("/examples/")
+}
+
+fn lua_files(slice) {
+  return slice.files.filter({ file -> is_lua_path(file.path) })
+}
+
+fn production_lua_files(slice) {
+  return lua_files(slice)
+    .filter({ file -> !is_test_path(file.path) && !is_script_path(file.path) })
+}
+
+fn module_lua_files(slice) {
+  return production_lua_files(slice)
+    .filter({ file -> regex_match(r"\A#!", file.text, "s") == nil })
+}
+
+fn scan_files(files, pattern, flags) {
+  var findings = []
+  for file in files {
+    if regex_match(pattern, file.text, flags) != nil {
+      findings = findings.push({path: file.path, pattern: pattern})
+    }
+  }
+  return findings
+}
+
+fn scan_files_if(files, predicate) {
+  var findings = []
+  for file in files {
+    if predicate(file) {
+      findings = findings.push({path: file.path})
+    }
+  }
+  return findings
+}
+
+fn scan_files_without(files, include_pattern, exclude_pattern) {
+  return scan_files_if(
+    files,
+    { file -> regex_match(include_pattern, file.text, "s") != nil
+      && regex_match(exclude_pattern, file.text, "s") == nil },
+  )
+}
+
+fn allow(rule) {
+  return {verdict: "Allow", rule: rule, findings: [], remediation: ""}
+}
+
+fn warn(rule, remediation, findings) {
+  return {verdict: "Warn", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block(rule, remediation, findings) {
+  return {verdict: "Block", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return block(rule, remediation, findings)
+}
+
+fn warn_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return warn(rule, remediation, findings)
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_GLOBAL_FUNCTION, confidence: 0.78, source_date: "2026-05-10")
+/** Blocks top-level `function name(...)` definitions that create implicit globals. */
+pub fn no_global_function_definition(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_lua_files(slice),
+    r"(?m)^[ \t]*function\s+[A-Za-z_][A-Za-z0-9_]*\s*\(",
+    "m",
+  )
+  return block_on_findings(
+    "no_global_function_definition",
+    "Use `local function name(...)` or attach the function to a module table (`function M.name(...)`).",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_IMPLICIT_GLOBALS, confidence: 0.7, source_date: "2026-05-10")
+/** Warns on bare column-zero assignments that create implicit globals instead of locals. */
+pub fn no_implicit_globals(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_lua_files(slice),
+    r"(?m)^[A-Za-z_][A-Za-z0-9_]*(?:\s*,\s*[A-Za-z_][A-Za-z0-9_]*)*\s*=[^=]",
+    "m",
+  )
+  return warn_on_findings(
+    "no_implicit_globals",
+    "Prefix top-level bindings with `local`, or write through `_G.` to make the global write explicit.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_LOAD_FAMILY, confidence: 0.78, source_date: "2026-05-10")
+/** Blocks dynamic source loading via load/loadstring/loadfile/dofile with non-literal arguments. */
+pub fn no_loadstring_or_loadfile(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_without(
+    lua_files(slice),
+    r"(?m)(^|[^A-Za-z0-9_.:])(loadstring|load|loadfile|dofile)\s*\(",
+    r"(?m)(^|[^A-Za-z0-9_.:])(loadstring|load|loadfile|dofile)\s*\(\s*(['\"]|\[\[|\[=)",
+  )
+  return block_on_findings(
+    "no_loadstring_or_loadfile",
+    "Pass a literal string or trusted file path; never compile or execute caller-supplied source.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_SETFENV_GETFENV, confidence: 0.88, source_date: "2026-05-10")
+/** Blocks setfenv/getfenv usage that was removed in Lua 5.2 and is unavailable on modern runtimes. */
+pub fn no_setfenv_or_getfenv(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    lua_files(slice),
+    r"(?m)(^|[^A-Za-z0-9_.:])(setfenv|getfenv)\s*\(",
+    "m",
+  )
+  return block_on_findings(
+    "no_setfenv_or_getfenv",
+    "Use the Lua 5.2+ `_ENV` upvalue or an explicit environment table; setfenv/getfenv were removed.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_OS_COMMAND, confidence: 0.74, source_date: "2026-05-10")
+/** Blocks os.execute/io.popen calls whose first argument is not a literal string. */
+pub fn no_unsafe_os_command(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_without(
+    lua_files(slice),
+    r"\b(os\.execute|io\.popen)\s*\(",
+    r"\b(os\.execute|io\.popen)\s*\(\s*(['\"]|\[\[|\[=)",
+  )
+  return block_on_findings(
+    "no_unsafe_os_command",
+    "Build the argv as a table or quote each interpolated value; never concatenate untrusted input into a shell string.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_MODULE_RETURN, confidence: 0.66, source_date: "2026-05-10")
+/** Warns when a Lua module file has no column-zero `return` statement. */
+pub fn module_returns_value(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    module_lua_files(slice),
+    { file -> regex_match(r"(?m)^return\b", file.text, "m") == nil },
+  )
+  return warn_on_findings(
+    "module_returns_value",
+    "End the module with `return M` (or the module table you defined) so `require` consumers receive a value.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_REQUIRE_LOCAL, confidence: 0.7, source_date: "2026-05-10")
+/** Warns on `require` calls at top-level that are not assigned to a local binding. */
+pub fn require_assigned_to_local(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_lua_files(slice),
+    r"(?m)^[ \t]*require\s*[\(\"'\[]",
+    "m",
+  )
+  return warn_on_findings(
+    "require_assigned_to_local",
+    "Bind require results to a local: `local mod = require('mod')`; bare `require` calls leak through package.loaded only.",
+    findings,
+  )
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_TAIL_CALLS, confidence: 0.6, source_date: "2026-05-10")
+/** Warns on recursive Lua functions whose recursive call is not in tail position. */
+pub fn tail_call_recursion(slice, ctx, _repo_at_base) {
+  let rubric = "Warn only when changed Lua source defines a function that calls itself recursively and the recursive call is not in tail position — that is, the result is consumed by an arithmetic, logical, indexing, or wrapping expression before being returned. A call is in tail position when it is the entire return expression (e.g., `return f(...)`). Allow when recursion depth is bounded by a small literal, when the recursive call is wrapped in pcall/xpcall for protected execution, or when the function is iterative."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: lua_files(slice)})
+  if judgement.verdict == "Block" {
+    return warn(
+      "tail_call_recursion",
+      "Move the recursive call into tail position (`return self_call(...)`) or rewrite as a loop to avoid stack growth.",
+      judgement.findings,
+    )
+  }
+  return allow("tail_call_recursion")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_METATABLES, confidence: 0.62, source_date: "2026-05-10")
+/** Blocks metatable mutations that change reads, writes, or identity without an adjacent comment. */
+pub fn metatable_boundary_documented(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed Lua source assigns to a metatable field that crosses a behavior boundary — `__index`, `__newindex`, `__metatable`, `__call`, `__eq`, `__lt`, `__le`, `__add`, `__concat`, `__tostring`, or `__gc` — without an adjacent comment, docstring, or annotation that names the target type and explains the new behavior. Allow purely additive helper assignments inside a class-builder helper that already documents the pattern."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: lua_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "metatable_boundary_documented",
+      "Document the metatable contract in a comment next to the assignment: which field, which type, and what the new behavior is.",
+      judgement.findings,
+    )
+  }
+  return allow("metatable_boundary_documented")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_SECRETS, confidence: 0.68, source_date: "2026-05-10")
+/** Blocks hardcoded credentials and high-risk secrets in Lua source. */
+pub fn no_hardcoded_secrets(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed Lua source embeds credentials, API tokens, private keys, signing secrets, database passwords, production connection strings, or long-lived service credentials instead of reading them from a secret manager or scoped environment variable."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: lua_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "no_hardcoded_secrets",
+      "Move secrets to a secret manager or scoped environment variable and rotate exposed values.",
+      judgement.findings,
+    )
+  }
+  return allow("no_hardcoded_secrets")
+}


### PR DESCRIPTION
## Summary

- Adds the v0 Lua seed predicate pack covering general-purpose Lua application and library code targeting Lua 5.2+ and LuaJIT.
- 7 deterministic predicates (implicit globals, removed APIs, dynamic source loading, shell-execution hygiene, module-return convention, `require` binding) + 3 semantic predicates (tail-call recursion, metatable-boundary documentation, hardcoded secrets).
- Each predicate has at least two independent evidence sources (Lua reference manual, Programming in Lua, Lua-users wiki, Luacheck docs, OWASP cheat sheets) scanned 2026-05-10 and a fixture pair (allow + block) under `lua/fixtures/`.

## Test plan

- [x] `node -e 'JSON.parse(...)'` — every fixture parses as valid JSON.
- [x] Manually traced each deterministic regex against its fixture text in a JS regex sandbox — every fixture flips the verdict in the expected direction.
- [x] Confirmed the regex grammar avoids lookarounds (Rust `regex` crate compatible).
- [ ] CI placeholders pass once the Harn Flow runtime ships and replays fixtures.

Closes #21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)