### PR TITLE
Add Scala seed predicate pack (#16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ See the Harn Flow design docs for the full predicate language spec.
 - [R](./r/) — v0 draft predicates for R analysis scripts, R Markdown / Quarto documents, and R packages.
 - [Ruby](./ruby/) — v0 draft predicates for Ruby application and library code.
 - [Rust](./rust/) — v0 draft predicates for Rust application and library code.
+- [Scala](./scala/) — v0 draft predicates for Scala 2 and Scala 3 source covering null safety, immutability, effect-system hygiene, and pattern-match exhaustiveness.
 - [SQL](./sql/) — v0 draft predicates for schema, migration, and query safety.
 - [Swift](./swift/) — v0 draft predicates for Swift application and UI code.
 - [Terraform](./terraform/) — v0 draft predicates for Terraform configurations across AWS, Azure, and GCP providers.

--- a/scala/README.md
+++ b/scala/README.md
@@ -1,0 +1,68 @@
+# Scala Seed Predicate Pack
+
+This pack covers Scala 2.13 and Scala 3 source on the JVM, with an emphasis on null safety, immutability, total function shape, effect-system hygiene, and pattern-match exhaustiveness. The v0 rules favor simple source-text predicates for concrete failure modes and semantic predicates where effect-system boundaries or exhaustiveness require code context.
+
+## Stack Assumptions
+
+- Files use `.scala`. Worksheets (`.sc`) and sbt build files (`.sbt`) are out of scope; the v0 pack reads only compiled-source `.scala` files.
+- Projects may use sbt, Mill, Bloop, Metals, ScalaTest, MUnit, ZIO, cats-effect, Akka, Pekko, or Spark; predicates target idioms that are common across these stacks rather than framework-specific patterns.
+- Deterministic predicates run over changed production Scala source text. Test (`src/test/`, `src/it/`, `*Spec.scala`, `*Suite.scala`, `*Test(s).scala`, `*Properties.scala`), generated (`target/`, `.bloop/`, `.metals/`, `.bsp/`, `generated/`), and build script paths (`*.sbt`, `*.sc`) are excluded.
+- Library-only predicates additionally exclude common entry-point filenames (`Main.scala`, `App.scala`, `Application.scala`, `Boot.scala`).
+- Semantic predicates use `ctx.semantic_judge(...)` and must cite concrete changed spans before blocking.
+- The pack is a seed canon, not a replacement for the Scala compiler, scalac `-Xfatal-warnings`, scalafix, scalafmt, or WartRemover.
+
+## Predicate Coverage
+
+| Predicate | Mode | Verdict | Purpose |
+|---|---|---|---|
+| `no_any_in_public_api` | deterministic | Warn | Avoid leaking `Any`/`AnyRef`/`AnyVal` in declared return types. |
+| `no_null` | deterministic | Block | Use `Option`/`Either`/`Try` instead of `null` literals. |
+| `immutable_by_default` | deterministic | Warn | Prefer `val` over mutable `var` declarations. |
+| `no_return_keyword` | deterministic | Warn | Drop explicit `return`; nested non-local returns are deprecated since Scala 3.2. |
+| `explicit_return_types_on_public_defs` | deterministic | Warn | Annotate public defs with explicit return types. |
+| `no_get_on_option_or_try` | deterministic | Block | Avoid `.get` accessors that throw on absence/failure. |
+| `no_unchecked_type_casts` | deterministic | Warn | Replace `asInstanceOf`/`isInstanceOf` with pattern matching. |
+| `no_global_execution_context` | deterministic | Block | Take an `ExecutionContext` parameter instead of importing the global. |
+| `no_await_in_library_code` | deterministic | Block | Keep `Await.result`/`Await.ready` at the process boundary. |
+| `effect_typed_boundaries` | semantic | Block | Cross IO/ZIO ↔ Future only through documented adapters. |
+| `no_unsafe_run_in_library_code` | semantic | Block | Run effects only in `IOApp`/`ZIOAppDefault`/Dispatcher boundaries. |
+| `pattern_matches_are_exhaustive` | semantic | Warn | Match expressions need a sealed subject or explicit fallback. |
+
+## Evidence
+
+Evidence scanned on 2026-05-10.
+
+- Scala 3 book and reference: functional error handling, vars/data types, methods, dropped non-local returns, and pattern matching with `TypeTest`.
+- Scala 3 tour: pattern matching exhaustiveness on sealed types.
+- Official Scala style guide: declarations, return-type guidance for public members.
+- Scala overviews: futures, `Await`, and the global `ExecutionContext`.
+- Cats Effect documentation: getting started and runtime escape hatches.
+- ZIO documentation: the `ZIO[R, E, A]` effect type and runtime entry points.
+- WartRemover wart catalogue: `Any`, `Null`, `Var`, `Return`, `OptionPartial`, `TryPartial`, `AsInstanceOf`, `IsInstanceOf` as ecosystem precedent.
+
+## Known False Positives
+
+- `no_any_in_public_api` matches return-type position only; `Any` in parameter types or as a generic upper bound (`[T <: Any]`) is not flagged. Method overloading on `Any` is occasionally intentional and the rule is Warn-level.
+- `no_null` is source-text based and may flag the literal token inside string content (`"value is null"`). Test paths and Java-interop suppressions are out of scope; scope `null` to a local interop helper if you genuinely need it.
+- `immutable_by_default` warns on every production `var`, including stateful UI, persistence, or buffer types where mutation is intentional.
+- `no_return_keyword` matches statement-position `return` only and will miss inline early returns inside a single-line `if`/lambda.
+- `explicit_return_types_on_public_defs` excludes only `private` defs; `protected`-scoped APIs are still flagged because they cross compilation-unit boundaries.
+- `no_get_on_option_or_try` cannot disambiguate `Option.get` from a parameterless `def get` on a user-defined type, so it will flag the latter; rename or wrap such accessors.
+- `no_unchecked_type_casts` warns on every cast, including legitimate Java-interop boundaries; suppress narrowly with a comment once suppressions exist.
+- `no_global_execution_context` treats `Main.scala`/`App.scala`/`Application.scala`/`Boot.scala` as boundaries; other entry-point filenames may need a suppression.
+- `no_await_in_library_code` accepts `Await` only in tests and recognized entry points; non-standard runner filenames will be flagged.
+- The semantic predicates depend on a cheap judge and should block only when the changed span clearly introduces the risk.
+
+## Fixtures
+
+Each fixture in `fixtures/` contains at least one blocked or warned production example and one allowed example for the corresponding predicate:
+
+```json
+{
+  "predicate": "name",
+  "cases": [
+    {"expect": "Block", "files": [{"path": "src/main/scala/App.scala", "text": "..."}]},
+    {"expect": "Allow", "files": [{"path": "src/main/scala/App.scala", "text": "..."}]}
+  ]
+}
+```

--- a/scala/fixtures/effect_typed_boundaries.json
+++ b/scala/fixtures/effect_typed_boundaries.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "effect_typed_boundaries",
+  "cases": [
+    {
+      "name": "blocks_unsafe_run_inside_future",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/main/scala/example/Bridge.scala",
+          "text": "package example\n\nimport cats.effect.IO\nimport cats.effect.unsafe.IORuntime\nimport scala.concurrent.{ExecutionContext, Future}\n\nfinal class Bridge(io: IO[Int])(using ExecutionContext, IORuntime):\n  def asFuture(): Future[Int] = Future(io.unsafeRunSync())\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_io_from_future_adapter",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/scala/example/Bridge.scala",
+          "text": "package example\n\nimport cats.effect.IO\nimport scala.concurrent.{ExecutionContext, Future}\n\nfinal class Bridge(future: => Future[Int])(using ExecutionContext):\n  def asIO: IO[Int] = IO.fromFuture(IO(future))\n"
+        }
+      ]
+    }
+  ]
+}

