### PR TITLE
Add Haskell seed predicate pack (#19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ See the Harn Flow design docs for the full predicate language spec.
 - [Go](./go/) — v0 draft predicates for Go modules, command packages, and reusable libraries.
 - [GraphQL](./graphql/) — v0 draft predicates for GraphQL schema files and the server wiring that hosts them.
 - [Harn](./harn/) — v0 draft predicates for `.harn` scripts, Flow workflows, and agent-facing Harn modules.
+- [Haskell](./haskell/) — v0 draft predicates for plain Haskell application and library code.
 - [HTML](./html/) — v0 draft predicates for plain HTML markup, accessibility, and safe new-window navigation.
 - [Java](./java/) — v0 draft predicates for plain Java application and library code.
 - [JavaScript](./javascript/) — v0 draft predicates for plain JavaScript source, async handling, dynamic-code hazards, and untrusted data boundaries.

--- a/haskell/README.md
+++ b/haskell/README.md
@@ -1,0 +1,63 @@
+# Haskell Seed Predicate Pack
+
+This pack covers general-purpose Haskell application and library code. It targets the well-known footguns that an Archivist can catch cheaply on a changed slice: Prelude partial functions in the public API, `undefined` and `error` stubs, unsafe IO escapes, open imports, missing export lists, single-field records that should be `newtype`s, non-exhaustive pattern matches, orphan typeclass instances, and hardcoded secrets.
+
+## Stack Assumptions
+
+- Source files use the `.hs` (Haskell) or `.lhs` (literate Haskell) extension.
+- Production paths exclude any path under `test/`, `tests/`, `spec/`, `bench/`, `benches/`, or `examples/`, and any file whose name ends in `Spec.hs`, `Test.hs`, `_spec.hs`, or `_test.hs`.
+- "Public API" paths additionally exclude any path under `Internal/`, any module name containing `.Internal.`, and any file ending in `/Internal.hs`. Predicates that should tolerate intentionally unsafe primitives (`no_partial_functions_in_pub_api`) restrict themselves to the public-API set; the `Internal` convention is the standard Haskell escape hatch for partial helpers exposed to maintainers but not callers.
+- Deterministic predicates use file-text regex scans because Harn Flow does not yet expose a stable Haskell AST query API; rules with meaningful false-positive risk warn rather than block. Semantic predicates make a single judge call over changed Haskell files.
+- Predicates are GHC2024-aware: `total_function_semantic_check` and `prefer_newtype_for_single_field` reflect modern GHC defaults (`-Wincomplete-patterns`, `-Wmissing-export-lists`, `-Wmissing-import-lists`).
+
+## Predicate Coverage
+
+| Predicate | Mode | Verdict | Purpose |
+|---|---|---|---|
+| `no_partial_functions_in_pub_api` | deterministic | Block | Prelude partials (`head`, `tail`, `init`, `last`, `fromJust`, `(!!)`) crash on edge cases callers cannot anticipate. |
+| `no_undefined_in_prod` | deterministic | Block | `undefined` is a placeholder; shipping it crashes the program at the first use. |
+| `no_error_call_in_prod` | deterministic | Warn | `error "..."` raises a non-recoverable `ErrorCall` instead of a typed value or exception callers can handle. |
+| `no_unsafe_perform_io` | deterministic | Block | `unsafePerformIO`/`unsafeInterleaveIO`/`unsafeFixIO` break referential transparency and the strictness analyser's assumptions. |
+| `explicit_imports` | deterministic | Warn | Open imports leak the entire downstream namespace into scope, masking conflicts and slowing review. |
+| `explicit_export_list` | deterministic | Warn | Modules without an export list expose every binding as public surface, blocking safe refactors. |
+| `prefer_newtype_for_single_field` | deterministic | Warn | A single-constructor, single-field record is `newtype`-able for zero runtime overhead and a stricter representation. |
+| `total_function_semantic_check` | semantic | Block | Functions whose pattern matches are non-exhaustive crash at runtime when an unhandled constructor flows through. |
+| `no_orphan_instances` | semantic | Block | Orphan instances make typeclass coherence depend on import order and break compositional reasoning. |
+| `no_hardcoded_secrets` | semantic | Block | Credentials embedded in source leak through commits, build artefacts, and error messages. |
+
+## Evidence
+
+Evidence scanned on 2026-05-10.
+
+- GHC user guide: `using-warnings.html` (`-Wincomplete-patterns`, `-Wmissing-import-lists`, `-Wmissing-export-lists`, `-Worphans`, `-Wx-partial`) and the FFI/extensions chapters covering `unsafePerformIO`.
+- Hackage `base` reference: `Prelude` (`head`, `tail`, `init`, `last`, `undefined`, `error`), `Data.Maybe.fromJust`, `System.IO.Unsafe`, and `Control.Exception` for typed exception handling.
+- Haskell Wiki: `Avoiding_partial_functions`, `Newtype`, and `Orphan_instance` community guidance pages.
+- HLint: hint catalogue covering partial functions, single-field records, and import discipline.
+- Haskell 2010 Report §5: module export lists and visibility semantics.
+- OWASP Cheat Sheet Series and GitHub secret-scanning documentation: hardcoded-credential risk and remediation patterns.
+
+## Known False Positives
+
+- Regex predicates do not parse Haskell. Comments, string literals, Template Haskell quasi-quotes, and identifier ticks (`head'`) can fool the deterministic checks until AST-backed matching lands.
+- `no_partial_functions_in_pub_api` flags bare uses of `head`/`tail`/`init`/`last`/`fromJust` and the `(!!)` operator. Fully qualified references (`Data.List.head`) are not caught because the leading `.` confuses the boundary heuristic; qualified `Prelude` partials are rare in practice because `Prelude` is auto-imported. Move legitimate partial helpers into an `Internal` module to suppress the rule.
+- `no_undefined_in_prod` flags every occurrence of the `undefined` token. Shadowed local `undefined` bindings (rare) are a false positive.
+- `no_error_call_in_prod` matches `error "..."`, `error [...]`, and `error show ...` but does not parse expression context, so an `error` call inside a Template Haskell splice or a quasi-quoted string can be flagged.
+- `no_unsafe_perform_io` flags any reference to the listed identifiers, including type signatures and re-exports. Wrap legitimate uses in an `Internal` module or a clearly-named `unsafe*` helper.
+- `explicit_imports` only inspects single-line `import` statements that fit on one line; multi-line imports with the parenthesised list on a follow-up line are out of scope until AST queries land.
+- `explicit_export_list` matches `module Foo where` on a single line and tolerates Haddock comments before `module`. Modules whose `where` keyword is on a separate line from the module name are treated as having an export list and are not flagged.
+- `prefer_newtype_for_single_field` only matches the single-line, single-field record syntax `data X = X { f :: T }`; multi-line records and positional single-field types (`data X = X T`) are not flagged because they overlap with sum-type stubs that often grow more constructors.
+- `total_function_semantic_check` and `no_orphan_instances` are conservative semantic checks. Until Flow exposes structured Haskell data, the judge can miss matches that span imports it cannot see.
+
+## Fixtures
+
+Each fixture in `fixtures/` contains one blocked or warned example and one allowed example for the corresponding predicate. The fixture shape mirrors the existing seed packs:
+
+```json
+{
+  "predicate": "name",
+  "cases": [
+    {"expect": "Block", "files": [{"path": "src/Foo.hs", "text": "..."}]},
+    {"expect": "Allow", "files": [{"path": "src/Foo.hs", "text": "..."}]}
+  ]
+}
+```

--- a/haskell/fixtures/explicit_export_list.json
+++ b/haskell/fixtures/explicit_export_list.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "explicit_export_list",
+  "cases": [
+    {
+      "name": "warns_module_without_export_list",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/Acme/Inventory.hs",
+          "text": "module Acme.Inventory where\n\nimport qualified Data.Map.Strict as Map\n\nstockOnHand :: Map.Map Sku Int -> Sku -> Int\nstockOnHand m sku = Map.findWithDefault 0 sku m\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_module_with_export_list",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/Acme/Inventory.hs",
+          "text": "module Acme.Inventory (stockOnHand) where\n\nimport qualified Data.Map.Strict as Map\n\nstockOnHand :: Map.Map Sku Int -> Sku -> Int\nstockOnHand m sku = Map.findWithDefault 0 sku m\n"
+        }
+      ]
+    }
+  ]
+}

