### PR TITLE
Add PHP seed predicate pack (#15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ See the Harn Flow design docs for the full predicate language spec.
 - [JSON](./json/) — v0 draft predicates for strict JSON conformance, encoding hygiene, declared-schema respect, and untrusted-data boundaries.
 - [Kotlin](./kotlin/) — v0 draft predicates for Kotlin JVM, Android, and Multiplatform source.
 - [Markdown](./markdown/) — v0 draft predicates for prose Markdown files used for documentation, READMEs, and design notes.
+- [PHP](./php/) — v0 draft predicates for plain PHP application and library code.
 - [Python](./python/) — v0 draft predicates for Python application and library code.
 - [Ruby](./ruby/) — v0 draft predicates for Ruby application and library code.
 - [Rust](./rust/) — v0 draft predicates for Rust application and library code.

--- a/php/README.md
+++ b/php/README.md
@@ -1,0 +1,63 @@
+# PHP Seed Predicate Pack
+
+This pack covers general-purpose PHP application and library code targeting modern PHP (8.1+) before framework-specific packs (Laravel, Symfony, WordPress) layer in tighter defaults. It targets review-slice issues with clear correctness, maintenance, or security impact: missing strict-types declarations, legacy syntax that depends on ini settings, removed extensions, code-injection sinks, register-globals revivals via `extract()`, untyped class state, debug leakage, SQL injection, hardcoded secrets, and PHP object injection through `unserialize()`.
+
+## Stack Assumptions
+
+- Source files use the `.php` extension; templates additionally use `.phtml`. Strict-types and typed-property checks scope to `.php` only because templates frequently open with HTML.
+- Production paths exclude any path under `/tests/`, `/Tests/`, `/test/`, `/spec/`, `/bin/`, `/scripts/`, `/script/`, and any file ending in `Test.php`, `TestCase.php`, or `_test.php`. Vendored paths under `/vendor/`, `/node_modules/`, `/build/`, and `/dist/` are excluded everywhere.
+- Projects target PHP 8.0+ where typed properties, constructor property promotion, `match`, and named arguments are standard, and where `create_function()` and the `ext/mysql` extension are gone.
+- Deterministic predicates run regex over changed source text until Flow exposes a stable PHP AST query API. Rules with meaningful false-positive risk warn rather than block.
+- Semantic predicates make a single judge call over changed PHP files; they should only block when they can cite concrete changed spans.
+
+## Predicate Coverage
+
+| Predicate | Mode | Verdict | Purpose |
+|---|---|---|---|
+| `declare_strict_types_enforced` | deterministic | Block | Production class files should opt into strict scalar coercion so type errors surface at the boundary. |
+| `no_short_open_tags` | deterministic | Block | `<?` short open tags depend on the `short_open_tag` ini directive and are non-portable; PSR-1 forbids them. |
+| `no_deprecated_mysql_ext` | deterministic | Block | The `ext/mysql` extension was removed in PHP 7.0; new code must use PDO or mysqli. |
+| `no_create_function` | deterministic | Block | `create_function()` evaluates a string body and was removed in PHP 8.0; closures replace it. |
+| `no_eval` | deterministic | Block | `eval()` is the canonical PHP code-injection sink. |
+| `no_extract_from_request` | deterministic | Block | `extract($_GET/$_POST/...)` recreates the register_globals injection pattern. |
+| `typed_properties` | deterministic | Warn | Untyped class properties skip the runtime invariant that typed properties enforce on every write. |
+| `no_debug_dump_in_prod` | deterministic | Warn | `var_dump`/`print_r`/`var_export` write directly to output and leak internal state in production paths. |
+| `prepared_statements_only` | semantic | Block | SQL built by interpolating user-controlled values is the leading vector for SQL injection. |
+| `no_hardcoded_secrets` | semantic | Block | Credentials and tokens should come from `getenv`/`$_ENV` or a secret manager, not literals or `define()`. |
+| `unserialize_input_is_trusted` | semantic | Block | Calling `unserialize()` on untrusted input enables PHP object injection (POP-chain) attacks. |
+
+## Evidence
+
+Evidence scanned on 2026-05-10.
+
+- PHP manual: language type declarations and `strict_types`, basic syntax PHP tags, `mysqlinfo.api.choosing`, `function.create-function`, `function.eval`, `function.extract`, `function.var-dump`, `function.print-r`, `function.unserialize`, `function.getenv`, `language.oop5.properties`, PDO prepared statements, mysqli quickstart prepared statements, `migration70.removed-exts-sapis`, the PHP 8.0 migration overview, and `security.variables`.
+- PHP RFCs: `scalar_type_hints_v5`, `mysql_deprecation`, `deprecations_php_7_2` (which deprecated `create_function`), `typed_properties_v2`.
+- PHP-FIG: PSR-1 (basic coding standard) for PHP tag and side-effect rules; PSR-3 (logger interface) as the alternative to ad-hoc dumping.
+- PHP The Right Way: `strict_types` recommendation.
+- OWASP cheat sheets and project pages: SQL Injection Prevention, Secrets Management, Deserialization, Code Injection, PHP Object Injection, PHP File Inclusion, CICD-SEC-06 Insufficient Credential Hygiene.
+- CWE: CWE-95 (eval injection).
+
+## Known False Positives
+
+- Regex predicates do not parse PHP. String literals, heredocs, and comments containing keywords can fool deterministic checks until AST-backed matching lands.
+- `declare_strict_types_enforced` only inspects `.php` files that begin with `<?php` (after an optional UTF-8 BOM). Files that open with HTML or other content are intentionally skipped because strict-types must be the first statement of the file. Expect false negatives on files with leading whitespace beyond a BOM.
+- `no_short_open_tags` flags `<?` followed by anything other than `php`, `=`, or `xml`, including escapes inside strings or HTML embedded in heredocs.
+- `no_deprecated_mysql_ext` matches `mysql_<name>(` at word boundaries. Project-defined helpers named `mysql_helper_*` would be flagged; rename them.
+- `no_create_function`, `no_eval`, `no_extract_from_request`, and `no_debug_dump_in_prod` allow method calls (`$obj->eval(`) by excluding `>` from the leading character class. Function calls inside docblock examples will still flag.
+- `typed_properties` matches property declarations on a line of their own. Inline constructor property promotion such as `function __construct(public $name, public $age)` is missed; multi-line promotion (each parameter on its own line) is caught.
+- `no_debug_dump_in_prod` only inspects production paths. Calls in `/bin/`, `/scripts/`, or test directories are intentionally allowed.
+- Semantic predicates depend on a cheap judge call and should stay high-threshold until Flow exposes structured PHP data-flow analysis.
+
+## Fixtures
+
+Each fixture in `fixtures/` contains one blocked or warned example and one allowed example for the corresponding predicate. The fixture shape mirrors the existing seed packs:
+
+```json
+{
+  "predicate": "name",
+  "cases": [
+    {"expect": "Block", "files": [{"path": "src/Service.php", "text": "..."}]},
+    {"expect": "Allow", "files": [{"path": "src/Service.php", "text": "..."}]}
+  ]
+}
+```

--- a/php/fixtures/declare_strict_types_enforced.json
+++ b/php/fixtures/declare_strict_types_enforced.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "declare_strict_types_enforced",
+  "cases": [
+    {
+      "name": "blocks_class_file_without_strict_types",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/Billing/InvoiceService.php",
+          "text": "<?php\n\nnamespace App\\Billing;\n\nfinal class InvoiceService\n{\n    public function total(int $cents): int\n    {\n        return $cents;\n    }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_class_file_with_strict_types",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/Billing/InvoiceService.php",
+          "text": "<?php\n\ndeclare(strict_types=1);\n\nnamespace App\\Billing;\n\nfinal class InvoiceService\n{\n    public function total(int $cents): int\n    {\n        return $cents;\n    }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_template_phtml_file",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "resources/views/invoice.phtml",
+          "text": "<!doctype html>\n<html>\n  <body>\n    <h1>Invoice <?= htmlspecialchars($invoice->number()) ?></h1>\n  </body>\n</html>\n"
+        }
+      ]
+    }
+  ]
+}