--- a/scala/fixtures/explicit_return_types_on_public_defs.json
+++ b/scala/fixtures/explicit_return_types_on_public_defs.json
@@ -1,0 +1,45 @@
+{
+  "predicate": "explicit_return_types_on_public_defs",
+  "cases": [
+    {
+      "name": "warns_inferred_return_type",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/main/scala/example/Greeter.scala",
+          "text": "package example\n\nobject Greeter:\n  def hello(name: String) = s\"Hello, $name\"\n"
+        }
+      ]
+    },
+    {
+      "name": "warns_inferred_with_type_params",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/main/scala/example/Box.scala",
+          "text": "package example\n\nfinal class Box[A](a: A):\n  def map[B](f: A => B) = Box(f(a))\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_explicit_return_type",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/scala/example/Greeter.scala",
+          "text": "package example\n\nobject Greeter:\n  def hello(name: String): String = s\"Hello, $name\"\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_private_inferred",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/scala/example/Greeter.scala",
+          "text": "package example\n\nobject Greeter:\n  private def banner = \"--- hello ---\"\n  def hello(name: String): String = s\"$banner $name\"\n"
+        }
+      ]
+    }
+  ]
+}

--- a/scala/fixtures/immutable_by_default.json
+++ b/scala/fixtures/immutable_by_default.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "immutable_by_default",
+  "cases": [
+    {
+      "name": "warns_var_member",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/main/scala/example/Cart.scala",
+          "text": "package example\n\nfinal class Cart:\n  var totalCents: Int = 0\n"
+        }
+      ]
+    },
+    {
+      "name": "warns_private_scoped_var",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/main/scala/example/Counter.scala",
+          "text": "package example\n\nfinal class Counter:\n  private[example] var ticks: Long = 0L\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_val_declaration",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/scala/example/Cart.scala",
+          "text": "package example\n\nfinal case class Cart(items: List[Item]):\n  val totalCents: Int = items.map(_.priceCents).sum\n\nfinal case class Item(priceCents: Int)\n"
+        }
+      ]
+    }
+  ]
+}

