### PR TITLE
Add C seed predicate pack (#13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ See the Harn Flow design docs for the full predicate language spec.
 
 ## Packs
 
+- [C](./c/) — v0 draft predicates for plain C source and headers covering memory, string-handling, format-string, and tempfile footguns.
 - [C#](./csharp/) — v0 draft predicates for plain C# and .NET library or application code.
 - [CSS](./css/) — v0 draft predicates for CSS, Sass, and Less stylesheets covering cascade hygiene, internationalization, and accessibility.
 - [Dockerfile](./dockerfile/) — v0 draft predicates for `Dockerfile` and `Containerfile` build recipes.

--- a/c/README.md
+++ b/c/README.md
@@ -1,0 +1,66 @@
+# C Seed Predicate Pack
+
+This pack covers plain C source and header files for hosted application and library code. It targets the high-signal review issues an Archivist can catch cheaply on changed slices: classic memory and string-handling footguns (`gets`, unbounded copies, format-string vulns), unsafe entry points (`void main`, `tmpnam`/`mktemp`), parsing helpers that swallow errors (`atoi`/`atol`/`atof`), header hygiene, and stack-allocation hazards. Three semantic predicates carry the load that regex cannot: NULL-return checks on heap allocations, evidence of a static-analyzer or sanitizer pipeline, and vulnerability-check evidence for native dependency changes.
+
+## Stack Assumptions
+
+- C source files use `.c`; C headers use `.h`. Files containing only C++ (`.cc`, `.cpp`, `.cxx`, `.hpp`) are out of scope for this pack — see a future C++ pack for those.
+- Production paths exclude any path under `test/`, `tests/`, `unittest/`, `unittests/`, and any file matching `*_test.c`, `*_tests.c`, or `test_main.c`.
+- Generated C files marked with a top-level `Code generated ... DO NOT EDIT` or `Auto-generated ... DO NOT EDIT` comment are ignored by deterministic source predicates.
+- Deterministic predicates use file-text regex scans because Harn Flow does not yet expose a stable C AST or preprocessor query API.
+- Semantic predicates make a single judge call over changed C and project files using only evidence captured at authoring time.
+- Hosted environment is assumed (i.e., `int main` is required). Freestanding builds (kernel, embedded firmware, microcontrollers) should suppress `no_void_main` locally once the predicate runtime supports suppressions.
+
+## Predicate Coverage
+
+| Predicate | Mode | Verdict | Purpose |
+|---|---|---|---|
+| `no_gets` | deterministic | Block | `gets()` has no length bound and was removed from the C standard library in C11; there is no safe call site. |
+| `bounded_string_ops` | deterministic | Warn | `strcpy`, `strcat`, `sprintf`, `vsprintf`, and `scanf` cannot accept a length bound; bounded variants exist for each. |
+| `no_void_main` | deterministic | Block | Hosted-environment programs must declare `main` with `int` return type; `void main` is undefined behavior on most exit paths. |
+| `no_format_string_from_variable` | deterministic | Block | Passing a non-literal as the format argument is the standard format-string vulnerability (CWE-134). |
+| `no_unsafe_tmpfile` | deterministic | Block | `tmpnam`, `tempnam`, and `mktemp` choose a name and leave a TOCTOU window before `open`. |
+| `no_atoi_family` | deterministic | Warn | `atoi`/`atol`/`atoll`/`atof` cannot signal conversion failure or overflow; `strtol`/`strtoul`/`strtod` can. |
+| `c_header_has_include_guard` | deterministic | Warn | C headers must be safe to include multiple times; missing guards cause redefinition errors and ODR-style problems. |
+| `no_alloca` | deterministic | Warn | `alloca` and dynamic VLAs sized by user input can silently exhaust the stack; behavior on overflow is implementation-defined. |
+| `allocation_return_checked` | semantic | Block | Heap allocators (`malloc`/`calloc`/`realloc`/`strdup`/`asprintf`) can return NULL; using the result without a check is undefined behavior. |
+| `static_analyzer_clean` | semantic | Block | Pointer arithmetic, manual memory management, parsing, and concurrency primitives benefit from clang-analyzer / cppcheck / sanitizer coverage; the change should show evidence one of those is wired up. |
+| `c_dependency_security_checked` | semantic | Block | Native dependency manifests (CMake/Make/conan/vcpkg/meson) and CI changes should preserve a CVE/OSV/Dependabot review path. |
+
+## Evidence
+
+Evidence scanned on 2026-05-10.
+
+- **Linux man pages (man7.org)**: `gets(3)`, `fgets(3p)`, `strncpy(3)`, `snprintf(3)`, `printf(3)`, `mkstemp(3)`, `tmpnam(3)`, `strtol(3)`, `atoi(3)`, `malloc(3)`, `alloca(3)`.
+- **GNU C Library Reference Manual**: program arguments and `main`, copying strings and arrays, parsing of integers, variable-size automatic storage, unconstrained allocation.
+- **GCC Preprocessor Manual**: once-only headers (canonical `#pragma once` / `#ifndef` guidance).
+- **ISO C standard**: ISO/IEC 9899:1999 working draft (N1570) for hosted-environment `main` signature.
+- **CWE / MITRE**: CWE-120 (classic buffer overflow), CWE-134 (uncontrolled format string), CWE-242 (use of inherently dangerous function), CWE-377 (insecure temporary file), CWE-690 (unchecked return value to NULL pointer dereference).
+- **OWASP**: Format String Attack reference, Source Code Analysis Tools index.
+- **Static-analysis and sanitizer tooling**: Clang Static Analyzer, Cppcheck manual, Google Sanitizers wiki (AddressSanitizer/UBSan/MSan/TSan).
+- **Style guides**: Google C++ Style Guide on `#define` header guards (applies cleanly to C).
+- **Dependency security**: OSV.dev, Microsoft `vcpkg` docs, Conan 2.x requirements docs, GitHub Dependabot configuration docs.
+
+## Known False Positives
+
+- Regex predicates do not parse C. Macro-expanded names, comments containing the function names, string-literal arguments quoting the names, and unusual whitespace can confuse deterministic checks.
+- `no_format_string_from_variable` matches conservative patterns: a bare identifier as the format argument for `printf`/`vprintf`/`sprintf`/`vsprintf`, the second argument for `fprintf`/`dprintf`/`vfprintf`/`syslog`, and the third argument for `snprintf`/`vsnprintf`. Helper wrappers that take a `va_list` and call-expression format arguments such as `printf(get_msg())` are false negatives this predicate intentionally does not cover; rely on `static_analyzer_clean` (clang-analyzer's `-Wformat-nonliteral`) for those. Calls that build the format via `strcat` and then pass the buffer are likewise covered by `static_analyzer_clean` or `bounded_string_ops`.
+- `bounded_string_ops` flags any use, including cases where the length is statically provable (e.g. `sprintf(buf, "%d", id)` into a sufficiently large buffer). It is intentionally a Warn so reviewers can confirm the bound rather than rewriting.
+- `no_void_main` only inspects `.c` source files. It does not catch `void main` declared in a header that is then defined elsewhere; that pattern is exotic enough that the noise of scanning headers was not worth it.
+- `c_header_has_include_guard` accepts both `#pragma once` and the canonical `#ifndef`/`#define`/`#endif` triple. Headers that wrap their entire body in a single conditional for unrelated reasons are a rare false positive.
+- `no_alloca` does not currently flag VLAs (variable-length arrays). VLA detection without an AST has too high a false-positive rate; the semantic `static_analyzer_clean` predicate covers the common case via clang-analyzer.
+- Semantic predicates depend on the judge recognizing concrete changed spans. They should stay high-threshold and cite exact code or build-config evidence before blocking.
+
+## Fixtures
+
+Each fixture in `fixtures/` contains at least one blocked or warned example and at least one allowed example for the corresponding predicate. The fixture shape matches the harn-canon convention:
+
+```json
+{
+  "predicate": "name",
+  "cases": [
+    {"expect": "Block", "files": [{"path": "src/parser.c", "text": "..."}]},
+    {"expect": "Allow", "files": [{"path": "src/parser.c", "text": "..."}]}
+  ]
+}
+```

--- a/c/fixtures/allocation_return_checked.json
+++ b/c/fixtures/allocation_return_checked.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "allocation_return_checked",
+  "cases": [
+    {
+      "name": "blocks_unchecked_malloc_dereference",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/store.c",
+          "text": "#include <stdlib.h>\n#include <string.h>\n\nchar *make_copy(const char *src, size_t n) {\n\tchar *buf = malloc(n + 1);\n\tmemcpy(buf, src, n);\n\tbuf[n] = '\\0';\n\treturn buf;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_null_check_then_use",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/store.c",
+          "text": "#include <stdlib.h>\n#include <string.h>\n\nchar *make_copy(const char *src, size_t n) {\n\tchar *buf = malloc(n + 1);\n\tif (buf == NULL) {\n\t\treturn NULL;\n\t}\n\tmemcpy(buf, src, n);\n\tbuf[n] = '\\0';\n\treturn buf;\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/c/fixtures/bounded_string_ops.json
+++ b/c/fixtures/bounded_string_ops.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "bounded_string_ops",
+  "cases": [
+    {
+      "name": "warns_on_strcpy",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/format.c",
+          "text": "#include <string.h>\n\nvoid copy_name(char *dst, const char *src) {\n\tstrcpy(dst, src);\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_snprintf_with_size",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/format.c",
+          "text": "#include <stdio.h>\n\nint format_id(char *buf, size_t cap, int id) {\n\treturn snprintf(buf, cap, \"id=%d\", id);\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/c/fixtures/c_dependency_security_checked.json
+++ b/c/fixtures/c_dependency_security_checked.json
@@ -1,0 +1,33 @@
+{
+  "predicate": "c_dependency_security_checked",
+  "cases": [
+    {
+      "name": "blocks_dependency_change_without_vuln_check",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "conanfile.txt",
+          "text": "[requires]\nopenssl/3.2.0\nlibcurl/8.5.0\nzlib/1.3\n\n[generators]\nCMakeDeps\nCMakeToolchain\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_dependency_change_with_dependabot_and_advisory_pipeline",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "conanfile.txt",
+          "text": "[requires]\nopenssl/3.2.0\nlibcurl/8.5.0\nzlib/1.3\n\n[generators]\nCMakeDeps\nCMakeToolchain\n"
+        },
+        {
+          "path": ".github/dependabot.yml",
+          "text": "version: 2\nupdates:\n  - package-ecosystem: \"github-actions\"\n    directory: \"/\"\n    schedule:\n      interval: \"weekly\"\n  - package-ecosystem: \"docker\"\n    directory: \"/\"\n    schedule:\n      interval: \"weekly\"\n"
+        },
+        {
+          "path": ".github/workflows/cve-scan.yml",
+          "text": "name: cve-scan\non: [push, pull_request]\njobs:\n  scan:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v6\n      - name: Run OSV scanner over native deps\n        uses: google/osv-scanner-action@v2\n        with:\n          scan-args: --lockfile=conanfile.txt --format=table\n"
+        }
+      ]
+    }
+  ]
+}

--- a/c/fixtures/c_header_has_include_guard.json
+++ b/c/fixtures/c_header_has_include_guard.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "c_header_has_include_guard",
+  "cases": [
+    {
+      "name": "warns_on_unguarded_header",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "include/widget.h",
+          "text": "struct widget {\n\tint id;\n};\n\nvoid widget_init(struct widget *w);\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_pragma_once",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "include/widget.h",
+          "text": "#pragma once\n\nstruct widget {\n\tint id;\n};\n\nvoid widget_init(struct widget *w);\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_ifndef_define_endif",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "include/widget.h",
+          "text": "#ifndef WIDGET_H\n#define WIDGET_H\n\nstruct widget {\n\tint id;\n};\n\nvoid widget_init(struct widget *w);\n\n#endif /* WIDGET_H */\n"
+        }
+      ]
+    }
+  ]
+}

--- a/c/fixtures/no_alloca.json
+++ b/c/fixtures/no_alloca.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_alloca",
+  "cases": [
+    {
+      "name": "warns_on_alloca",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/buf.c",
+          "text": "#include <alloca.h>\n#include <string.h>\n\nchar *dup_local(const char *src, size_t n) {\n\tchar *buf = (char *)alloca(n + 1);\n\tmemcpy(buf, src, n);\n\tbuf[n] = '\\0';\n\treturn buf;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_fixed_buffer_with_size_cap",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/buf.c",
+          "text": "#include <stdlib.h>\n#include <string.h>\n\n#define MAX_LOCAL 4096\n\nchar *dup_local(const char *src, size_t n) {\n\tif (n + 1 > MAX_LOCAL) {\n\t\treturn NULL;\n\t}\n\tchar *buf = (char *)malloc(n + 1);\n\tif (buf == NULL) {\n\t\treturn NULL;\n\t}\n\tmemcpy(buf, src, n);\n\tbuf[n] = '\\0';\n\treturn buf;\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/c/fixtures/no_atoi_family.json
+++ b/c/fixtures/no_atoi_family.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_atoi_family",
+  "cases": [
+    {
+      "name": "warns_on_atoi",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/parse.c",
+          "text": "#include <stdlib.h>\n\nint port_from(const char *raw) {\n\treturn atoi(raw);\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_strtol_with_error_check",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/parse.c",
+          "text": "#include <errno.h>\n#include <limits.h>\n#include <stdlib.h>\n\nint port_from(const char *raw, int *out) {\n\tchar *end = NULL;\n\terrno = 0;\n\tlong v = strtol(raw, &end, 10);\n\tif (errno != 0 || end == raw || *end != '\\0' || v < 0 || v > 65535) {\n\t\treturn -1;\n\t}\n\t*out = (int)v;\n\treturn 0;\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/c/fixtures/no_format_string_from_variable.json
+++ b/c/fixtures/no_format_string_from_variable.json
@@ -1,0 +1,55 @@
+{
+  "predicate": "no_format_string_from_variable",
+  "cases": [
+    {
+      "name": "blocks_printf_with_variable_format",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/log.c",
+          "text": "#include <stdio.h>\n\nvoid emit(const char *msg) {\n\tprintf(msg);\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "blocks_fprintf_with_variable_format",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/log.c",
+          "text": "#include <stdio.h>\n\nvoid emit(FILE *out, const char *msg) {\n\tfprintf(out, msg);\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "blocks_snprintf_with_variable_format",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/log.c",
+          "text": "#include <stdio.h>\n\nvoid emit(char *buf, size_t cap, const char *fmt) {\n\tsnprintf(buf, cap, fmt);\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_literal_format_with_variable_arg",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/log.c",
+          "text": "#include <stdio.h>\n\nvoid emit(FILE *out, const char *msg) {\n\tfprintf(out, \"%s\\n\", msg);\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_snprintf_with_literal_format",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/log.c",
+          "text": "#include <stdio.h>\n\nint emit(char *buf, size_t cap, int code) {\n\treturn snprintf(buf, cap, \"code=%d\", code);\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/c/fixtures/no_gets.json
+++ b/c/fixtures/no_gets.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_gets",
+  "cases": [
+    {
+      "name": "blocks_gets_call",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/input.c",
+          "text": "#include <stdio.h>\n\nvoid read_line(char *buf) {\n\tgets(buf);\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_fgets_with_size",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/input.c",
+          "text": "#include <stdio.h>\n\nvoid read_line(char *buf, size_t cap) {\n\tif (fgets(buf, cap, stdin) == NULL) {\n\t\tbuf[0] = '\\0';\n\t}\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/c/fixtures/no_unsafe_tmpfile.json
+++ b/c/fixtures/no_unsafe_tmpfile.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "no_unsafe_tmpfile",
+  "cases": [
+    {
+      "name": "blocks_mktemp",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/tmp.c",
+          "text": "#include <stdlib.h>\n\nchar *make_path(char *template) {\n\treturn mktemp(template);\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "blocks_tmpnam",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/tmp.c",
+          "text": "#include <stdio.h>\n\nchar *make_path(char *out) {\n\treturn tmpnam(out);\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_mkstemp",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/tmp.c",
+          "text": "#include <stdlib.h>\n\nint open_tmp(char *template) {\n\treturn mkstemp(template);\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/c/fixtures/no_void_main.json
+++ b/c/fixtures/no_void_main.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_void_main",
+  "cases": [
+    {
+      "name": "blocks_void_main",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/main.c",
+          "text": "#include <stdio.h>\n\nvoid main(void) {\n\tputs(\"hi\");\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_int_main",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main.c",
+          "text": "#include <stdio.h>\n\nint main(int argc, char *argv[]) {\n\t(void)argc; (void)argv;\n\tputs(\"hi\");\n\treturn 0;\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/c/fixtures/static_analyzer_clean.json
+++ b/c/fixtures/static_analyzer_clean.json
@@ -1,0 +1,33 @@
+{
+  "predicate": "static_analyzer_clean",
+  "cases": [
+    {
+      "name": "blocks_unsafe_change_without_analyzer_path",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/parser.c",
+          "text": "#include <stdlib.h>\n#include <string.h>\n\nstruct token { char *lex; size_t len; };\n\nstruct token *parse(const char *input) {\n\tstruct token *t = malloc(sizeof *t);\n\tt->len = strlen(input);\n\tt->lex = malloc(t->len + 1);\n\tmemcpy(t->lex, input, t->len + 1);\n\treturn t;\n}\n"
+        },
+        {
+          "path": "Makefile",
+          "text": "CC = gcc\nCFLAGS = -O2 -Wall\n\nparser: src/parser.c\n\t$(CC) $(CFLAGS) -o $@ $<\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_change_with_analyzer_in_ci",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/parser.c",
+          "text": "#include <stdlib.h>\n#include <string.h>\n\nstruct token { char *lex; size_t len; };\n\nstruct token *parse(const char *input) {\n\tstruct token *t = malloc(sizeof *t);\n\tif (t == NULL) return NULL;\n\tt->len = strlen(input);\n\tt->lex = malloc(t->len + 1);\n\tif (t->lex == NULL) { free(t); return NULL; }\n\tmemcpy(t->lex, input, t->len + 1);\n\treturn t;\n}\n"
+        },
+        {
+          "path": ".github/workflows/static-analysis.yml",
+          "text": "name: static-analysis\non: [push, pull_request]\njobs:\n  scan:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v6\n      - run: sudo apt-get install -y clang-tools cppcheck\n      - run: scan-build --status-bugs make\n      - run: cppcheck --error-exitcode=1 --enable=warning,style src\n      - run: make CFLAGS=\"-fsanitize=address,undefined -fno-omit-frame-pointer -O1 -g\"\n"
+        }
+      ]
+    }
+  ]
+}

--- a/c/invariants.harn
+++ b/c/invariants.harn
@@ -1,0 +1,371 @@
+let _EVIDENCE_GETS = [
+  "https://man7.org/linux/man-pages/man3/gets.3.html",
+  "https://man7.org/linux/man-pages/man3/fgets.3p.html",
+  "https://cwe.mitre.org/data/definitions/242.html",
+]
+
+let _EVIDENCE_BOUNDED_STRING_OPS = [
+  "https://man7.org/linux/man-pages/man3/strncpy.3.html",
+  "https://man7.org/linux/man-pages/man3/snprintf.3.html",
+  "https://www.gnu.org/software/libc/manual/html_node/Copying-Strings-and-Arrays.html",
+  "https://cwe.mitre.org/data/definitions/120.html",
+]
+
+let _EVIDENCE_VOID_MAIN = [
+  "https://www.gnu.org/software/libc/manual/html_node/Program-Arguments.html",
+  "https://www.iso-9899.info/n1570.html",
+]
+
+let _EVIDENCE_FORMAT_STRING = [
+  "https://cwe.mitre.org/data/definitions/134.html",
+  "https://owasp.org/www-community/attacks/Format_string_attack",
+  "https://man7.org/linux/man-pages/man3/printf.3.html",
+]
+
+let _EVIDENCE_UNSAFE_TMPFILE = [
+  "https://man7.org/linux/man-pages/man3/mkstemp.3.html",
+  "https://man7.org/linux/man-pages/man3/tmpnam.3.html",
+  "https://cwe.mitre.org/data/definitions/377.html",
+]
+
+let _EVIDENCE_ATOI_FAMILY = [
+  "https://man7.org/linux/man-pages/man3/strtol.3.html",
+  "https://man7.org/linux/man-pages/man3/atoi.3.html",
+  "https://www.gnu.org/software/libc/manual/html_node/Parsing-of-Integers.html",
+]
+
+let _EVIDENCE_INCLUDE_GUARDS = [
+  "https://gcc.gnu.org/onlinedocs/cpp/Once-Only-Headers.html",
+  "https://google.github.io/styleguide/cppguide.html#The__define_Guard",
+]
+
+let _EVIDENCE_ALLOCA = [
+  "https://man7.org/linux/man-pages/man3/alloca.3.html",
+  "https://www.gnu.org/software/libc/manual/html_node/Variable-Size-Automatic.html",
+  "https://www.gnu.org/software/libc/manual/html_node/Unconstrained-Allocation.html",
+]
+
+let _EVIDENCE_ALLOC_NULL_CHECK = [
+  "https://man7.org/linux/man-pages/man3/malloc.3.html",
+  "https://www.gnu.org/software/libc/manual/html_node/Unconstrained-Allocation.html",
+  "https://cwe.mitre.org/data/definitions/690.html",
+]
+
+let _EVIDENCE_STATIC_ANALYZER = [
+  "https://clang-analyzer.llvm.org/",
+  "https://cppcheck.sourceforge.io/manual.html",
+  "https://github.com/google/sanitizers/wiki/AddressSanitizer",
+  "https://owasp.org/www-community/Source_Code_Analysis_Tools",
+]
+
+let _EVIDENCE_DEP_SECURITY = [
+  "https://osv.dev/",
+  "https://learn.microsoft.com/en-us/vcpkg/users/binarycaching",
+  "https://docs.conan.io/2/reference/conanfile/methods/requirements.html",
+  "https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates",
+]
+
+fn is_c_source_path(path) {
+  return path.ends_with(".c")
+}
+
+fn is_c_header_path(path) {
+  return path.ends_with(".h")
+}
+
+fn is_c_path(path) {
+  return is_c_source_path(path) || is_c_header_path(path)
+}
+
+fn is_test_path(path) {
+  return path.contains("/test/")
+    || path.contains("/tests/")
+    || path.contains("/unittest/")
+    || path.contains("/unittests/")
+    || path.ends_with("_test.c")
+    || path.ends_with("_tests.c")
+    || path.ends_with("test_main.c")
+}
+
+fn is_generated_c(file) {
+  return regex_match(r"(?im)^\s*(?://|/\*|\*)\s*(?:Code\s+generated|Auto-?generated|GENERATED FILE)[^\n]*DO NOT EDIT", file.text, "m") != nil
+}
+
+fn c_files(slice) {
+  return slice.files
+    .filter({ file -> is_c_path(file.path) && !is_generated_c(file) })
+}
+
+fn production_c_files(slice) {
+  return c_files(slice).filter({ file -> !is_test_path(file.path) })
+}
+
+fn production_c_source_files(slice) {
+  return production_c_files(slice).filter({ file -> is_c_source_path(file.path) })
+}
+
+fn production_c_header_files(slice) {
+  return production_c_files(slice).filter({ file -> is_c_header_path(file.path) })
+}
+
+fn c_project_files(slice) {
+  return slice.files
+    .filter(
+    { file -> is_c_path(file.path)
+      || file.path.ends_with("CMakeLists.txt")
+      || file.path.ends_with(".cmake")
+      || file.path.ends_with("Makefile")
+      || file.path.ends_with(".mk")
+      || file.path.ends_with("conanfile.txt")
+      || file.path.ends_with("conanfile.py")
+      || file.path.ends_with("vcpkg.json")
+      || file.path.ends_with("meson.build")
+      || file.path.ends_with("dependabot.yml")
+      || file.path.ends_with("dependabot.yaml")
+      || file.path.contains(".github/workflows/") },
+  )
+}
+
+fn scan_files(files, pattern, flags) {
+  var findings = []
+  for file in files {
+    if regex_match(pattern, file.text, flags) != nil {
+      findings = findings
+        .push({path: file.path, pattern: pattern})
+    }
+  }
+  return findings
+}
+
+fn scan_files_if(files, predicate) {
+  var findings = []
+  for file in files {
+    if predicate(file) {
+      findings = findings
+        .push({path: file.path})
+    }
+  }
+  return findings
+}
+
+fn allow(rule) {
+  return {verdict: "Allow", rule: rule, findings: [], remediation: ""}
+}
+
+fn warn(rule, remediation, findings) {
+  return {verdict: "Warn", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block(rule, remediation, findings) {
+  return {verdict: "Block", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return block(rule, remediation, findings)
+}
+
+fn warn_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return warn(rule, remediation, findings)
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_GETS, confidence: 0.95, source_date: "2026-05-10")
+/** Blocks gets, which has no length-bounded form and was removed from the C standard library in C11. */
+pub fn no_gets(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(production_c_files(slice), r"\bgets\s*\(", "s")
+  return block_on_findings(
+    "no_gets",
+    "Use fgets with an explicit buffer size; gets cannot be made safe and was removed from C11 onward.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_BOUNDED_STRING_OPS, confidence: 0.7, source_date: "2026-05-10")
+/** Warns on unbounded string and formatted-input calls that prefer length-bounded variants. */
+pub fn bounded_string_ops(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_c_files(slice),
+    r"\b(?:strcpy|strcat|sprintf|vsprintf|scanf)\s*\(",
+    "s",
+  )
+  return warn_on_findings(
+    "bounded_string_ops",
+    "Prefer strncpy/strlcpy, strncat/strlcat, snprintf/vsnprintf, or fgets+sscanf with explicit lengths.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_VOID_MAIN, confidence: 0.88, source_date: "2026-05-10")
+/** Blocks void main entry points; hosted C requires int main. */
+pub fn no_void_main(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(production_c_source_files(slice), r"(?m)^\s*void\s+main\s*\(", "m")
+  return block_on_findings(
+    "no_void_main",
+    "Declare main with int return type: int main(void) or int main(int argc, char *argv[]).",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_FORMAT_STRING, confidence: 0.78, source_date: "2026-05-10")
+/** Blocks printf-family calls whose format argument is a non-literal variable. */
+pub fn no_format_string_from_variable(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    production_c_files(slice),
+    { file -> regex_match(
+      r"\b(?:printf|vprintf|sprintf|vsprintf)\s*\(\s*[A-Za-z_]\w*\s*[,)]",
+      file.text,
+      "s",
+    ) != nil
+      || regex_match(
+      r"\b(?:fprintf|dprintf|vfprintf|syslog)\s*\(\s*[^,)\n]+,\s*[A-Za-z_]\w*\s*[,)]",
+      file.text,
+      "s",
+    ) != nil
+      || regex_match(
+      r"\b(?:snprintf|vsnprintf)\s*\(\s*[^,)\n]+,\s*[^,)\n]+,\s*[A-Za-z_]\w*\s*[,)]",
+      file.text,
+      "s",
+    ) != nil },
+  )
+  return block_on_findings(
+    "no_format_string_from_variable",
+    "Pass a string literal as the format argument and forward variables as positional parameters; never let untrusted data drive the format.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_UNSAFE_TMPFILE, confidence: 0.9, source_date: "2026-05-10")
+/** Blocks tmpnam, tempnam, and mktemp; they create races between name choice and file open. */
+pub fn no_unsafe_tmpfile(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_c_files(slice),
+    r"\b(?:tmpnam|tempnam|mktemp)\s*\(",
+    "s",
+  )
+  return block_on_findings(
+    "no_unsafe_tmpfile",
+    "Use mkstemp, mkostemp, or tmpfile, which atomically create the file with the returned name.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_ATOI_FAMILY, confidence: 0.78, source_date: "2026-05-10")
+/** Warns on atoi, atol, atoll, and atof, which silently swallow conversion errors and overflow. */
+pub fn no_atoi_family(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_c_files(slice),
+    r"\b(?:atoi|atol|atoll|atof)\s*\(",
+    "s",
+  )
+  return warn_on_findings(
+    "no_atoi_family",
+    "Use strtol/strtoul/strtod with errno and endptr checks so invalid input and overflow are detectable.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_INCLUDE_GUARDS, confidence: 0.8, source_date: "2026-05-10")
+/** Warns on production C headers that lack #pragma once or an #ifndef/#define include guard. */
+pub fn c_header_has_include_guard(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    production_c_header_files(slice),
+    { file -> regex_match(r"(?m)^\s*#\s*pragma\s+once\b", file.text, "m") == nil
+      && regex_match(
+      r"(?ms)^\s*#\s*ifndef\s+\w+\s*\n\s*#\s*define\s+\w+\b.*^\s*#\s*endif\b",
+      file.text,
+      "ms",
+    ) == nil },
+  )
+  return warn_on_findings(
+    "c_header_has_include_guard",
+    "Add #pragma once or a matching #ifndef HEADER_NAME_H / #define HEADER_NAME_H / #endif guard.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_ALLOCA, confidence: 0.72, source_date: "2026-05-10")
+/** Warns on alloca and variable-length arrays sized by user input; both can silently overflow the stack. */
+pub fn no_alloca(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_c_files(slice),
+    r"\b(?:alloca|_alloca|__builtin_alloca)\s*\(",
+    "s",
+  )
+  return warn_on_findings(
+    "no_alloca",
+    "Use a fixed-size buffer, malloc with a checked size cap, or a stack-bounded helper; alloca is unportable and unchecked.",
+    findings,
+  )
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_ALLOC_NULL_CHECK, confidence: 0.64, source_date: "2026-05-10")
+/** Blocks heap allocation paths that lack a NULL-return check before the result is dereferenced. */
+pub fn allocation_return_checked(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed C code calls malloc, calloc, realloc, aligned_alloc, strdup, strndup, or asprintf and dereferences, indexes, copies into, or passes the resulting pointer to a function that requires a non-null argument before any check that the result is non-NULL or before forwarding the NULL upward as an error. Allow allocations followed by a NULL check, an assignment-and-return-on-NULL helper, a wrapper that aborts on OOM, a goto cleanup pattern, or a checked allocator that the project documents."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: production_c_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "allocation_return_checked",
+      "Check the allocator return for NULL before use, or route through a wrapper that aborts or returns an error on OOM.",
+      judgement.findings,
+    )
+  }
+  return allow("allocation_return_checked")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_STATIC_ANALYZER, confidence: 0.6, source_date: "2026-05-10")
+/** Blocks meaningful C source changes that ship without evidence of a static-analysis or sanitizer path. */
+pub fn static_analyzer_clean(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed C source materially adds or rewrites pointer arithmetic, manual memory management, file or socket I/O, parsing, concurrency primitives, or unsafe casts, and the slice plus repo configuration shows no evidence of clang-analyzer, scan-build, clang-tidy, cppcheck, an Address/Undefined/Memory/Thread sanitizer build mode, or an equivalent static-analysis or dynamic-analysis pipeline being applied to the changed code. Allow trivial refactors, comment-only edits, and changes to projects that already wire one of these tools into CI or developer tooling."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: c_project_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "static_analyzer_clean",
+      "Run clang-analyzer/scan-build, clang-tidy, cppcheck, or a sanitizer build over the change, or wire one into CI before shipping.",
+      judgement.findings,
+    )
+  }
+  return allow("static_analyzer_clean")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_DEP_SECURITY, confidence: 0.6, source_date: "2026-05-10")
+/** Blocks C dependency or build-system changes that omit advisory or vulnerability-check evidence. */
+pub fn c_dependency_security_checked(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when C build or dependency metadata changed, such as CMakeLists.txt, *.cmake, Makefile, *.mk, conanfile.txt, conanfile.py, vcpkg.json, meson.build, or C-targeted CI workflows, and the slice provides no evidence that vulnerability review was considered: NVD/CVE lookup, OSV, Dependabot, vendored-source pinning with documented update cadence, or a tool such as cargo-audit-style scanning for native deps. Allow pure source changes, formatting-only changes, and dependency changes that add or preserve a clear vulnerability-check path."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: c_project_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "c_dependency_security_checked",
+      "Document or wire up a CVE/OSV/Dependabot-style vulnerability check for native C dependencies before merging.",
+      judgement.findings,
+    )
+  }
+  return allow("c_dependency_security_checked")
+}


### PR DESCRIPTION
## Summary

- Closes #13.
- 8 deterministic + 3 semantic predicates for plain C source and headers covering memory, string-handling, format-string, and tempfile footguns.
- Evidence pinned to man7.org, GNU libc/GCC manuals, ISO C N1570, MITRE CWE, OWASP, clang-analyzer/cppcheck/sanitizers, OSV/vcpkg/Conan/Dependabot.
- Stack scope: `.c`/`.h`, hosted environment, with explicit test/generated/freestanding caveats in `c/README.md`.

### Predicates

| Predicate | Mode | Verdict |
|---|---|---|
| `no_gets` | deterministic | Block |
| `bounded_string_ops` | deterministic | Warn |
| `no_void_main` | deterministic | Block |
| `no_format_string_from_variable` | deterministic | Block |
| `no_unsafe_tmpfile` | deterministic | Block |
| `no_atoi_family` | deterministic | Warn |
| `c_header_has_include_guard` | deterministic | Warn |
| `no_alloca` | deterministic | Warn |
| `allocation_return_checked` | semantic | Block |
| `static_analyzer_clean` | semantic | Block |
| `c_dependency_security_checked` | semantic | Block |

## Test plan

- [x] All 11 fixture files parse as valid JSON
- [x] Each predicate has a paired `Block`/`Warn` and `Allow` case (the format-string predicate covers `printf`/`fprintf`/`snprintf` shape variants explicitly)
- [x] All 33 evidence URLs return HTTP 200 to a plain-curl probe (matches the convention used by every other pack in this repo)
- [x] Predicate count and structure match `CONTRIBUTING.md`'s 5–10 deterministic + 2–3 semantic guidance
- [ ] CI status checks pass (placeholders today; will exercise once the predicate runtime ships)

🤖 Generated with [Claude Code](https://claude.com/claude-code)