### PR TITLE
Add Dart seed predicate pack (#17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ See the Harn Flow design docs for the full predicate language spec.
 
 - [C#](./csharp/) — v0 draft predicates for plain C# and .NET library or application code.
 - [CSS](./css/) — v0 draft predicates for CSS, Sass, and Less stylesheets covering cascade hygiene, internationalization, and accessibility.
+- [Dart](./dart/) — v0 draft predicates for Dart application, package, and Flutter source covering null safety, public-API hygiene, async correctness, and widget immutability.
 - [Dockerfile](./dockerfile/) — v0 draft predicates for `Dockerfile` and `Containerfile` build recipes.
 - [Go](./go/) — v0 draft predicates for Go modules, command packages, and reusable libraries.
 - [GraphQL](./graphql/) — v0 draft predicates for GraphQL schema files and the server wiring that hosts them.

--- a/dart/README.md
+++ b/dart/README.md
@@ -1,0 +1,64 @@
+# Dart Seed Predicate Pack
+
+This pack covers Dart application, package, and Flutter source with an emphasis on null safety, public-API hygiene, async correctness, and Flutter widget immutability. The v0 rules favor simple source-text predicates for concrete failure modes and semantic predicates where Dart and Flutter framework contracts require code context the regex layer cannot infer.
+
+## Stack Assumptions
+
+- Files use the `.dart` extension and target Dart 3.x (sound null safety required) and current Flutter stable.
+- Projects may use the standard `pub` package layout (`lib/`, `bin/`, `test/`, `integration_test/`, `example/`) and code generation tools that emit `*.g.dart`, `*.freezed.dart`, `*.gr.dart`, `*.config.dart`, `*.mocks.dart`, `*.chopper.dart`, and protobuf `*.pb.dart` files.
+- Deterministic predicates run over changed production Dart source text. Test, generated, and example paths are excluded from production-only rules.
+- The `lib/`-only rules (`no_relative_lib_imports`, `effective_dart_documents_public_apis`) limit their scan to files inside a `lib/` segment so command-line entry points under `bin/` are not penalized.
+- Semantic predicates use `ctx.semantic_judge(...)` and must cite concrete changed spans before blocking.
+- The pack is a seed canon, not a replacement for `dart analyze`, `flutter analyze`, the official lint rule sets in `package:lints` or `package:flutter_lints`, or `dart format`.
+
+## Predicate Coverage
+
+| Predicate | Mode | Verdict | Purpose |
+|---|---|---|---|
+| `no_null_safety_opt_out` | deterministic | Block | Reject pre-null-safety `// @dart=2.x` markers in production code. |
+| `no_force_null_assertion` | deterministic | Block | Avoid runtime crashes from postfix `!` null assertions. |
+| `no_dynamic_in_signatures` | deterministic | Warn | Keep `dynamic` out of public function and method signatures. |
+| `no_print_in_production` | deterministic | Warn | Production diagnostics should use `dart:developer`, `package:logging`, or the project logger. |
+| `no_top_level_mutable_state` | deterministic | Warn | Top-level `var` is process-global mutable state and is rarely justified. |
+| `no_broad_lint_ignores` | deterministic | Warn | `// ignore_for_file` directives should suppress one rule with a justification, not a bundle. |
+| `prefer_const_constructor_for_widgets` | deterministic | Warn | Flutter Widget subclasses should declare a `const` constructor. |
+| `no_relative_lib_imports` | deterministic | Warn | Library code under `lib/` should not climb out with `../` imports. |
+| `widget_state_is_immutable` | semantic | Block | Stateless and inherited widgets must not hold mutable instance state. |
+| `unawaited_futures_are_intentional` | semantic | Block | Discarded `Future`s inside async bodies must be awaited or marked `unawaited`. |
+| `effective_dart_documents_public_apis` | semantic | Block | New public APIs in `lib/` need a `///` doc comment per Effective Dart. |
+
+## Evidence
+
+Evidence scanned on 2026-05-10.
+
+- dart.dev language reference: null safety overview, language versioning markers, and the "understanding null safety" reference for the null assertion operator semantics.
+- dart.dev linter rule docs: `avoid_print`, `avoid_dynamic_calls`, `prefer_final_fields`, `prefer_const_constructors_in_immutables`, `unawaited_futures`, `avoid_relative_lib_imports`, `public_member_api_docs`, and `null_check_on_nullable_type_parameter` as the canonical ecosystem lint precedent.
+- dart.dev Effective Dart guides: usage and documentation pages for variable declaration style and public-API documentation rules.
+- api.dart.dev: `dart:developer log()` and `dart:async unawaited()` reference pages.
+- api.flutter.dev: `StatelessWidget` class docs and the `@immutable` annotation as the framework contract behind widget immutability.
+- dart.dev tooling: pub package layout and the analyzer overview that govern import-path expectations and `// ignore_for_file` directives.
+
+## Known False Positives
+
+- `no_force_null_assertion` is source-text based. It can flag legitimate `expr!` uses where the type system genuinely cannot prove non-null (for example, a generated `late` field accessed after a documented init step). Until predicate-level suppressions exist, prefer narrowing the regex with a wrapper or refactoring the call site.
+- `no_dynamic_in_signatures` warns on any function whose return or parameter type is the keyword `dynamic`. It does not currently detect `dynamic` inside generic positions like `List<dynamic>`, and it may catch generated adapters that legitimately return `dynamic`; route those files through `is_generated_path` or rename them to a generated suffix.
+- `no_print_in_production` flags every `print` and `debugPrint` call. Flutter teams that intentionally use `debugPrint` behind `kDebugMode` may need a local suppression once one exists.
+- `no_top_level_mutable_state` matches unindented `var` declarations and may miss `late var` declarations that span multiple lines; it can also flag intentionally-mutable test doubles that leak into production paths.
+- `no_broad_lint_ignores` triggers when a single `// ignore_for_file` line lists three or more rules or when it disables a whole `type=` category. Single- or two-rule suppressions with a justification are allowed.
+- `prefer_const_constructor_for_widgets` is file-scoped: it warns when a file declares a Widget subclass and contains no `const Capital(` declaration at two-space class-body indent. It can miss Widget subclasses that intentionally declare a `factory` constructor and it can over-allow files that mix const Widget classes with non-const ones — review the file as a whole when warned.
+- `no_relative_lib_imports` flags only imports that begin with `../`. Same-directory `./sibling.dart` and `package:` imports are allowed.
+- The semantic predicates depend on a cheap judge and should block only when the changed span clearly introduces the risk; rubrics list the carve-outs.
+
+## Fixtures
+
+Each fixture in `fixtures/` contains at least one blocked or warned production example and one allowed example for the corresponding predicate:
+
+```json
+{
+  "predicate": "name",
+  "cases": [
+    {"expect": "Block", "files": [{"path": "lib/src/foo.dart", "text": "..."}]},
+    {"expect": "Allow", "files": [{"path": "lib/src/foo.dart", "text": "..."}]}
+  ]
+}
+```

--- a/dart/fixtures/effective_dart_documents_public_apis.json
+++ b/dart/fixtures/effective_dart_documents_public_apis.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "effective_dart_documents_public_apis",
+  "cases": [
+    {
+      "name": "blocks_undocumented_public_class",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "lib/src/order_repository.dart",
+          "text": "class OrderRepository {\n  Future<Order> findById(String id) async => Order(id);\n}\n\nclass Order {\n  Order(this.id);\n  final String id;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_documented_public_class",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "lib/src/order_repository.dart",
+          "text": "/// Read-only access to persisted [Order] aggregates.\nclass OrderRepository {\n  /// Loads an order by its identifier.\n  Future<Order> findById(String id) async => Order(id);\n}\n\n/// A purchase order recorded in the system of record.\nclass Order {\n  /// Creates an order with the supplied [id].\n  Order(this.id);\n\n  /// The opaque, server-assigned order identifier.\n  final String id;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_private_member_without_doc",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "lib/src/order_repository.dart",
+          "text": "/// Read-only access to persisted [_Order] aggregates.\nclass OrderRepository {\n  Future<_Order> _findById(String id) async => _Order(id);\n}\n\nclass _Order {\n  _Order(this.id);\n  final String id;\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/dart/fixtures/no_broad_lint_ignores.json
+++ b/dart/fixtures/no_broad_lint_ignores.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "no_broad_lint_ignores",
+  "cases": [
+    {
+      "name": "warns_on_multi_rule_ignore_for_file",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "lib/src/widget_tree.dart",
+          "text": "// ignore_for_file: avoid_print, prefer_const_constructors, lines_longer_than_80_chars\n\nvoid main() {}\n"
+        }
+      ]
+    },
+    {
+      "name": "warns_on_type_lint_blanket",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "lib/src/widget_tree.dart",
+          "text": "// ignore_for_file: type=lint\n\nvoid main() {}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_single_rule_ignore_with_reason",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "lib/src/widget_tree.dart",
+          "text": "// ignore_for_file: avoid_print // CLI tool prints help text\n\nvoid main() {\n  print('hello');\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/dart/fixtures/no_dynamic_in_signatures.json
+++ b/dart/fixtures/no_dynamic_in_signatures.json
@@ -1,0 +1,45 @@
+{
+  "predicate": "no_dynamic_in_signatures",
+  "cases": [
+    {
+      "name": "warns_on_dynamic_return_type",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "lib/src/parser.dart",
+          "text": "dynamic decode(String input) {\n  return input.split(',');\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "warns_on_dynamic_parameter_type",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "lib/src/parser.dart",
+          "text": "List<String> render(dynamic value) {\n  return ['$value'];\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_concrete_signature",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "lib/src/parser.dart",
+          "text": "List<String> decode(String input) {\n  return input.split(',');\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_generic_signature",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "lib/src/parser.dart",
+          "text": "T identity<T>(T value) => value;\n"
+        }
+      ]
+    }
+  ]
+}

--- a/dart/fixtures/no_force_null_assertion.json
+++ b/dart/fixtures/no_force_null_assertion.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "no_force_null_assertion",
+  "cases": [
+    {
+      "name": "blocks_force_null_assertion",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "lib/src/profile.dart",
+          "text": "String displayName(User? user) {\n  return user!.name;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_if_null_fallback",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "lib/src/profile.dart",
+          "text": "String displayName(User? user) {\n  return user?.name ?? 'Anonymous';\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_boolean_negation",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "lib/src/profile.dart",
+          "text": "bool isReady(bool ready) {\n  if (!ready) {\n    return false;\n  }\n  return ready != false;\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/dart/fixtures/no_null_safety_opt_out.json
+++ b/dart/fixtures/no_null_safety_opt_out.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "no_null_safety_opt_out",
+  "cases": [
+    {
+      "name": "blocks_legacy_dart_2_9_marker",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "lib/src/legacy_io.dart",
+          "text": "// @dart=2.9\n\nimport 'dart:io';\n\nString readConfig() => File('config').readAsStringSync();\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_no_marker_under_dart_3",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "lib/src/legacy_io.dart",
+          "text": "import 'dart:io';\n\nString readConfig() => File('config').readAsStringSync();\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_modern_dart_3_marker",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "lib/src/legacy_io.dart",
+          "text": "// @dart=3.4\n\nimport 'dart:io';\n\nString readConfig() => File('config').readAsStringSync();\n"
+        }
+      ]
+    }
+  ]
+}

--- a/dart/fixtures/no_print_in_production.json
+++ b/dart/fixtures/no_print_in_production.json
@@ -1,0 +1,45 @@
+{
+  "predicate": "no_print_in_production",
+  "cases": [
+    {
+      "name": "warns_on_print_in_production",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "lib/src/order_service.dart",
+          "text": "void placeOrder(Order order) {\n  print('placing order ${order.id}');\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "warns_on_debug_print_in_production",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "lib/src/order_service.dart",
+          "text": "import 'package:flutter/foundation.dart';\n\nvoid placeOrder(Order order) {\n  debugPrint('placing order ${order.id}');\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_developer_log",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "lib/src/order_service.dart",
+          "text": "import 'dart:developer' as developer;\n\nvoid placeOrder(Order order) {\n  developer.log('placing order ${order.id}', name: 'orders');\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_print_in_test",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "test/order_service_test.dart",
+          "text": "void main() {\n  print('starting order tests');\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/dart/fixtures/no_relative_lib_imports.json
+++ b/dart/fixtures/no_relative_lib_imports.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "no_relative_lib_imports",
+  "cases": [
+    {
+      "name": "warns_on_parent_relative_import_in_lib",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "lib/src/feature/order_view.dart",
+          "text": "import '../../widgets/loader.dart';\n\nclass OrderView {}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_package_import_in_lib",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "lib/src/feature/order_view.dart",
+          "text": "import 'package:my_app/widgets/loader.dart';\n\nclass OrderView {}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_sibling_relative_import_in_lib",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "lib/src/feature/order_view.dart",
+          "text": "import 'order_model.dart';\n\nclass OrderView {}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/dart/fixtures/no_top_level_mutable_state.json
+++ b/dart/fixtures/no_top_level_mutable_state.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "no_top_level_mutable_state",
+  "cases": [
+    {
+      "name": "warns_on_top_level_var",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "lib/src/cache.dart",
+          "text": "var cachedToken = '';\n\nString token() => cachedToken;\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_top_level_final",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "lib/src/cache.dart",
+          "text": "final String defaultRegion = 'us-east-1';\n\nString region() => defaultRegion;\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_top_level_const",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "lib/src/cache.dart",
+          "text": "const int maxRetries = 3;\n\nint retries() => maxRetries;\n"
+        }
+      ]
+    }
+  ]
+}

--- a/dart/fixtures/prefer_const_constructor_for_widgets.json
+++ b/dart/fixtures/prefer_const_constructor_for_widgets.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "prefer_const_constructor_for_widgets",
+  "cases": [
+    {
+      "name": "warns_on_widget_without_const_constructor",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "lib/src/greeting.dart",
+          "text": "import 'package:flutter/widgets.dart';\n\nclass Greeting extends StatelessWidget {\n  Greeting({super.key, required this.name});\n\n  final String name;\n\n  @override\n  Widget build(BuildContext context) {\n    return Text('Hello, $name');\n  }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_widget_with_const_constructor",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "lib/src/greeting.dart",
+          "text": "import 'package:flutter/widgets.dart';\n\nclass Greeting extends StatelessWidget {\n  const Greeting({super.key, required this.name});\n\n  final String name;\n\n  @override\n  Widget build(BuildContext context) {\n    return Text('Hello, $name');\n  }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/dart/fixtures/unawaited_futures_are_intentional.json
+++ b/dart/fixtures/unawaited_futures_are_intentional.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "unawaited_futures_are_intentional",
+  "cases": [
+    {
+      "name": "blocks_discarded_future_inside_async",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "lib/src/order_service.dart",
+          "text": "import 'dart:async';\n\nclass OrderService {\n  Future<void> place(Order order) async {\n    persist(order);\n    await notify(order);\n  }\n\n  Future<void> persist(Order order) async {}\n  Future<void> notify(Order order) async {}\n}\n\nclass Order {}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_unawaited_marker",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "lib/src/order_service.dart",
+          "text": "import 'dart:async';\n\nclass OrderService {\n  Future<void> place(Order order) async {\n    unawaited(persist(order));\n    await notify(order);\n  }\n\n  Future<void> persist(Order order) async {}\n  Future<void> notify(Order order) async {}\n}\n\nclass Order {}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_awaited_call",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "lib/src/order_service.dart",
+          "text": "import 'dart:async';\n\nclass OrderService {\n  Future<void> place(Order order) async {\n    await persist(order);\n    await notify(order);\n  }\n\n  Future<void> persist(Order order) async {}\n  Future<void> notify(Order order) async {}\n}\n\nclass Order {}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/dart/fixtures/widget_state_is_immutable.json
+++ b/dart/fixtures/widget_state_is_immutable.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "widget_state_is_immutable",
+  "cases": [
+    {
+      "name": "blocks_stateless_widget_with_mutable_field",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "lib/src/counter_label.dart",
+          "text": "import 'package:flutter/widgets.dart';\n\nclass CounterLabel extends StatelessWidget {\n  CounterLabel({super.key, required this.initial});\n\n  int count;\n\n  @override\n  Widget build(BuildContext context) {\n    count += 1;\n    return Text('$count');\n  }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_stateless_widget_with_final_fields",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "lib/src/counter_label.dart",
+          "text": "import 'package:flutter/widgets.dart';\n\nclass CounterLabel extends StatelessWidget {\n  const CounterLabel({super.key, required this.count});\n\n  final int count;\n\n  @override\n  Widget build(BuildContext context) {\n    return Text('$count');\n  }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_state_in_stateful_widget_state_object",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "lib/src/counter_label.dart",
+          "text": "import 'package:flutter/widgets.dart';\n\nclass CounterLabel extends StatefulWidget {\n  const CounterLabel({super.key});\n\n  @override\n  State<CounterLabel> createState() => _CounterLabelState();\n}\n\nclass _CounterLabelState extends State<CounterLabel> {\n  int _count = 0;\n\n  @override\n  Widget build(BuildContext context) {\n    return Text('${_count++}');\n  }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/dart/invariants.harn
+++ b/dart/invariants.harn
@@ -1,0 +1,333 @@
+let _EVIDENCE_NULL_SAFETY = [
+  "https://dart.dev/null-safety",
+  "https://dart.dev/language/versioning",
+]
+
+let _EVIDENCE_NULL_ASSERTION = [
+  "https://dart.dev/null-safety/understanding-null-safety",
+  "https://dart.dev/tools/linter-rules/null_check_on_nullable_type_parameter",
+]
+
+let _EVIDENCE_DYNAMIC = [
+  "https://dart.dev/tools/linter-rules/avoid_dynamic_calls",
+  "https://dart.dev/effective-dart/design",
+]
+
+let _EVIDENCE_PRINT = [
+  "https://dart.dev/tools/linter-rules/avoid_print",
+  "https://api.dart.dev/stable/dart-developer/log.html",
+]
+
+let _EVIDENCE_MUTABILITY = [
+  "https://dart.dev/tools/linter-rules/prefer_final_fields",
+  "https://dart.dev/effective-dart/usage",
+]
+
+let _EVIDENCE_LINT_IGNORES = [
+  "https://dart.dev/tools/analysis",
+  "https://dart.dev/tools/linter-rules",
+]
+
+let _EVIDENCE_CONST_WIDGETS = [
+  "https://dart.dev/tools/linter-rules/prefer_const_constructors_in_immutables",
+  "https://api.flutter.dev/flutter/widgets/StatelessWidget-class.html",
+]
+
+let _EVIDENCE_RELATIVE_LIB_IMPORTS = [
+  "https://dart.dev/tools/linter-rules/avoid_relative_lib_imports",
+  "https://dart.dev/tools/pub/package-layout",
+]
+
+let _EVIDENCE_IMMUTABLE_WIDGET = [
+  "https://api.flutter.dev/flutter/widgets/StatelessWidget-class.html",
+  "https://api.flutter.dev/flutter/meta/immutable-constant.html",
+]
+
+let _EVIDENCE_UNAWAITED_FUTURES = [
+  "https://dart.dev/tools/linter-rules/unawaited_futures",
+  "https://api.dart.dev/stable/dart-async/unawaited.html",
+]
+
+let _EVIDENCE_EFFECTIVE_DART_DOCS = [
+  "https://dart.dev/effective-dart/documentation",
+  "https://dart.dev/tools/linter-rules/public_member_api_docs",
+]
+
+fn dart_files(slice) {
+  return slice.files.filter({ file -> file.path.ends_with(".dart") })
+}
+
+fn is_test_path(path) {
+  return contains(path, "/test/")
+    || contains(path, "/tests/")
+    || contains(path, "/integration_test/")
+    || contains(path, "/test_driver/")
+    || path.ends_with("_test.dart")
+}
+
+fn is_generated_path(path) {
+  return contains(path, "/.dart_tool/")
+    || contains(path, "/build/")
+    || contains(path, "/generated/")
+    || contains(path, "/.gen/")
+    || path.ends_with(".g.dart")
+    || path.ends_with(".freezed.dart")
+    || path.ends_with(".gr.dart")
+    || path.ends_with(".config.dart")
+    || path.ends_with(".mocks.dart")
+    || path.ends_with(".chopper.dart")
+    || path.ends_with(".pb.dart")
+    || path.ends_with(".pbenum.dart")
+    || path.ends_with(".pbjson.dart")
+    || path.ends_with(".pbserver.dart")
+}
+
+fn is_example_path(path) {
+  return contains(path, "/example/") || contains(path, "/examples/")
+}
+
+fn production_dart_files(slice) {
+  return dart_files(slice)
+    .filter({ file -> !is_test_path(file.path)
+      && !is_generated_path(file.path)
+      && !is_example_path(file.path) },
+    )
+}
+
+fn lib_dart_files(slice) {
+  return production_dart_files(slice).filter({ file -> contains(file.path, "/lib/") })
+}
+
+fn scan_files(files, pattern, flags) {
+  var findings = []
+  for file in files {
+    if regex_match(pattern, file.text, flags) != nil {
+      findings = findings.push({path: file.path, pattern: pattern})
+    }
+  }
+  return findings
+}
+
+fn scan_files_if(files, predicate) {
+  var findings = []
+  for file in files {
+    if predicate(file) {
+      findings = findings.push({path: file.path})
+    }
+  }
+  return findings
+}
+
+fn allow(rule) {
+  return {verdict: "Allow", rule: rule, findings: [], remediation: ""}
+}
+
+fn warn(rule, remediation, findings) {
+  return {verdict: "Warn", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block(rule, remediation, findings) {
+  return {verdict: "Block", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return block(rule, remediation, findings)
+}
+
+fn warn_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return warn(rule, remediation, findings)
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_NULL_SAFETY, confidence: 0.92, source_date: "2026-05-10")
+/** Blocks pre-null-safety language version markers in production Dart sources. */
+pub fn no_null_safety_opt_out(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_dart_files(slice),
+    r"(?m)^\s*//\s*@dart\s*=\s*2\.([0-9]|1[01])(?!\d)",
+    "m",
+  )
+  return block_on_findings(
+    "no_null_safety_opt_out",
+    "Remove the legacy @dart language version marker; sound null safety is required since Dart 3.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_NULL_ASSERTION, confidence: 0.78, source_date: "2026-05-10")
+/** Blocks the postfix null assertion operator in production Dart sources. */
+pub fn no_force_null_assertion(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_dart_files(slice),
+    r"[A-Za-z_0-9\)\]]!(?=[\s\.\[\)\]\}\,;])",
+    "s",
+  )
+  return block_on_findings(
+    "no_force_null_assertion",
+    "Replace expr! with explicit null handling: if-null (??), pattern matching, ArgumentError, or a typed non-null contract.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_DYNAMIC, confidence: 0.7, source_date: "2026-05-10")
+/** Warns when production Dart functions use dynamic in their signature. */
+pub fn no_dynamic_in_signatures(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_dart_files(slice),
+    r"(?m)(^|[\(,])\s*\bdynamic\b\s+[a-zA-Z_][a-zA-Z0-9_]*\s*[\(,\)\{=;]",
+    "m",
+  )
+  return warn_on_findings(
+    "no_dynamic_in_signatures",
+    "Replace dynamic in function signatures with a concrete type, generic parameter, Object?, or sealed/union type.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_PRINT, confidence: 0.85, source_date: "2026-05-10")
+/** Warns on ad hoc console output in production Dart sources. */
+pub fn no_print_in_production(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(production_dart_files(slice), r"\b(print|debugPrint)\s*\(", "s")
+  return warn_on_findings(
+    "no_print_in_production",
+    "Use dart:developer log(), package:logging, or the project logger instead of print/debugPrint.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_MUTABILITY, confidence: 0.7, source_date: "2026-05-10")
+/** Warns on top-level mutable variables in production Dart sources. */
+pub fn no_top_level_mutable_state(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_dart_files(slice),
+    r"(?m)^(?:late\s+)?var\s+[a-zA-Z_][a-zA-Z0-9_]*\s*[=;]",
+    "m",
+  )
+  return warn_on_findings(
+    "no_top_level_mutable_state",
+    "Prefer top-level final or const, or scope mutable state inside a class or async-safe container.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_LINT_IGNORES, confidence: 0.66, source_date: "2026-05-10")
+/** Warns on file-wide analyzer suppressions that bundle multiple rules or whole categories. */
+pub fn no_broad_lint_ignores(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    production_dart_files(slice),
+    { file -> regex_match(r"(?m)^\s*//\s*ignore_for_file\s*:\s*[a-z_]+(\s*,\s*[a-z_]+){2,}", file.text, "m") != nil
+      || regex_match(r"(?m)^\s*//\s*ignore_for_file\s*:\s*type\s*=\s*[a-z]+", file.text, "m") != nil },
+  )
+  return warn_on_findings(
+    "no_broad_lint_ignores",
+    "Suppress one analyzer rule per // ignore comment with a justification; do not blanket-disable categories.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_CONST_WIDGETS, confidence: 0.66, source_date: "2026-05-10")
+/** Warns when a Flutter Widget subclass file declares no const constructor at class body indent. */
+pub fn prefer_const_constructor_for_widgets(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    production_dart_files(slice),
+    { file -> regex_match(
+      r"class\s+\w+\s+extends\s+(StatelessWidget|StatefulWidget|InheritedWidget|InheritedNotifier|RenderObjectWidget)\b",
+      file.text,
+      "s",
+    )
+      != nil
+      && regex_match(r"(?m)^\s{2}const\s+[A-Z]\w*\s*\(", file.text, "m") == nil },
+  )
+  return warn_on_findings(
+    "prefer_const_constructor_for_widgets",
+    "Give Widget subclasses a const constructor so callers can construct them with const and avoid rebuild churn.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_RELATIVE_LIB_IMPORTS, confidence: 0.82, source_date: "2026-05-10")
+/** Warns on parent-relative imports inside lib/ Dart sources. */
+pub fn no_relative_lib_imports(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    lib_dart_files(slice),
+    r"(?m)^\s*import\s+['\x22]\.\.[\\/]",
+    "m",
+  )
+  return warn_on_findings(
+    "no_relative_lib_imports",
+    "Inside lib/, import sibling libraries with a package: URI or a same-directory relative path; do not climb out of lib/.",
+    findings,
+  )
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_IMMUTABLE_WIDGET, confidence: 0.66, source_date: "2026-05-10")
+/** Blocks Flutter Widget subclasses that hold mutable instance state. */
+pub fn widget_state_is_immutable(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed Dart introduces or modifies a class extending StatelessWidget, InheritedWidget, InheritedNotifier, or another widget that the framework requires to be immutable, and that class declares a non-final, non-static, non-const instance field, late mutable field, or setter that lets external code mutate the widget after construction. State mutation belongs in a separate State<StatefulWidget> object, an InheritedNotifier listenable, or another framework-sanctioned mutable container."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: production_dart_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "widget_state_is_immutable",
+      "Mark widget instance fields final or move mutable state into a State<StatefulWidget> or listenable.",
+      judgement.findings,
+    )
+  }
+  return allow("widget_state_is_immutable")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_UNAWAITED_FUTURES, confidence: 0.62, source_date: "2026-05-10")
+/** Blocks discarded Futures inside async bodies without intentional fire-and-forget. */
+pub fn unawaited_futures_are_intentional(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed production Dart inside an async function, Future-returning method, or constructor body discards the result of a Future-returning expression without await, without wrapping it in unawaited(...), and without an attached .catchError or .then chain that explicitly handles errors. Top-level fire-and-forget at process startup, deliberate background tasks tagged with unawaited, and Stream subscriptions are out of scope."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: production_dart_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "unawaited_futures_are_intentional",
+      "await the Future, mark the call with unawaited(...), or attach explicit error handling.",
+      judgement.findings,
+    )
+  }
+  return allow("unawaited_futures_are_intentional")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_EFFECTIVE_DART_DOCS, confidence: 0.6, source_date: "2026-05-10")
+/** Blocks new public Dart APIs in lib/ that lack /// doc comments. */
+pub fn effective_dart_documents_public_apis(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed Dart inside a package's lib/ directory introduces a new public top-level declaration (class, mixin, extension, enum, typedef, function, getter, setter, or constant whose name does not start with underscore) and the declaration has no immediately preceding /// doc comment, satisfying the Effective Dart documentation guideline that public APIs carry a doc comment. Private members, overrides of already-documented members, and changes that only modify existing bodies are out of scope."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: lib_dart_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "effective_dart_documents_public_apis",
+      "Add a /// doc comment describing what the new public API does; even one sentence beats none.",
+      judgement.findings,
+    )
+  }
+  return allow("effective_dart_documents_public_apis")
+}


### PR DESCRIPTION
## Summary

Closes #17. v0 seed predicate pack for Dart application, package, and Flutter source. Eight `@deterministic` predicates plus three `@semantic` predicates, each with at least one Block/Warn fixture and one Allow fixture.

| Predicate | Mode | Verdict |
|---|---|---|
| `no_null_safety_opt_out` | det. | Block |
| `no_force_null_assertion` | det. | Block |
| `no_dynamic_in_signatures` | det. | Warn |
| `no_print_in_production` | det. | Warn |
| `no_top_level_mutable_state` | det. | Warn |
| `no_broad_lint_ignores` | det. | Warn |
| `prefer_const_constructor_for_widgets` | det. | Warn |
| `no_relative_lib_imports` | det. | Warn |
| `widget_state_is_immutable` | sem. | Block |
| `unawaited_futures_are_intentional` | sem. | Block |
| `effective_dart_documents_public_apis` | sem. | Block |

Production-only predicates exclude `_test.dart`, `integration_test/`, generated suffixes (`*.g.dart`, `*.freezed.dart`, `*.gr.dart`, `*.config.dart`, `*.mocks.dart`, `*.chopper.dart`, `*.pb*.dart`), `.dart_tool/`, `build/`, and `example/`.

## Evidence

Each `@archivist` block carries ≥2 official sources (dart.dev linter rules, Effective Dart guides, dart.dev null-safety docs, api.dart.dev, api.flutter.dev) scanned 2026-05-10. All 21 evidence URLs HTTP-200 verified before commit.

## Test plan

- [x] `jq empty` validates every fixture JSON
- [x] Spot-check each deterministic regex against its block + allow fixture text via `grep -P`
- [x] All evidence URLs return 200
- [ ] Awaiting Harn Flow runtime fixture replay (CI placeholder)