--- a/scala/fixtures/no_any_in_public_api.json
+++ b/scala/fixtures/no_any_in_public_api.json
@@ -1,0 +1,45 @@
+{
+  "predicate": "no_any_in_public_api",
+  "cases": [
+    {
+      "name": "warns_any_return_type_on_public_def",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/main/scala/example/Lookup.scala",
+          "text": "package example\n\nfinal class Lookup(values: Map[String, Int]):\n  def find(key: String): Any = values.getOrElse(key, \"missing\")\n"
+        }
+      ]
+    },
+    {
+      "name": "warns_anyref_return_type",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/main/scala/example/Box.scala",
+          "text": "package example\n\nclass Box[A](a: A):\n  def value: AnyRef = a.asInstanceOf[AnyRef]\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_concrete_return_type",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/scala/example/Lookup.scala",
+          "text": "package example\n\nfinal class Lookup(values: Map[String, Int]):\n  def find(key: String): Option[Int] = values.get(key)\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_private_any_return",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/scala/example/Lookup.scala",
+          "text": "package example\n\nfinal class Lookup:\n  private def raw(key: String): Any = key\n"
+        }
+      ]
+    }
+  ]
+}

--- a/scala/fixtures/no_await_in_library_code.json
+++ b/scala/fixtures/no_await_in_library_code.json
@@ -1,0 +1,45 @@
+{
+  "predicate": "no_await_in_library_code",
+  "cases": [
+    {
+      "name": "blocks_await_result_in_service",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/main/scala/example/Service.scala",
+          "text": "package example\n\nimport scala.concurrent.{Await, Future, ExecutionContext}\nimport scala.concurrent.duration.*\n\nfinal class Service(using ExecutionContext):\n  def fetch(): Int = Await.result(Future(1), 5.seconds)\n"
+        }
+      ]
+    },
+    {
+      "name": "blocks_await_ready_in_service",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/main/scala/example/Service.scala",
+          "text": "package example\n\nimport scala.concurrent.{Await, Future, ExecutionContext}\nimport scala.concurrent.duration.*\n\nfinal class Service(using ExecutionContext):\n  def warm(): Future[Int] =\n    val f = Future(1)\n    Await.ready(f, 1.second)\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_future_composition",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/scala/example/Service.scala",
+          "text": "package example\n\nimport scala.concurrent.{Future, ExecutionContext}\n\nfinal class Service(using ExecutionContext):\n  def fetch(): Future[Int] = Future(1).map(_ + 1)\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_await_in_main_entry",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/scala/example/Main.scala",
+          "text": "package example\n\nimport scala.concurrent.{Await, ExecutionContext, Future}\nimport scala.concurrent.duration.*\n\nobject Main:\n  def main(args: Array[String]): Unit =\n    given ExecutionContext = ExecutionContext.global\n    val _ = Await.result(Future(1), 5.seconds)\n"
+        }
+      ]
+    }
+  ]
+}