--- a/haskell/fixtures/explicit_imports.json
+++ b/haskell/fixtures/explicit_imports.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "explicit_imports",
+  "cases": [
+    {
+      "name": "warns_open_import_without_qualified_or_list",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/Acme/Report.hs",
+          "text": "module Acme.Report (renderReport) where\n\nimport Data.Map.Strict\n\nrenderReport :: Map ReportId Report -> Text\nrenderReport _ = mempty\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_qualified_import",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/Acme/Report.hs",
+          "text": "module Acme.Report (renderReport) where\n\nimport qualified Data.Map.Strict as Map\n\nrenderReport :: Map.Map ReportId Report -> Text\nrenderReport _ = mempty\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_explicit_import_list",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/Acme/Report.hs",
+          "text": "module Acme.Report (renderReport) where\n\nimport Data.Map.Strict (Map)\n\nrenderReport :: Map ReportId Report -> Text\nrenderReport _ = mempty\n"
+        }
+      ]
+    }
+  ]
+}

--- a/haskell/fixtures/no_error_call_in_prod.json
+++ b/haskell/fixtures/no_error_call_in_prod.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_error_call_in_prod",
+  "cases": [
+    {
+      "name": "warns_error_with_string_literal",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/Acme/Auth.hs",
+          "text": "module Acme.Auth (authenticate) where\n\nauthenticate :: Credentials -> Session\nauthenticate c\n  | not (verify c) = error \"invalid credentials\"\n  | otherwise      = newSession c\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_typed_exception",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/Acme/Auth.hs",
+          "text": "module Acme.Auth (authenticate, AuthError (..)) where\n\nimport Control.Exception (Exception, throwIO)\n\ndata AuthError = InvalidCredentials\n  deriving (Show)\n\ninstance Exception AuthError\n\nauthenticate :: Credentials -> IO Session\nauthenticate c\n  | not (verify c) = throwIO InvalidCredentials\n  | otherwise      = pure (newSession c)\n"
+        }
+      ]
+    }
+  ]
+}