--- a/php/fixtures/no_create_function.json
+++ b/php/fixtures/no_create_function.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_create_function",
+  "cases": [
+    {
+      "name": "blocks_create_function",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/Util/Sorter.php",
+          "text": "<?php\n\ndeclare(strict_types=1);\n\n$compare = create_function('$a, $b', 'return $a <=> $b;');\nusort($items, $compare);\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_arrow_function",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/Util/Sorter.php",
+          "text": "<?php\n\ndeclare(strict_types=1);\n\nusort($items, fn ($a, $b) => $a <=> $b);\n"
+        }
+      ]
+    }
+  ]
+}

--- a/php/fixtures/no_debug_dump_in_prod.json
+++ b/php/fixtures/no_debug_dump_in_prod.json
@@ -1,0 +1,45 @@
+{
+  "predicate": "no_debug_dump_in_prod",
+  "cases": [
+    {
+      "name": "warns_var_dump_in_production_path",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/Http/InvoiceController.php",
+          "text": "<?php\n\ndeclare(strict_types=1);\n\nfinal class InvoiceController\n{\n    public function show(Invoice $invoice): void\n    {\n        var_dump($invoice);\n    }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "warns_print_r_with_return_in_production_path",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/Reports/Renderer.php",
+          "text": "<?php\n\ndeclare(strict_types=1);\n\nfunction render(array $rows): string\n{\n    return print_r($rows, true);\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_logger_call_in_production",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/Http/InvoiceController.php",
+          "text": "<?php\n\ndeclare(strict_types=1);\n\nfinal class InvoiceController\n{\n    public function __construct(private LoggerInterface $logger) {}\n\n    public function show(Invoice $invoice): void\n    {\n        $this->logger->debug('rendering invoice', ['id' => $invoice->id()]);\n    }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_var_dump_in_test_path",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "tests/Unit/Http/InvoiceControllerTest.php",
+          "text": "<?php\n\ndeclare(strict_types=1);\n\nfinal class InvoiceControllerTest\n{\n    public function testDebug(): void\n    {\n        var_dump($this->invoice);\n    }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/php/fixtures/no_deprecated_mysql_ext.json
+++ b/php/fixtures/no_deprecated_mysql_ext.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "no_deprecated_mysql_ext",
+  "cases": [
+    {
+      "name": "blocks_mysql_query_call",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/Legacy/UserRepository.php",
+          "text": "<?php\n\ndeclare(strict_types=1);\n\nfunction find_user(int $id): array {\n    $conn = mysql_connect('localhost', 'app', 'secret');\n    $result = mysql_query('SELECT id, email FROM users WHERE id = ' . $id, $conn);\n    return mysql_fetch_assoc($result);\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_pdo_equivalent",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/Legacy/UserRepository.php",
+          "text": "<?php\n\ndeclare(strict_types=1);\n\nfunction find_user(PDO $pdo, int $id): array {\n    $stmt = $pdo->prepare('SELECT id, email FROM users WHERE id = :id');\n    $stmt->execute(['id' => $id]);\n    return $stmt->fetch(PDO::FETCH_ASSOC);\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_mysqli_function",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/Legacy/Connection.php",
+          "text": "<?php\n\ndeclare(strict_types=1);\n\n$conn = mysqli_connect('localhost', 'app', getenv('DB_PASS'));\n"
+        }
+      ]
+    }
+  ]
+}