--- a/scala/fixtures/no_get_on_option_or_try.json
+++ b/scala/fixtures/no_get_on_option_or_try.json
@@ -1,0 +1,45 @@
+{
+  "predicate": "no_get_on_option_or_try",
+  "cases": [
+    {
+      "name": "blocks_option_get",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/main/scala/example/User.scala",
+          "text": "package example\n\nobject User:\n  def displayName(maybe: Option[String]): String = maybe.get\n"
+        }
+      ]
+    },
+    {
+      "name": "blocks_try_get",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/main/scala/example/Parsing.scala",
+          "text": "package example\n\nimport scala.util.Try\n\nobject Parsing:\n  def asInt(raw: String): Int = Try(raw.toInt).get\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_get_or_else",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/scala/example/User.scala",
+          "text": "package example\n\nobject User:\n  def displayName(maybe: Option[String]): String = maybe.getOrElse(\"anonymous\")\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_map_lookup_with_arg",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/scala/example/Lookup.scala",
+          "text": "package example\n\nobject Lookup:\n  def find(values: Map[String, Int], key: String): Option[Int] = values.get(key)\n"
+        }
+      ]
+    }
+  ]
+}

--- a/scala/fixtures/no_global_execution_context.json
+++ b/scala/fixtures/no_global_execution_context.json
@@ -1,0 +1,45 @@
+{
+  "predicate": "no_global_execution_context",
+  "cases": [
+    {
+      "name": "blocks_global_execution_context_import",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/main/scala/example/Service.scala",
+          "text": "package example\n\nimport scala.concurrent.ExecutionContext.Implicits.global\nimport scala.concurrent.Future\n\nfinal class Service:\n  def fetch(): Future[Int] = Future(1)\n"
+        }
+      ]
+    },
+    {
+      "name": "blocks_wildcard_implicits_import",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/main/scala/example/Service.scala",
+          "text": "package example\n\nimport scala.concurrent.ExecutionContext.Implicits.*\nimport scala.concurrent.Future\n\nfinal class Service:\n  def fetch(): Future[Int] = Future(1)\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_explicit_execution_context_param",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/scala/example/Service.scala",
+          "text": "package example\n\nimport scala.concurrent.{ExecutionContext, Future}\n\nfinal class Service(ec: ExecutionContext):\n  given ExecutionContext = ec\n  def fetch(): Future[Int] = Future(1)\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_global_in_main_entry",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/scala/example/Main.scala",
+          "text": "package example\n\nimport scala.concurrent.ExecutionContext.Implicits.global\nimport scala.concurrent.Future\n\nobject Main:\n  def main(args: Array[String]): Unit =\n    val _ = Future(println(\"hi\"))\n"
+        }
+      ]
+    }
+  ]
+}

--- a/scala/fixtures/no_null.json
+++ b/scala/fixtures/no_null.json
@@ -1,0 +1,45 @@
+{
+  "predicate": "no_null",
+  "cases": [
+    {
+      "name": "blocks_null_assignment",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/main/scala/example/User.scala",
+          "text": "package example\n\nfinal class User:\n  var name: String = null\n"
+        }
+      ]
+    },
+    {
+      "name": "blocks_null_argument",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/main/scala/example/Logger.scala",
+          "text": "package example\n\nobject Logger:\n  def log(message: String): Unit =\n    println(message)\n\n  def boot(): Unit = log(null)\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_option_for_absent_value",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/scala/example/User.scala",
+          "text": "package example\n\nfinal case class User(name: Option[String])\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_test_path_with_null_for_interop_fixture",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/test/scala/example/UserSpec.scala",
+          "text": "package example\n\nclass UserSpec extends munit.FunSuite:\n  test(\"interop allows null\") {\n    val raw: String = null\n    assert(raw == null)\n  }\n"
+        }
+      ]
+    }
+  ]
+}

--- a/scala/fixtures/no_return_keyword.json
+++ b/scala/fixtures/no_return_keyword.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_return_keyword",
+  "cases": [
+    {
+      "name": "warns_explicit_return",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/main/scala/example/Search.scala",
+          "text": "package example\n\nobject Search:\n  def first(values: List[Int]): Option[Int] =\n    for value <- values do\n      if value > 0 then\n        return Some(value)\n    None\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_last_expression_result",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/scala/example/Search.scala",
+          "text": "package example\n\nobject Search:\n  def first(values: List[Int]): Option[Int] = values.find(_ > 0)\n"
+        }
+      ]
+    }
+  ]
+}