--- a/haskell/fixtures/no_hardcoded_secrets.json
+++ b/haskell/fixtures/no_hardcoded_secrets.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_hardcoded_secrets",
+  "cases": [
+    {
+      "name": "blocks_hardcoded_api_token",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/Acme/Stripe.hs",
+          "text": "module Acme.Billing (charge) where\n\nimport Network.HTTP.Simple (Request, addRequestHeader)\nimport Data.ByteString.Char8 (pack)\n\napiToken :: String\napiToken = \"example_live_token_do_not_use_0123456789abcdef\"\n\ncharge :: Request -> Request\ncharge = addRequestHeader \"Authorization\" (pack (\"Bearer \" <> apiToken))\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_secret_from_environment",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/Acme/Stripe.hs",
+          "text": "module Acme.Billing (charge) where\n\nimport Network.HTTP.Simple (Request, addRequestHeader)\nimport Data.ByteString.Char8 (pack)\nimport System.Environment (getEnv)\n\ncharge :: Request -> IO Request\ncharge req = do\n  token <- getEnv \"BILLING_API_TOKEN\"\n  pure (addRequestHeader \"Authorization\" (pack (\"Bearer \" <> token)) req)\n"
+        }
+      ]
+    }
+  ]
+}

--- a/haskell/fixtures/no_orphan_instances.json
+++ b/haskell/fixtures/no_orphan_instances.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_orphan_instances",
+  "cases": [
+    {
+      "name": "blocks_orphan_instance",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/Acme/Json/Time.hs",
+          "text": "module Acme.Json.Time () where\n\nimport Data.Aeson (FromJSON, ToJSON)\nimport Data.Time (UTCTime)\n\ninstance ToJSON UTCTime where\n  toJSON _ = error \"omitted\"\n\ninstance FromJSON UTCTime where\n  parseJSON _ = error \"omitted\"\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_instance_owned_by_module",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/Acme/Json/Time.hs",
+          "text": "module Acme.Json.Time (Timestamp (..)) where\n\nimport Data.Aeson (FromJSON, ToJSON)\nimport Data.Time (UTCTime)\n\nnewtype Timestamp = Timestamp { unTimestamp :: UTCTime }\n  deriving (Eq, Show)\n\ninstance ToJSON Timestamp where\n  toJSON _ = error \"omitted\"\n\ninstance FromJSON Timestamp where\n  parseJSON _ = error \"omitted\"\n"
+        }
+      ]
+    }
+  ]
+}