--- a/php/fixtures/no_eval.json
+++ b/php/fixtures/no_eval.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "no_eval",
+  "cases": [
+    {
+      "name": "blocks_eval_call",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/Rules/Engine.php",
+          "text": "<?php\n\ndeclare(strict_types=1);\n\nfinal class Engine\n{\n    public function run(string $expression): mixed\n    {\n        return eval('return ' . $expression . ';');\n    }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_explicit_dispatch",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/Rules/Engine.php",
+          "text": "<?php\n\ndeclare(strict_types=1);\n\nfinal class Engine\n{\n    /** @var array<string, callable(int): int> */\n    private array $ops = [\n        'double' => fn (int $v): int => $v * 2,\n    ];\n\n    public function run(string $op, int $value): int\n    {\n        return ($this->ops[$op])($value);\n    }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_method_call_named_eval",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/Rules/Caller.php",
+          "text": "<?php\n\ndeclare(strict_types=1);\n\n$result = $evaluator->eval($tree);\n"
+        }
+      ]
+    }
+  ]
+}

--- a/php/fixtures/no_extract_from_request.json
+++ b/php/fixtures/no_extract_from_request.json
@@ -1,0 +1,45 @@
+{
+  "predicate": "no_extract_from_request",
+  "cases": [
+    {
+      "name": "blocks_extract_from_post",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/Http/SignupController.php",
+          "text": "<?php\n\ndeclare(strict_types=1);\n\nfunction handle_signup(): void\n{\n    extract($_POST);\n    save_user($email, $password);\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "blocks_extract_from_request",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/Http/LegacyHandler.php",
+          "text": "<?php\n\ndeclare(strict_types=1);\n\nextract($_REQUEST);\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_explicit_key_reads",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/Http/SignupController.php",
+          "text": "<?php\n\ndeclare(strict_types=1);\n\nfunction handle_signup(): void\n{\n    $email = trim((string) ($_POST['email'] ?? ''));\n    $password = (string) ($_POST['password'] ?? '');\n    save_user($email, $password);\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_extract_from_known_array",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/Templates/Renderer.php",
+          "text": "<?php\n\ndeclare(strict_types=1);\n\nfunction render(string $template, array $bindings): string\n{\n    extract($bindings, EXTR_SKIP);\n    ob_start();\n    require $template;\n    return (string) ob_get_clean();\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/php/fixtures/no_hardcoded_secrets.json
+++ b/php/fixtures/no_hardcoded_secrets.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_hardcoded_secrets",
+  "cases": [
+    {
+      "name": "blocks_define_with_api_key",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "config/services.php",
+          "text": "<?php\n\ndeclare(strict_types=1);\n\ndefine('PAYMENTS_API_TOKEN', 'live_REPLACE_ME_WITH_REAL_VALUE');\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_env_lookup",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "config/services.php",
+          "text": "<?php\n\ndeclare(strict_types=1);\n\nreturn [\n    'payments' => [\n        'api_token' => getenv('PAYMENTS_API_TOKEN') ?: throw new RuntimeException('PAYMENTS_API_TOKEN missing'),\n    ],\n];\n"
+        }
+      ]
+    }
+  ]
+}