--- a/scala/fixtures/no_unchecked_type_casts.json
+++ b/scala/fixtures/no_unchecked_type_casts.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "no_unchecked_type_casts",
+  "cases": [
+    {
+      "name": "warns_as_instance_of",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/main/scala/example/Decoder.scala",
+          "text": "package example\n\nobject Decoder:\n  def asLong(value: Any): Long = value.asInstanceOf[Long]\n"
+        }
+      ]
+    },
+    {
+      "name": "warns_is_instance_of",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/main/scala/example/Routing.scala",
+          "text": "package example\n\nobject Routing:\n  def isString(value: Any): Boolean = value.isInstanceOf[String]\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_pattern_matching",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/scala/example/Decoder.scala",
+          "text": "package example\n\nobject Decoder:\n  def asLong(value: Any): Option[Long] = value match\n    case n: Long => Some(n)\n    case n: Int  => Some(n.toLong)\n    case _       => None\n"
+        }
+      ]
+    }
+  ]
+}

--- a/scala/fixtures/no_unsafe_run_in_library_code.json
+++ b/scala/fixtures/no_unsafe_run_in_library_code.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "no_unsafe_run_in_library_code",
+  "cases": [
+    {
+      "name": "blocks_unsafe_run_sync_in_service",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/main/scala/example/Repository.scala",
+          "text": "package example\n\nimport cats.effect.IO\nimport cats.effect.unsafe.IORuntime\n\nfinal class Repository(load: IO[Int])(using IORuntime):\n  def value: Int = load.unsafeRunSync()\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_unsafe_run_in_main",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/scala/example/Main.scala",
+          "text": "package example\n\nimport cats.effect.IO\nimport cats.effect.unsafe.IORuntime\n\nobject Main:\n  def main(args: Array[String]): Unit =\n    given IORuntime = IORuntime.global\n    IO.println(\"hi\").unsafeRunSync()\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_io_app_main",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/scala/example/App.scala",
+          "text": "package example\n\nimport cats.effect.{IO, IOApp, ExitCode}\n\nobject Bootstrap extends IOApp:\n  def run(args: List[String]): IO[ExitCode] = IO.pure(ExitCode.Success)\n"
+        }
+      ]
+    }
+  ]
+}

--- a/scala/fixtures/pattern_matches_are_exhaustive.json
+++ b/scala/fixtures/pattern_matches_are_exhaustive.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "pattern_matches_are_exhaustive",
+  "cases": [
+    {
+      "name": "warns_open_match_without_fallback",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/main/scala/example/Decoder.scala",
+          "text": "package example\n\nobject Decoder:\n  def label(value: Any): String = value match\n    case s: String => s\n    case n: Int    => n.toString\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_sealed_subject",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/scala/example/Direction.scala",
+          "text": "package example\n\nenum Direction:\n  case North, South, East, West\n\nobject Compass:\n  def label(d: Direction): String = d match\n    case Direction.North => \"N\"\n    case Direction.South => \"S\"\n    case Direction.East  => \"E\"\n    case Direction.West  => \"W\"\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_explicit_default_case",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/main/scala/example/Decoder.scala",
+          "text": "package example\n\nobject Decoder:\n  def label(value: Any): String = value match\n    case s: String => s\n    case n: Int    => n.toString\n    case _         => \"unknown\"\n"
+        }
+      ]
+    }
+  ]
+}