--- a/haskell/fixtures/no_partial_functions_in_pub_api.json
+++ b/haskell/fixtures/no_partial_functions_in_pub_api.json
@@ -1,0 +1,55 @@
+{
+  "predicate": "no_partial_functions_in_pub_api",
+  "cases": [
+    {
+      "name": "blocks_head_in_public_module",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/Acme/Users.hs",
+          "text": "module Acme.Users (firstUser) where\n\nimport Data.List (sort)\n\nfirstUser :: [User] -> User\nfirstUser = head . sort\n"
+        }
+      ]
+    },
+    {
+      "name": "blocks_bang_bang_indexing",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/Acme/Users.hs",
+          "text": "module Acme.Users (pickUser) where\n\npickUser :: [User] -> Int -> User\npickUser xs i = xs !! i\n"
+        }
+      ]
+    },
+    {
+      "name": "blocks_from_just",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/Acme/Users.hs",
+          "text": "module Acme.Users (lookupUser) where\n\nimport qualified Data.Map.Strict as Map\nimport Data.Maybe (fromJust)\n\nlookupUser :: Map.Map UserId User -> UserId -> User\nlookupUser m i = fromJust (Map.lookup i m)\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_total_alternatives",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/Acme/Users.hs",
+          "text": "module Acme.Users (firstUser, lookupUser) where\n\nimport qualified Data.Map.Strict as Map\nimport Data.List (sort, uncons)\n\nfirstUser :: [User] -> Maybe User\nfirstUser = fmap fst . uncons . sort\n\nlookupUser :: Map.Map UserId User -> UserId -> Maybe User\nlookupUser m i = Map.lookup i m\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_partial_helper_under_internal",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/Acme/Users/Internal.hs",
+          "text": "module Acme.Users.Internal (unsafeHead) where\n\nunsafeHead :: [a] -> a\nunsafeHead = head\n"
+        }
+      ]
+    }
+  ]
+}

--- a/haskell/fixtures/no_undefined_in_prod.json
+++ b/haskell/fixtures/no_undefined_in_prod.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "no_undefined_in_prod",
+  "cases": [
+    {
+      "name": "blocks_undefined_stub",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/Acme/Pricing.hs",
+          "text": "module Acme.Pricing (priceQuote) where\n\npriceQuote :: Order -> Money\npriceQuote = undefined\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_typed_either_return",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/Acme/Pricing.hs",
+          "text": "module Acme.Pricing (priceQuote) where\n\npriceQuote :: Order -> Either PricingError Money\npriceQuote o\n  | null (orderLines o) = Left EmptyOrder\n  | otherwise           = Right (sumLines o)\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_undefined_in_test_module",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "test/Acme/PricingSpec.hs",
+          "text": "module Acme.PricingSpec where\n\nplaceholder :: a\nplaceholder = undefined\n"
+        }
+      ]
+    }
+  ]
+}