--- a/php/fixtures/no_short_open_tags.json
+++ b/php/fixtures/no_short_open_tags.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "no_short_open_tags",
+  "cases": [
+    {
+      "name": "blocks_short_open_tag_in_template",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "resources/views/banner.phtml",
+          "text": "<? if ($flash): ?>\n  <div class=\"flash\"><?= $flash ?></div>\n<? endif; ?>\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_full_open_and_short_echo",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "resources/views/banner.phtml",
+          "text": "<?php if ($flash): ?>\n  <div class=\"flash\"><?= $flash ?></div>\n<?php endif; ?>\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_xml_prolog_in_response",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/Http/SitemapResponse.php",
+          "text": "<?php\n\ndeclare(strict_types=1);\n\nheader('Content-Type: application/xml');\necho '<?xml version=\"1.0\" encoding=\"UTF-8\"?>';\n"
+        }
+      ]
+    }
+  ]
+}

--- a/php/fixtures/prepared_statements_only.json
+++ b/php/fixtures/prepared_statements_only.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "prepared_statements_only",
+  "cases": [
+    {
+      "name": "blocks_string_concatenated_query",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/Repository/UserLookup.php",
+          "text": "<?php\n\ndeclare(strict_types=1);\n\nfinal class UserLookup\n{\n    public function __construct(private PDO $pdo) {}\n\n    public function findByEmail(string $email): ?array\n    {\n        $row = $this->pdo->query(\"SELECT id, email FROM users WHERE email = '\" . $email . \"'\")->fetch(PDO::FETCH_ASSOC);\n        return $row ?: null;\n    }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_pdo_prepared_statement",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/Repository/UserLookup.php",
+          "text": "<?php\n\ndeclare(strict_types=1);\n\nfinal class UserLookup\n{\n    public function __construct(private PDO $pdo) {}\n\n    public function findByEmail(string $email): ?array\n    {\n        $stmt = $this->pdo->prepare('SELECT id, email FROM users WHERE email = :email');\n        $stmt->execute(['email' => $email]);\n        $row = $stmt->fetch(PDO::FETCH_ASSOC);\n        return $row ?: null;\n    }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/php/fixtures/typed_properties.json
+++ b/php/fixtures/typed_properties.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "typed_properties",
+  "cases": [
+    {
+      "name": "warns_untyped_visibility_property",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/Domain/User.php",
+          "text": "<?php\n\ndeclare(strict_types=1);\n\nfinal class User\n{\n    private $email;\n    public $createdAt;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "warns_legacy_var_keyword",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/Domain/Legacy.php",
+          "text": "<?php\n\ndeclare(strict_types=1);\n\nclass Legacy\n{\n    var $name;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_typed_properties",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/Domain/User.php",
+          "text": "<?php\n\ndeclare(strict_types=1);\n\nfinal class User\n{\n    private string $email;\n    private ?DateTimeImmutable $createdAt = null;\n    private static array $cache = [];\n    public readonly string $id;\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/php/fixtures/unserialize_input_is_trusted.json
+++ b/php/fixtures/unserialize_input_is_trusted.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "unserialize_input_is_trusted",
+  "cases": [
+    {
+      "name": "blocks_unserialize_of_cookie",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/Session/CartLoader.php",
+          "text": "<?php\n\ndeclare(strict_types=1);\n\nfinal class CartLoader\n{\n    public function load(): Cart\n    {\n        $payload = $_COOKIE['cart'] ?? '';\n        return unserialize($payload);\n    }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_json_decode_for_untrusted_payload",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/Session/CartLoader.php",
+          "text": "<?php\n\ndeclare(strict_types=1);\n\nfinal class CartLoader\n{\n    public function load(): Cart\n    {\n        $payload = $_COOKIE['cart'] ?? '{}';\n        $data = json_decode($payload, associative: true, flags: JSON_THROW_ON_ERROR);\n        return Cart::fromArray($data);\n    }\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_unserialize_with_allowed_classes_false",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/Cache/Loader.php",
+          "text": "<?php\n\ndeclare(strict_types=1);\n\nfinal class Loader\n{\n    public function read(string $blob): array\n    {\n        return unserialize($blob, ['allowed_classes' => false]);\n    }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/php/invariants.harn
+++ b/php/invariants.harn
@@ -1,0 +1,338 @@
+let _EVIDENCE_STRICT_TYPES = [
+  "https://www.php.net/manual/en/language.types.declarations.php#language.types.declarations.strict",
+  "https://wiki.php.net/rfc/scalar_type_hints_v5",
+  "https://phptherightway.com/#strict_types",
+]
+
+let _EVIDENCE_SHORT_OPEN_TAGS = [
+  "https://www.php.net/manual/en/language.basic-syntax.phptags.php",
+  "https://www.php-fig.org/psr/psr-1/",
+]
+
+let _EVIDENCE_DEPRECATED_MYSQL = [
+  "https://www.php.net/manual/en/mysqlinfo.api.choosing.php",
+  "https://wiki.php.net/rfc/mysql_deprecation",
+  "https://www.php.net/manual/en/migration70.removed-exts-sapis.php",
+]
+
+let _EVIDENCE_CREATE_FUNCTION = [
+  "https://www.php.net/manual/en/function.create-function.php",
+  "https://wiki.php.net/rfc/deprecations_php_7_2",
+  "https://www.php.net/migration80",
+]
+
+let _EVIDENCE_EVAL = [
+  "https://www.php.net/manual/en/function.eval.php",
+  "https://owasp.org/www-community/attacks/Code_Injection",
+  "https://cwe.mitre.org/data/definitions/95.html",
+]
+
+let _EVIDENCE_EXTRACT_REQUEST = [
+  "https://www.php.net/manual/en/function.extract.php",
+  "https://owasp.org/www-community/vulnerabilities/PHP_File_Inclusion",
+  "https://www.php.net/manual/en/security.variables.php",
+]
+
+let _EVIDENCE_TYPED_PROPERTIES = [
+  "https://www.php.net/manual/en/language.oop5.properties.php",
+  "https://wiki.php.net/rfc/typed_properties_v2",
+]
+
+let _EVIDENCE_DEBUG_FUNCTIONS = [
+  "https://www.php.net/manual/en/function.var-dump.php",
+  "https://www.php.net/manual/en/function.print-r.php",
+  "https://www.php-fig.org/psr/psr-3/",
+]
+
+let _EVIDENCE_PARAMETERIZED = [
+  "https://www.php.net/manual/en/pdo.prepared-statements.php",
+  "https://www.php.net/manual/en/mysqli.quickstart.prepared-statements.php",
+  "https://cheatsheetseries.owasp.org/cheatsheets/SQL_Injection_Prevention_Cheat_Sheet.html",
+]
+
+let _EVIDENCE_SECRETS = [
+  "https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html",
+  "https://www.php.net/manual/en/function.getenv.php",
+  "https://owasp.org/www-project-top-10-ci-cd-security-risks/CICD-SEC-06-Insufficient-Credential-Hygiene",
+]
+
+let _EVIDENCE_UNSERIALIZE = [
+  "https://www.php.net/manual/en/function.unserialize.php",
+  "https://owasp.org/www-community/vulnerabilities/PHP_Object_Injection",
+  "https://cheatsheetseries.owasp.org/cheatsheets/Deserialization_Cheat_Sheet.html",
+]
+
+fn is_php_path(path) {
+  return path.ends_with(".php") || path.ends_with(".phtml")
+}
+
+fn is_class_php_path(path) {
+  return path.ends_with(".php")
+}
+
+fn is_test_path(path) {
+  return regex_match(r"(^|/)([Tt]ests?|spec)/", path, "") != nil
+    || path.ends_with("Test.php")
+    || path.ends_with("TestCase.php")
+    || path.ends_with("_test.php")
+}
+
+fn is_script_path(path) {
+  return regex_match(r"(^|/)(bin|scripts?)/", path, "") != nil
+}
+
+fn is_vendored_path(path) {
+  return regex_match(r"(^|/)(vendor|node_modules|build|dist)/", path, "") != nil
+}
+
+fn php_files(slice) {
+  return slice.files.filter({ file -> is_php_path(file.path) && !is_vendored_path(file.path) })
+}
+
+fn class_php_files(slice) {
+  return slice.files
+    .filter({ file -> is_class_php_path(file.path) && !is_vendored_path(file.path) })
+}
+
+fn production_php_files(slice) {
+  return php_files(slice)
+    .filter({ file -> !is_test_path(file.path) && !is_script_path(file.path) })
+}
+
+fn production_class_php_files(slice) {
+  return class_php_files(slice)
+    .filter({ file -> !is_test_path(file.path) && !is_script_path(file.path) })
+}
+
+fn scan_files(files, pattern, flags) {
+  var findings = []
+  for file in files {
+    if regex_match(pattern, file.text, flags) != nil {
+      findings = findings.push({path: file.path, pattern: pattern})
+    }
+  }
+  return findings
+}
+
+fn scan_files_if(files, predicate) {
+  var findings = []
+  for file in files {
+    if predicate(file) {
+      findings = findings.push({path: file.path})
+    }
+  }
+  return findings
+}
+
+fn scan_files_without(files, include_pattern, exclude_pattern) {
+  return scan_files_if(
+    files,
+    { file -> regex_match(include_pattern, file.text, "s") != nil
+      && regex_match(exclude_pattern, file.text, "s") == nil },
+  )
+}
+
+fn allow(rule) {
+  return {verdict: "Allow", rule: rule, findings: [], remediation: ""}
+}
+
+fn warn(rule, remediation, findings) {
+  return {verdict: "Warn", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block(rule, remediation, findings) {
+  return {verdict: "Block", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return block(rule, remediation, findings)
+}
+
+fn warn_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return warn(rule, remediation, findings)
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_STRICT_TYPES, confidence: 0.82, source_date: "2026-05-10")
+/** Blocks production .php class files that open with <?php but lack declare(strict_types=1). */
+pub fn declare_strict_types_enforced(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_without(
+    production_class_php_files(slice),
+    r"(?s)\A\s*(?:\xef\xbb\xbf)?<\?php\b",
+    r"(?i)declare\s*\(\s*strict_types\s*=\s*1\s*\)",
+  )
+  return block_on_findings(
+    "declare_strict_types_enforced",
+    "Add declare(strict_types=1); as the first statement after the <?php opener so type coercion errors surface early.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_SHORT_OPEN_TAGS, confidence: 0.9, source_date: "2026-05-10")
+/** Blocks PHP short open tags `<?` that depend on the short_open_tag ini directive. */
+pub fn no_short_open_tags(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(php_files(slice), r"<\?(?!php\b|=|xml\b)", "")
+  return block_on_findings(
+    "no_short_open_tags",
+    "Use the full <?php opener (and <?= for short echo); short_open_tag is a portability hazard.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_DEPRECATED_MYSQL, confidence: 0.95, source_date: "2026-05-10")
+/** Blocks calls to functions in the removed ext/mysql extension. */
+pub fn no_deprecated_mysql_ext(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    php_files(slice),
+    r"(^|[^_A-Za-z0-9>])mysql_[a-z_]+\s*\(",
+    "m",
+  )
+  return block_on_findings(
+    "no_deprecated_mysql_ext",
+    "Replace mysql_* calls with PDO or mysqli; the ext/mysql extension was deprecated in 5.5 and removed in 7.0.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_CREATE_FUNCTION, confidence: 0.93, source_date: "2026-05-10")
+/** Blocks calls to create_function(), which was removed in PHP 8.0 and is an eval-style sink. */
+pub fn no_create_function(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    php_files(slice),
+    r"(^|[^_A-Za-z0-9>])create_function\s*\(",
+    "m",
+  )
+  return block_on_findings(
+    "no_create_function",
+    "Use a closure or arrow function instead of create_function(); it was removed in PHP 8.0 and evaluates its body as a string.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_EVAL, confidence: 0.85, source_date: "2026-05-10")
+/** Blocks direct eval() calls in PHP source. */
+pub fn no_eval(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(php_files(slice), r"(^|[^_A-Za-z0-9>])eval\s*\(", "m")
+  return block_on_findings(
+    "no_eval",
+    "Replace eval() with explicit dispatch, a parser, or a constrained interpreter; eval is a code-injection sink.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_EXTRACT_REQUEST, confidence: 0.92, source_date: "2026-05-10")
+/** Blocks extract() over superglobals, which re-creates the register_globals injection footgun. */
+pub fn no_extract_from_request(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    php_files(slice),
+    r"(^|[^_A-Za-z0-9>])extract\s*\(\s*\$_(?:GET|POST|REQUEST|COOKIE|FILES|SERVER|ENV)\b",
+    "m",
+  )
+  return block_on_findings(
+    "no_extract_from_request",
+    "Read individual keys from the superglobal and validate them; extract() over $_GET/$_POST lets attackers overwrite arbitrary local variables.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_TYPED_PROPERTIES, confidence: 0.7, source_date: "2026-05-10")
+/** Warns on class property declarations that omit a type (PHP 7.4+ supports typed properties). */
+pub fn typed_properties(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    class_php_files(slice),
+    r"(?m)^\s*(?:var|public|protected|private)(?:\s+static)?\s+\$[A-Za-z_]",
+    "m",
+  )
+  return warn_on_findings(
+    "typed_properties",
+    "Add a property type (e.g. private string $name); typed properties enforce invariants at write time.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_DEBUG_FUNCTIONS, confidence: 0.72, source_date: "2026-05-10")
+/** Warns when production PHP source calls var_dump/print_r/var_export-style debug functions. */
+pub fn no_debug_dump_in_prod(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_php_files(slice),
+    r"(^|[^_A-Za-z0-9>])(var_dump|print_r|var_export|debug_zval_dump|debug_print_backtrace)\s*\(",
+    "m",
+  )
+  return warn_on_findings(
+    "no_debug_dump_in_prod",
+    "Route diagnostics through a PSR-3 logger; var_dump/print_r leak internal state to whoever sees the response.",
+    findings,
+  )
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_PARAMETERIZED, confidence: 0.66, source_date: "2026-05-10")
+/** Blocks SQL built by interpolating user-controlled values into the query text. */
+pub fn prepared_statements_only(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed PHP code builds a SQL query by concatenating, interpolating, or sprintf-ing user-controlled values into the SQL text instead of using PDO or mysqli prepared statements with bound parameters. Allow constant identifiers, whitelisted column or table names assembled from a fixed map, and ORM/query-builder calls that ultimately bind parameters."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: php_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "prepared_statements_only",
+      "Bind values with PDO::prepare or mysqli::prepare and execute with parameters; never concatenate untrusted input into SQL.",
+      judgement.findings,
+    )
+  }
+  return allow("prepared_statements_only")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_SECRETS, confidence: 0.66, source_date: "2026-05-10")
+/** Blocks hardcoded credentials and high-risk secrets in PHP source. */
+pub fn no_hardcoded_secrets(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed PHP source embeds credentials, API tokens, private keys, signing secrets, database passwords, production connection strings, or long-lived service credentials as string literals or define()/const declarations instead of reading them from getenv, $_ENV, a secret manager, or a parsed configuration file outside the repo."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: php_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "no_hardcoded_secrets",
+      "Load secrets from getenv/$_ENV or a secret manager; rotate any value that touched source control.",
+      judgement.findings,
+    )
+  }
+  return allow("no_hardcoded_secrets")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_UNSERIALIZE, confidence: 0.7, source_date: "2026-05-10")
+/** Blocks unserialize() calls on data that may originate from untrusted input. */
+pub fn unserialize_input_is_trusted(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed PHP code passes potentially user-controlled data (request bodies, cookies, query parameters, file contents from upload paths, cache entries that store request data, message-queue payloads from external systems) into unserialize() without setting the allowed_classes option to false or to a small explicit allowlist. Allow unserialize() over data that is provably internal (sealed cache values, signed payloads verified before unserialize, fixtures)."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: php_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "unserialize_input_is_trusted",
+      "Switch to json_decode for cross-trust-boundary data, or pass allowed_classes => false (or a tight allowlist) to unserialize.",
+      judgement.findings,
+    )
+  }
+  return allow("unserialize_input_is_trusted")
+}


### PR DESCRIPTION
## Summary

- New `php/` seed predicate pack: 8 `@deterministic` + 3 `@semantic` invariants for plain PHP (8.x) application and library code.
- Targets review-slice issues with clear correctness, maintenance, or security impact: `declare(strict_types=1)`, short open tags, removed `ext/mysql`, `create_function`, `eval`, `extract($_GET/$_POST)`, untyped properties, debug dumps, SQL injection, hardcoded secrets, and `unserialize()` of untrusted input.
- All evidence URLs (PHP manual, RFCs, PHP-FIG, OWASP, CWE) verified live; one fixture placeholder reworded after the GitHub secret-scanner false-positive on a sample Stripe-shaped string.

Closes #15

## Predicate inventory

| Predicate | Mode | Verdict |
|---|---|---|
| `declare_strict_types_enforced` | det | Block |
| `no_short_open_tags` | det | Block |
| `no_deprecated_mysql_ext` | det | Block |
| `no_create_function` | det | Block |
| `no_eval` | det | Block |
| `no_extract_from_request` | det | Block |
| `typed_properties` | det | Warn |
| `no_debug_dump_in_prod` | det | Warn |
| `prepared_statements_only` | sem | Block |
| `no_hardcoded_secrets` | sem | Block |
| `unserialize_input_is_trusted` | sem | Block |

## Test plan

- [x] All evidence URLs return 200 (verified via `curl -I`).
- [x] Each predicate has at least one Block/Warn fixture and one Allow fixture under `php/fixtures/`.
- [x] All fixture JSON files parse with `json.load`.
- [x] Mirrors the Python/Ruby/SQL pack conventions (helpers, attribute style, README structure).
- [ ] CI placeholder jobs (`evidence-links`, `fmt`, `fixture-replay`) — will exercise this pack once the runtime ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)