--- a/scala/invariants.harn
+++ b/scala/invariants.harn
@@ -1,0 +1,320 @@
+let _EVIDENCE_PUBLIC_API_TYPES = [
+  "https://docs.scala-lang.org/scala3/book/methods-most.html",
+  "https://www.wartremover.org/doc/warts.html",
+]
+
+let _EVIDENCE_NULL = [
+  "https://docs.scala-lang.org/scala3/book/fp-functional-error-handling.html",
+  "https://www.wartremover.org/doc/warts.html",
+]
+
+let _EVIDENCE_MUTABILITY = [
+  "https://docs.scala-lang.org/scala3/book/taste-vars-data-types.html",
+  "https://www.wartremover.org/doc/warts.html",
+]
+
+let _EVIDENCE_RETURN = [
+  "https://docs.scala-lang.org/scala3/reference/dropped-features/nonlocal-returns.html",
+  "https://www.wartremover.org/doc/warts.html",
+]
+
+let _EVIDENCE_EXPLICIT_TYPES = [
+  "https://docs.scala-lang.org/scala3/book/methods-most.html",
+  "https://docs.scala-lang.org/style/declarations.html",
+]
+
+let _EVIDENCE_OPTION_GET = [
+  "https://docs.scala-lang.org/scala3/book/fp-functional-error-handling.html",
+  "https://www.wartremover.org/doc/warts.html",
+]
+
+let _EVIDENCE_TYPE_CASTS = [
+  "https://docs.scala-lang.org/scala3/reference/changed-features/pattern-matching.html",
+  "https://www.wartremover.org/doc/warts.html",
+]
+
+let _EVIDENCE_GLOBAL_EC = [
+  "https://docs.scala-lang.org/overviews/core/futures.html",
+  "https://typelevel.org/cats-effect/docs/getting-started",
+]
+
+let _EVIDENCE_AWAIT = [
+  "https://docs.scala-lang.org/overviews/core/futures.html",
+  "https://typelevel.org/cats-effect/docs/getting-started",
+]
+
+let _EVIDENCE_EFFECTS = [
+  "https://typelevel.org/cats-effect/docs/getting-started",
+  "https://zio.dev/reference/core/zio/",
+]
+
+let _EVIDENCE_PATTERN_EXHAUSTIVE = [
+  "https://docs.scala-lang.org/scala3/reference/changed-features/pattern-matching.html",
+  "https://docs.scala-lang.org/tour/pattern-matching.html",
+]
+
+fn is_scala_path(path) {
+  return path.ends_with(".scala")
+}
+
+fn is_test_path(path) {
+  return path.contains("/src/test/")
+    || path.contains("/src/it/")
+    || path.contains("/src/funTest/")
+    || path.contains("/test/")
+    || path.contains("/tests/")
+    || path.contains("/it/")
+    || path.ends_with("Spec.scala")
+    || path.ends_with("Suite.scala")
+    || path.ends_with("Test.scala")
+    || path.ends_with("Tests.scala")
+    || path.ends_with("Properties.scala")
+}
+
+fn is_generated_path(path) {
+  return path.contains("/target/")
+    || path.contains("/.bloop/")
+    || path.contains("/.metals/")
+    || path.contains("/.bsp/")
+    || path.contains("/generated/")
+    || path.ends_with(".scala.bak")
+}
+
+fn is_main_entry_path(path) {
+  return path.ends_with("/Main.scala")
+    || path.ends_with("/App.scala")
+    || path.ends_with("/Application.scala")
+    || path.ends_with("/Boot.scala")
+}
+
+fn production_scala_files(slice) {
+  return slice.files.filter(
+    { file -> is_scala_path(file.path)
+      && !is_test_path(file.path)
+      && !is_generated_path(file.path) },
+  )
+}
+
+fn library_scala_files(slice) {
+  return production_scala_files(slice).filter({ file -> !is_main_entry_path(file.path) })
+}
+
+fn scan_files(files, pattern, flags) {
+  var findings = []
+  for file in files {
+    if regex_match(pattern, file.text, flags) != nil {
+      findings = findings.push({path: file.path, pattern: pattern})
+    }
+  }
+  return findings
+}
+
+fn allow(rule) {
+  return {verdict: "Allow", rule: rule, findings: [], remediation: ""}
+}
+
+fn warn(rule, remediation, findings) {
+  return {verdict: "Warn", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block(rule, remediation, findings) {
+  return {verdict: "Block", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return block(rule, remediation, findings)
+}
+
+fn warn_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return warn(rule, remediation, findings)
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_PUBLIC_API_TYPES, confidence: 0.7, source_date: "2026-05-10")
+/** Warns when a non-private def declares Any, AnyRef, or AnyVal as its return type. */
+pub fn no_any_in_public_api(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_scala_files(slice),
+    r"(?m)^\s*(?:final\s+|override\s+|implicit\s+|inline\s+|transparent\s+|opaque\s+|protected(?:\[[^\]]+\])?\s+)*def\s+\w+\s*(?:\[[^\]]*\])?\s*(?:\([^)]*\)\s*)*:\s*(?:Any|AnyRef|AnyVal)\b",
+    "m",
+  )
+  return warn_on_findings(
+    "no_any_in_public_api",
+    "Replace Any/AnyRef/AnyVal in public return types with a concrete type, sealed family, or generic parameter.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_NULL, confidence: 0.74, source_date: "2026-05-10")
+/** Blocks null literals in production Scala source outside of tests and Java interop layers. */
+pub fn no_null(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(production_scala_files(slice), r"(?:^|[\s=,(:!\[])null\b", "ms")
+  return block_on_findings(
+    "no_null",
+    "Use Option, Either, or Try to model absence; reserve null for narrowly scoped Java interop wrappers.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_MUTABILITY, confidence: 0.7, source_date: "2026-05-10")
+/** Warns on mutable var declarations in production Scala source. */
+pub fn immutable_by_default(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_scala_files(slice),
+    r"(?m)^\s*(?:private(?:\[[^\]]+\])?\s+|protected(?:\[[^\]]+\])?\s+|implicit\s+|lazy\s+|final\s+|override\s+)*var\s+\w+\s*[:=]",
+    "m",
+  )
+  return warn_on_findings(
+    "immutable_by_default",
+    "Prefer val; reach for var only when the object's contract intentionally mutates.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_RETURN, confidence: 0.72, source_date: "2026-05-10")
+/** Warns on explicit return statements in production Scala source. */
+pub fn no_return_keyword(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(production_scala_files(slice), r"(?m)^\s*return\b", "m")
+  return warn_on_findings(
+    "no_return_keyword",
+    "Let the last expression be the result; for early exit use boundary/break or restructure with match.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_EXPLICIT_TYPES, confidence: 0.7, source_date: "2026-05-10")
+/** Warns when a non-private def omits an explicit return type. */
+pub fn explicit_return_types_on_public_defs(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    production_scala_files(slice),
+    r"(?m)^\s*(?:final\s+|override\s+|implicit\s+|inline\s+|transparent\s+|opaque\s+|protected(?:\[[^\]]+\])?\s+)*def\s+\w+\s*(?:\[[^\]]*\])?\s*(?:\([^)]*\)\s*)*=\s*",
+    "m",
+  )
+  return warn_on_findings(
+    "explicit_return_types_on_public_defs",
+    "Annotate public defs with an explicit return type; inferred public types churn binary compatibility.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_OPTION_GET, confidence: 0.78, source_date: "2026-05-10")
+/** Blocks .get accessor calls on Option/Try values in production Scala source. */
+pub fn no_get_on_option_or_try(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(production_scala_files(slice), r"\.get\b(?!\s*\()", "s")
+  return block_on_findings(
+    "no_get_on_option_or_try",
+    "Use getOrElse, fold, pattern matching, or for-comprehensions; .get throws on None/Failure.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_TYPE_CASTS, confidence: 0.74, source_date: "2026-05-10")
+/** Warns on asInstanceOf or isInstanceOf type casts in production Scala source. */
+pub fn no_unchecked_type_casts(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(production_scala_files(slice), r"\.(?:asInstanceOf|isInstanceOf)\b", "s")
+  return warn_on_findings(
+    "no_unchecked_type_casts",
+    "Replace asInstanceOf/isInstanceOf with pattern matching, sealed hierarchies, or a TypeTest.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_GLOBAL_EC, confidence: 0.84, source_date: "2026-05-10")
+/** Blocks imports of the global ExecutionContext in production library Scala source. */
+pub fn no_global_execution_context(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    library_scala_files(slice),
+    r"import\s+scala\.concurrent\.ExecutionContext\.Implicits\.(?:global|_|\*)",
+    "s",
+  )
+  return block_on_findings(
+    "no_global_execution_context",
+    "Take an ExecutionContext as a parameter or wire one explicitly; the global pool is not safe for blocking workloads.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_AWAIT, confidence: 0.82, source_date: "2026-05-10")
+/** Blocks Await.result and Await.ready outside of tests and main entry points. */
+pub fn no_await_in_library_code(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(library_scala_files(slice), r"\bAwait\s*\.\s*(?:result|ready)\s*\(", "s")
+  return block_on_findings(
+    "no_await_in_library_code",
+    "Compose Futures with map/flatMap/for or expose them in the API; keep Await at the process boundary.",
+    findings,
+  )
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_EFFECTS, confidence: 0.62, source_date: "2026-05-10")
+/** Blocks unsafe boundaries between effect types and Future in production Scala. */
+pub fn effect_typed_boundaries(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed production Scala mixes a typed effect (cats-effect IO/Resource, ZIO, Monix Task) with scala.concurrent.Future in a way that defeats cancellation, error channels, or resource scoping. Examples: calling .unsafeRunSync inside a Future or eager block to thread a value back to async code; turning an IO into a Future without IO.fromFuture/IO.fromFutureCancelable or the equivalent ZIO.fromFuture; awaiting a Future inside an IO body instead of suspending it. Allow code that crosses the boundary explicitly through documented adapter APIs."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: production_scala_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "effect_typed_boundaries",
+      "Cross IO/ZIO and Future boundaries through fromFuture/fromFutureCancelable adapters; never unsafeRun inside another effect.",
+      judgement.findings,
+    )
+  }
+  return allow("effect_typed_boundaries")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_EFFECTS, confidence: 0.66, source_date: "2026-05-10")
+/** Blocks unsafe runtime escapes outside of process entry points. */
+pub fn no_unsafe_run_in_library_code(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed Scala calls an effect runtime escape hatch (cats-effect unsafeRunSync/unsafeRunAsync/unsafeRunTimed, IORuntime.global.unsafe, ZIO Runtime.default.unsafe.run, Monix runSyncUnsafe) from a file that is not a Main, App, IOApp, ZIOAppDefault, test, or documented Dispatcher boundary. Allow these calls in process entry points and in test setup or teardown."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: production_scala_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "no_unsafe_run_in_library_code",
+      "Move unsafeRun/runtime.unsafe calls to IOApp/ZIOAppDefault main, a Dispatcher, or test-only setup.",
+      judgement.findings,
+    )
+  }
+  return allow("no_unsafe_run_in_library_code")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_PATTERN_EXHAUSTIVE, confidence: 0.6, source_date: "2026-05-10")
+/** Warns when production match expressions are non-exhaustive without an explicit fallback. */
+pub fn pattern_matches_are_exhaustive(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed production Scala adds a match expression whose subject is not a sealed family, enum, ADT, or otherwise compiler-checked exhaustive type, and the match omits both a `case _ =>` fallback and any defensive Try/Either wrapping. Allow matches over sealed types, enums, tuples decomposed positionally, and explicit `case _ => ...` fallbacks."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: production_scala_files(slice)})
+  if judgement.verdict == "Block" {
+    return warn(
+      "pattern_matches_are_exhaustive",
+      "Add a `case _ =>` fallback or constrain the matched type to a sealed family the compiler can check.",
+      judgement.findings,
+    )
+  }
+  return allow("pattern_matches_are_exhaustive")
+}


### PR DESCRIPTION
## Summary

Drafts a v0 seed predicate pack for **Scala** ([#16](https://github.com/burin-labs/harn-canon/issues/16)) — covers Scala 2 and Scala 3 source on the JVM with 9 deterministic predicates and 3 semantic predicates.

| Predicate | Mode | Verdict | Purpose |
|---|---|---|---|
| `no_any_in_public_api` | deterministic | Warn | Avoid leaking `Any`/`AnyRef`/`AnyVal` in declared return types. |
| `no_null` | deterministic | Block | Use `Option`/`Either`/`Try` instead of `null` literals. |
| `immutable_by_default` | deterministic | Warn | Prefer `val` over mutable `var` declarations. |
| `no_return_keyword` | deterministic | Warn | Drop explicit `return`; nested non-local returns are deprecated since Scala 3.2. |
| `explicit_return_types_on_public_defs` | deterministic | Warn | Annotate public defs with explicit return types. |
| `no_get_on_option_or_try` | deterministic | Block | Avoid `.get` accessors that throw on absence/failure. |
| `no_unchecked_type_casts` | deterministic | Warn | Replace `asInstanceOf`/`isInstanceOf` with pattern matching. |
| `no_global_execution_context` | deterministic | Block | Take an `ExecutionContext` parameter instead of importing the global. |
| `no_await_in_library_code` | deterministic | Block | Keep `Await.result`/`Await.ready` at the process boundary. |
| `effect_typed_boundaries` | semantic | Block | Cross IO/ZIO ↔ Future only through documented adapters. |
| `no_unsafe_run_in_library_code` | semantic | Block | Run effects only in `IOApp`/`ZIOAppDefault`/Dispatcher boundaries. |
| `pattern_matches_are_exhaustive` | semantic | Warn | Match expressions need a sealed subject or explicit fallback. |

Each predicate cites at least two independent official sources — Scala 3 book and reference, Scala docs overviews and style guide, Cats Effect, ZIO, and WartRemover — with confidences calibrated to source-text match precision.

Closes #16.

## Test plan

- [x] `invariants.harn` follows the Kotlin/Java/SQL pack shape (helpers, `production_*`/`library_*` filtering, allow/warn/block constructors).
- [x] All 12 fixture JSON files parse as valid JSON and pair Block/Warn cases with Allow cases.
- [x] All 11 unique evidence URLs return HTTP 200 (deadlinks check).
- [x] Test paths (`src/test/`, `*Spec.scala`, `*Suite.scala`, `*Test.scala`, `*Properties.scala`), generated dirs (`target/`, `.bloop/`, `.metals/`, `.bsp/`), and main entries (`Main.scala`, `App.scala`, `Application.scala`, `Boot.scala`) are excluded where appropriate.
- [x] Top-level `README.md` lists the new pack alphabetically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)