--- a/haskell/fixtures/no_unsafe_perform_io.json
+++ b/haskell/fixtures/no_unsafe_perform_io.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "no_unsafe_perform_io",
+  "cases": [
+    {
+      "name": "blocks_unsafe_perform_io",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/Acme/Cache.hs",
+          "text": "module Acme.Cache (currentTime) where\n\nimport Data.Time (UTCTime, getCurrentTime)\nimport System.IO.Unsafe (unsafePerformIO)\n\ncurrentTime :: UTCTime\ncurrentTime = unsafePerformIO getCurrentTime\n{-# NOINLINE currentTime #-}\n"
+        }
+      ]
+    },
+    {
+      "name": "blocks_unsafe_interleave_io",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/Acme/Cache.hs",
+          "text": "module Acme.Cache (lazyLoad) where\n\nimport System.IO.Unsafe (unsafeInterleaveIO)\n\nlazyLoad :: IO a -> IO a\nlazyLoad = unsafeInterleaveIO\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_threaded_io",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/Acme/Cache.hs",
+          "text": "module Acme.Cache (currentTime) where\n\nimport Data.Time (UTCTime, getCurrentTime)\n\ncurrentTime :: IO UTCTime\ncurrentTime = getCurrentTime\n"
+        }
+      ]
+    }
+  ]
+}

--- a/haskell/fixtures/prefer_newtype_for_single_field.json
+++ b/haskell/fixtures/prefer_newtype_for_single_field.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "prefer_newtype_for_single_field",
+  "cases": [
+    {
+      "name": "warns_single_field_record_data",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/Acme/Identifiers.hs",
+          "text": "module Acme.Identifiers (UserId (..)) where\n\ndata UserId = UserId { unUserId :: Int }\n  deriving (Eq, Show)\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_newtype_single_field",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/Acme/Identifiers.hs",
+          "text": "module Acme.Identifiers (UserId (..)) where\n\nnewtype UserId = UserId { unUserId :: Int }\n  deriving (Eq, Show)\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_multi_field_record_data",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/Acme/Identifiers.hs",
+          "text": "module Acme.Identifiers (User (..)) where\n\ndata User = User { userId :: Int, userName :: Text }\n  deriving (Eq, Show)\n"
+        }
+      ]
+    }
+  ]
+}

--- a/haskell/fixtures/total_function_semantic_check.json
+++ b/haskell/fixtures/total_function_semantic_check.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "total_function_semantic_check",
+  "cases": [
+    {
+      "name": "blocks_non_exhaustive_pattern_match",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/Acme/Shape.hs",
+          "text": "module Acme.Shape (area) where\n\ndata Shape = Circle Double | Square Double | Triangle Double Double\n\narea :: Shape -> Double\narea (Circle r)   = pi * r * r\narea (Square s)   = s * s\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_exhaustive_pattern_match",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/Acme/Shape.hs",
+          "text": "module Acme.Shape (area) where\n\ndata Shape = Circle Double | Square Double | Triangle Double Double\n\narea :: Shape -> Double\narea (Circle r)       = pi * r * r\narea (Square s)       = s * s\narea (Triangle b h)   = 0.5 * b * h\n"
+        }
+      ]
+    }
+  ]
+}

--- a/haskell/invariants.harn
+++ b/haskell/invariants.harn
@@ -1,0 +1,290 @@
+let _EVIDENCE_PARTIAL_FUNCTIONS = [
+  "https://hackage.haskell.org/package/base/docs/Prelude.html",
+  "https://wiki.haskell.org/Avoiding_partial_functions",
+  "https://downloads.haskell.org/ghc/latest/docs/users_guide/using-warnings.html",
+]
+
+let _EVIDENCE_UNDEFINED = [
+  "https://hackage.haskell.org/package/base/docs/Prelude.html#v:undefined",
+  "https://wiki.haskell.org/Avoiding_partial_functions",
+]
+
+let _EVIDENCE_ERROR_CALL = [
+  "https://hackage.haskell.org/package/base/docs/Prelude.html#v:error",
+  "https://hackage.haskell.org/package/base/docs/Control-Exception.html",
+]
+
+let _EVIDENCE_UNSAFE_PERFORM_IO = [
+  "https://hackage.haskell.org/package/base/docs/System-IO-Unsafe.html",
+  "https://downloads.haskell.org/ghc/latest/docs/users_guide/exts/ffi.html",
+]
+
+let _EVIDENCE_EXPLICIT_IMPORTS = [
+  "https://downloads.haskell.org/ghc/latest/docs/users_guide/using-warnings.html",
+  "https://hackage.haskell.org/package/hlint",
+]
+
+let _EVIDENCE_EXPLICIT_EXPORT = [
+  "https://downloads.haskell.org/ghc/latest/docs/users_guide/using-warnings.html",
+  "https://www.haskell.org/onlinereport/haskell2010/haskellch5.html",
+]
+
+let _EVIDENCE_NEWTYPE = [
+  "https://wiki.haskell.org/Newtype",
+  "https://downloads.haskell.org/ghc/latest/docs/users_guide/exts/newtypes.html",
+  "https://hackage.haskell.org/package/hlint",
+]
+
+let _EVIDENCE_TOTAL_FUNCTIONS = [
+  "https://downloads.haskell.org/ghc/latest/docs/users_guide/using-warnings.html",
+  "https://wiki.haskell.org/Avoiding_partial_functions",
+]
+
+let _EVIDENCE_ORPHAN_INSTANCES = [
+  "https://downloads.haskell.org/ghc/latest/docs/users_guide/using-warnings.html",
+  "https://wiki.haskell.org/Orphan_instance",
+]
+
+let _EVIDENCE_SECRETS = [
+  "https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html",
+  "https://docs.github.com/code-security/secret-scanning/about-secret-scanning",
+]
+
+fn is_haskell_path(path) {
+  return path.ends_with(".hs") || path.ends_with(".lhs")
+}
+
+fn is_test_path(path) {
+  return path.starts_with("test/") || path.contains("/test/")
+    || path.starts_with("tests/") || path.contains("/tests/")
+    || path.starts_with("spec/") || path.contains("/spec/")
+    || path.starts_with("bench/") || path.contains("/bench/")
+    || path.starts_with("benches/") || path.contains("/benches/")
+    || path.starts_with("examples/") || path.contains("/examples/")
+    || path.ends_with("Spec.hs") || path.ends_with("Test.hs")
+    || path.ends_with("_spec.hs") || path.ends_with("_test.hs")
+}
+
+fn is_internal_path(path) {
+  return path.contains("/Internal/")
+    || path.contains(".Internal.")
+    || path.ends_with("/Internal.hs")
+}
+
+fn haskell_files(slice) {
+  return slice.files.filter({ file -> is_haskell_path(file.path) })
+}
+
+fn production_haskell_files(slice) {
+  return haskell_files(slice).filter({ file -> !is_test_path(file.path) })
+}
+
+fn pub_api_haskell_files(slice) {
+  return production_haskell_files(slice).filter({ file -> !is_internal_path(file.path) })
+}
+
+fn scan_files(files, pattern, flags) {
+  var findings = []
+  for file in files {
+    if regex_match(pattern, file.text, flags) != nil {
+      findings = findings.push({path: file.path, pattern: pattern})
+    }
+  }
+  return findings
+}
+
+fn allow(rule) {
+  return {verdict: "Allow", rule: rule, findings: [], remediation: ""}
+}
+
+fn warn(rule, remediation, findings) {
+  return {verdict: "Warn", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block(rule, remediation, findings) {
+  return {verdict: "Block", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return block(rule, remediation, findings)
+}
+
+fn warn_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return warn(rule, remediation, findings)
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_PARTIAL_FUNCTIONS, confidence: 0.78, source_date: "2026-05-10")
+/** Blocks Prelude partial functions (head, tail, init, last, fromJust, !!) in non-Internal production modules. */
+pub fn no_partial_functions_in_pub_api(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    pub_api_haskell_files(slice),
+    r"(?:^|[^A-Za-z0-9_'.])(?:head|tail|init|last|fromJust)(?:[^A-Za-z0-9_']|$)|(?:^|[^!])!!(?:[^!]|$)",
+    "m",
+  )
+  return block_on_findings(
+    "no_partial_functions_in_pub_api",
+    "Use total alternatives like uncons, listToMaybe, lookup, or pattern matching; if a partial helper is unavoidable, isolate it under an Internal module.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_UNDEFINED, confidence: 0.88, source_date: "2026-05-10")
+/** Blocks the Prelude `undefined` value in production modules. */
+pub fn no_undefined_in_prod(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_haskell_files(slice),
+    r"(?:^|[^A-Za-z0-9_'.])undefined(?:[^A-Za-z0-9_']|$)",
+    "m",
+  )
+  return block_on_findings(
+    "no_undefined_in_prod",
+    "Replace undefined with a real implementation, a typed Maybe/Either, or move the stub to a test or scratch module.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_ERROR_CALL, confidence: 0.7, source_date: "2026-05-10")
+/** Warns when production modules call `error` instead of returning Either or throwing a typed exception. */
+pub fn no_error_call_in_prod(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_haskell_files(slice),
+    r"(?:^|[^A-Za-z0-9_'.])error(?:[^A-Za-z0-9_']|$)",
+    "m",
+  )
+  return warn_on_findings(
+    "no_error_call_in_prod",
+    "Return Either/Maybe or throw a typed exception via Control.Exception (throwIO) instead of error.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_UNSAFE_PERFORM_IO, confidence: 0.86, source_date: "2026-05-10")
+/** Blocks unsafe IO escapes (unsafePerformIO and friends) in production modules. */
+pub fn no_unsafe_perform_io(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_haskell_files(slice),
+    r"(?:^|[^A-Za-z0-9_'.])(unsafePerformIO|unsafeDupablePerformIO|unsafeInterleaveIO|unsafeFixIO)(?:[^A-Za-z0-9_']|$)",
+    "m",
+  )
+  return block_on_findings(
+    "no_unsafe_perform_io",
+    "Thread IO through the type system; if escape is unavoidable, isolate it under an Internal module with a documented invariant and reviewer sign-off.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_EXPLICIT_IMPORTS, confidence: 0.7, source_date: "2026-05-10")
+/** Warns on open imports — imports without `qualified` and without an explicit import list. */
+pub fn explicit_imports(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_haskell_files(slice),
+    r"(?m)^import\s+[A-Z][\w\.]*(?:\s+as\s+\w+)?\s*$",
+    "m",
+  )
+  return warn_on_findings(
+    "explicit_imports",
+    "Add an explicit import list, e.g. `import Data.Map (Map, lookup)`, or qualify the import to keep the namespace stable.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_EXPLICIT_EXPORT, confidence: 0.74, source_date: "2026-05-10")
+/** Warns when modules omit an explicit export list before `where`. */
+pub fn explicit_export_list(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_haskell_files(slice),
+    r"(?m)^module\s+[A-Z][\w\.]*\s+where\b",
+    "m",
+  )
+  return warn_on_findings(
+    "explicit_export_list",
+    "Add an explicit export list to the module header so the public surface is documented and reviewable.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_NEWTYPE, confidence: 0.68, source_date: "2026-05-10")
+/** Warns when a single-field `data` record could be a `newtype` for zero runtime overhead. */
+pub fn prefer_newtype_for_single_field(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_haskell_files(slice),
+    r"(?m)^data\s+\w+(?:\s+\w+)*\s*=\s*\w+\s*\{\s*\w+\s*::\s*[^,}\n]+\}",
+    "m",
+  )
+  return warn_on_findings(
+    "prefer_newtype_for_single_field",
+    "Replace `data` with `newtype` for single-constructor, single-field records; it shares the runtime representation with the wrapped type.",
+    findings,
+  )
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_TOTAL_FUNCTIONS, confidence: 0.62, source_date: "2026-05-10")
+/** Blocks production functions that pattern-match non-exhaustively without a documented partial contract. */
+pub fn total_function_semantic_check(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed Haskell production code introduces a function whose pattern matches are non-exhaustive — for example, list patterns missing the empty case, Maybe patterns missing Nothing, sum-type patterns missing constructors, lambda-case clauses missing variants, or `head`/`fromJust`-style partial helpers — and the function lacks a Haddock comment, MonadFail context, or other clear documentation that the partiality is intentional. Allow exhaustive matches, GADT/refinement-driven coverage, intentionally partial Internal helpers, and matches whose missing branches are statically impossible."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: production_haskell_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "total_function_semantic_check",
+      "Cover every constructor, return Maybe/Either, or document the partial contract on a function isolated to an Internal module.",
+      judgement.findings,
+    )
+  }
+  return allow("total_function_semantic_check")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_ORPHAN_INSTANCES, confidence: 0.66, source_date: "2026-05-10")
+/** Blocks orphan typeclass instances — instances declared in a module that defines neither the class nor the type. */
+pub fn no_orphan_instances(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when a changed Haskell module declares a typeclass instance and the slice shows that neither the class nor the head type constructor is defined in this module or its package. Allow newtype-wrapper instances declared alongside the wrapper, and instances that the module clearly owns. The judge may rely on imports and module headers as evidence."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: haskell_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "no_orphan_instances",
+      "Declare the instance in the module that owns the class or the type, or wrap the type in a newtype and put the instance on the wrapper.",
+      judgement.findings,
+    )
+  }
+  return allow("no_orphan_instances")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_SECRETS, confidence: 0.7, source_date: "2026-05-10")
+/** Blocks hardcoded credentials, tokens, and other long-lived secrets in Haskell source. */
+pub fn no_hardcoded_secrets(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed Haskell source embeds API tokens, signing keys, database passwords, production connection strings, private keys, or other long-lived credentials as string literals instead of reading them from environment variables, a secret manager, or a runtime config. Allow obviously fake test fixtures, public identifiers, and example documentation literals."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: haskell_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "no_hardcoded_secrets",
+      "Move secrets to environment variables or a secret manager and rotate any credentials that were exposed in source.",
+      judgement.findings,
+    )
+  }
+  return allow("no_hardcoded_secrets")
+}


### PR DESCRIPTION
Closes #19. Adds a v0 starter predicate pack for **Haskell** under `haskell/`.

## Summary

- 7 deterministic + 3 semantic predicates covering the Prelude footguns and Haskell-specific review hazards an Archivist can catch on a changed slice.
- Each predicate ships an allow + block/warn fixture under `haskell/fixtures/`.
- Root `README.md` lists the pack alphabetically between `Harn` and `HTML`.

### Predicates

| Predicate | Mode | Verdict |
|---|---|---|
| `no_partial_functions_in_pub_api` | deterministic | Block |
| `no_undefined_in_prod` | deterministic | Block |
| `no_error_call_in_prod` | deterministic | Warn |
| `no_unsafe_perform_io` | deterministic | Block |
| `explicit_imports` | deterministic | Warn |
| `explicit_export_list` | deterministic | Warn |
| `prefer_newtype_for_single_field` | deterministic | Warn |
| `total_function_semantic_check` | semantic | Block |
| `no_orphan_instances` | semantic | Block |
| `no_hardcoded_secrets` | semantic | Block |

### Evidence

Each `@archivist` block cites at least two independent sources scanned 2026-05-10. Sources are official-first: GHC user-guide warning flags (`-Wincomplete-patterns`, `-Wmissing-import-lists`, `-Wmissing-export-lists`, `-Worphans`, `-Wx-partial`), Hackage `base` reference pages (`Prelude`, `System.IO.Unsafe`, `Control.Exception`, `Data.Maybe.fromJust`), the Haskell 2010 Report §5, the Haskell Wiki, HLint, and OWASP secrets guidance.

### Notes

- Production paths exclude `test/`, `tests/`, `spec/`, `bench/`, `benches/`, `examples/`, plus `*Spec.hs`/`*Test.hs`/`_spec.hs`/`_test.hs` (top-level and nested).
- "Public API" additionally excludes `/Internal/` and `Internal.hs`, the standard Haskell escape hatch for documented partial helpers.
- Predicates that have meaningful false-positive risk on regex-based scans (`no_error_call_in_prod`, `explicit_imports`, `explicit_export_list`, `prefer_newtype_for_single_field`) warn rather than block. Hard-edged primitives (`undefined`, `unsafePerformIO`, partial Prelude helpers in pub API) block.
- Known regex limitations and false positives are documented in `haskell/README.md`.

## Test plan

- [ ] CI green (evidence-link, fmt, fixture-replay placeholders pass).
- [ ] Reviewer skim of `invariants.harn` for evidence quality and remediation tone.
- [ ] Reviewer skim of fixtures: each has at least one block/warn case and one allow case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)