### PR TITLE
Add C++ seed predicate pack (#14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ See the Harn Flow design docs for the full predicate language spec.
 
 - [C](./c/) — v0 draft predicates for plain C source and headers covering memory, string-handling, format-string, and tempfile footguns.
 - [C#](./csharp/) — v0 draft predicates for plain C# and .NET library or application code.
+- [C++](./cpp/) — v0 draft predicates for plain C++ application and library code covering memory safety, header hygiene, and special-member discipline.
 - [CSS](./css/) — v0 draft predicates for CSS, Sass, and Less stylesheets covering cascade hygiene, internationalization, and accessibility.
 - [Dart](./dart/) — v0 draft predicates for Dart application, package, and Flutter source covering null safety, public-API hygiene, async correctness, and widget immutability.
 - [Dockerfile](./dockerfile/) — v0 draft predicates for `Dockerfile` and `Containerfile` build recipes.

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -1,0 +1,62 @@
+# C++ Seed Predicate Pack
+
+This pack covers plain C++ application and library code with an emphasis on memory safety, modern initialization, header hygiene, and special-member discipline. The v0 rules deliberately use simple source-text predicates where a failure mode is concrete (raw `new`/`delete`, `malloc`/`free`, `NULL`, missing include guards, `using namespace` in headers, C-style casts, `typedef`) and lean on semantic predicates where C++ class context is too rich for regex alone (Rule of Five, member initialization, const correctness).
+
+## Stack Assumptions
+
+- C++ source files use `.cpp`, `.cxx`, `.cc`, or `.c++`. Headers use `.h`, `.hpp`, `.hh`, `.hxx`, `.h++`, `.ipp`, `.tpp`, or `.inl`.
+- The pack targets C++17 and later. `nullptr`, `=default`/`=delete`, in-class member initializers, `using` aliases, and named casts are all assumed available.
+- Production paths exclude any path under `test/`, `tests/`, `Test/`, `Tests/`, `unittest/`, `unittests/`, `gtest/`, `example/`, `examples/`, `sample/`, `samples/`, `bench/`, `benchmark/`, `benchmarks/`, `demo/`, `demos/`, `fuzz/`, `third_party/`, `thirdparty/`, `vendor/`, `external/`, `extern/`, `deps/`, `build/`, `_build/`, `cmake-build*`, or `.deps/`. Files matching `*_test.{cpp,cc,cxx}` and `*Test.{cpp,cc}` are also excluded.
+- Header-scoped predicates (`header_include_guard_or_pragma_once`, `no_using_namespace_in_header`) inspect every changed header outside `third_party/` and similar vendor paths.
+- Deterministic predicates run over changed source text until Flow exposes a stable Clang/`libclang` AST query API; semantic predicates make a single judge call over the changed slice.
+- The pack is a seed canon, not a replacement for clang-tidy, the C++ compiler, AddressSanitizer/UBSan, or runtime profiling.
+
+## Predicate Coverage
+
+| Predicate | Mode | Verdict | Purpose |
+|---|---|---|---|
+| `no_raw_new_delete` | deterministic | Block | Production C++ should not call `new` or `delete` directly; use `std::make_unique`, `std::make_shared`, or a stack/`std::vector` allocation. |
+| `no_naked_malloc_free` | deterministic | Block | Production C++ should not call C allocators; use RAII containers and smart pointers. |
+| `prefer_nullptr_over_null` | deterministic | Warn | Pointer constants should be `nullptr`; `NULL` is an integer macro that breaks overload resolution. |
+| `header_include_guard_or_pragma_once` | deterministic | Block | Every C++ header needs `#pragma once` or an `#ifndef`/`#define`/`#endif` guard. |
+| `no_using_namespace_in_header` | deterministic | Block | Headers must not import a namespace at global scope; doing so leaks symbols into every translation unit that includes them. |
+| `no_c_style_cast_in_prod` | deterministic | Warn | C-style primitive casts hide intent; prefer `static_cast`, `const_cast`, `reinterpret_cast`, or `dynamic_cast`. |
+| `prefer_using_over_typedef` | deterministic | Warn | Use `using` aliases; they read left-to-right and support template aliases that `typedef` cannot express. |
+| `rule_of_five_consistency` | semantic | Block | Classes that declare any of dtor/copy/move special members must declare or `=default`/`=delete` the remaining set. |
+| `members_initialized` | semantic | Block | Class data members of fundamental, pointer, or enum type must be initialized either in-class or in every constructor. |
+| `const_correctness_on_pub_api` | semantic | Warn | Public or protected member functions that do not modify `*this` should be declared `const`. |
+
+## Evidence
+
+Evidence scanned on 2026-05-10.
+
+- ISO C++ Core Guidelines: R.10, R.11, ES.47, ES.49, SF.7, SF.8, T.43, C.21, C.48, Type.6, and Con.2.
+- LLVM clang-tidy checks: `cppcoreguidelines-owning-memory`, `cppcoreguidelines-no-malloc`, `cppcoreguidelines-pro-type-cstyle-cast`, `cppcoreguidelines-pro-type-member-init`, `cppcoreguidelines-special-member-functions`, `modernize-use-nullptr`, `modernize-use-using`, `llvm-header-guard`, `google-readability-casting`, and `readability-make-member-function-const`.
+- cppreference: `nullptr`, `unique_ptr`, the rule of three/five, and the `#include` and `#pragma once` preprocessor reference pages.
+- Google C++ Style Guide: namespaces section on `using namespace` discipline.
+
+## Known False Positives
+
+- All deterministic predicates scan raw file text. Source comments, raw string literals, and `#define` bodies that contain `new`, `delete`, `malloc`, `NULL`, `typedef`, or `using namespace` token sequences will be flagged until the pack runs against an AST query layer.
+- `no_raw_new_delete` matches `new T` and `delete ptr` in any context. Placement `new` (`new (mem) T`) deliberately bypasses the regex (`new` is followed by `(`, not an identifier); flag-and-grep is the recommended audit until placement new gets first-class detection.
+- `no_naked_malloc_free` matches the bare `malloc(`, `calloc(`, `realloc(`, and `free(` token sequences. Member methods or namespace-scoped helpers named `free` (e.g., `pool.free()`, `arena::free()`) will also match; suppress locally once predicate suppressions land.
+- `prefer_nullptr_over_null` flags `NULL` only when it is on the right-hand side of an assignment, comparison, return, function argument, ternary, or compared in Yoda style. `#define NULL 0` and `#undef NULL` lines escape detection by virtue of not matching the operator-prefix pattern.
+- `header_include_guard_or_pragma_once` accepts any pair of `#ifndef`/`#define` tokens in the file. A header that uses `#ifndef`/`#define` for a feature flag but lacks a real guard will be allowed; a real header guard is the dominant pattern in practice.
+- `no_using_namespace_in_header` flags `using namespace` even inside templates, function bodies, or anonymous namespaces inside the header. Function-local `using namespace` is acceptable C++ but is intentionally discouraged at this layer to keep the rule simple.
+- `no_c_style_cast_in_prod` is conservative: it only matches casts to fundamental types, fixed-width integers, and the standard character/`void` types. C-style casts to user-defined types are not flagged here; clang-tidy's `cppcoreguidelines-pro-type-cstyle-cast` covers the broader case.
+- `prefer_using_over_typedef` flags every `typedef` line, including those inside `extern "C"` blocks bridging to a C API. Suppress locally once predicate suppressions land.
+- The semantic predicates (`rule_of_five_consistency`, `members_initialized`, `const_correctness_on_pub_api`) depend on a cheap judge and should block (or warn) only when the changed span clearly introduces the risk; the rubrics call out the common exceptions.
+
+## Fixtures
+
+Each fixture in `fixtures/` contains at least one blocked or warned production example and one allowed example for the corresponding predicate:
+
+```json
+{
+  "predicate": "name",
+  "cases": [
+    {"expect": "Block", "files": [{"path": "src/widget.cpp", "text": "..."}]},
+    {"expect": "Allow", "files": [{"path": "src/widget.cpp", "text": "..."}]}
+  ]
+}
+```

--- a/cpp/fixtures/const_correctness_on_pub_api.json
+++ b/cpp/fixtures/const_correctness_on_pub_api.json
@@ -1,0 +1,45 @@
+{
+  "predicate": "const_correctness_on_pub_api",
+  "cases": [
+    {
+      "name": "warns_on_non_const_read_only_method",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "include/widget/widget.hpp",
+          "text": "#pragma once\n\n#include <string>\n\nclass Widget {\npublic:\n    explicit Widget(std::string name) : name_(std::move(name)) {}\n    std::string name() { return name_; }\nprivate:\n    std::string name_;\n};\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_const_qualified_accessor",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "include/widget/widget.hpp",
+          "text": "#pragma once\n\n#include <string>\n\nclass Widget {\npublic:\n    explicit Widget(std::string name) : name_(std::move(name)) {}\n    const std::string& name() const { return name_; }\nprivate:\n    std::string name_;\n};\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_method_that_mutates_state",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "include/widget/widget.hpp",
+          "text": "#pragma once\n\nclass Widget {\npublic:\n    void increment() { ++n_; }\n    int value() const { return n_; }\nprivate:\n    int n_{0};\n};\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_virtual_override_with_non_const_base",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/handler.cpp",
+          "text": "struct Base {\n    virtual void handle() = 0;\n    virtual ~Base() = default;\n};\n\nclass Derived : public Base {\npublic:\n    void handle() override {\n        // Base::handle is non-const; override must match.\n    }\n};\n"
+        }
+      ]
+    }
+  ]
+}

--- a/cpp/fixtures/header_include_guard_or_pragma_once.json
+++ b/cpp/fixtures/header_include_guard_or_pragma_once.json
@@ -1,0 +1,45 @@
+{
+  "predicate": "header_include_guard_or_pragma_once",
+  "cases": [
+    {
+      "name": "blocks_header_without_guard",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "include/widget/widget.h",
+          "text": "struct Widget {\n    int id;\n};\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_header_with_pragma_once",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "include/widget/widget.h",
+          "text": "#pragma once\n\nstruct Widget {\n    int id;\n};\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_header_with_ifndef_guard",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "include/widget/widget.hpp",
+          "text": "#ifndef WIDGET_WIDGET_HPP\n#define WIDGET_WIDGET_HPP\n\nstruct Widget {\n    int id;\n};\n\n#endif  // WIDGET_WIDGET_HPP\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_third_party_header_without_guard",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "third_party/legacy/legacy.h",
+          "text": "struct Legacy {\n    int v;\n};\n"
+        }
+      ]
+    }
+  ]
+}

--- a/cpp/fixtures/members_initialized.json
+++ b/cpp/fixtures/members_initialized.json
@@ -1,0 +1,45 @@
+{
+  "predicate": "members_initialized",
+  "cases": [
+    {
+      "name": "blocks_class_with_uninitialized_pod_member",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/counter.cpp",
+          "text": "class Counter {\npublic:\n    Counter() {}\n    int value() const { return n_; }\nprivate:\n    int n_;\n};\n"
+        }
+      ]
+    },
+    {
+      "name": "blocks_class_with_uninitialized_pointer_member",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "include/widget/widget.hpp",
+          "text": "#pragma once\n\nclass Widget {\npublic:\n    Widget();\nprivate:\n    int* data_;\n};\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_in_class_default_initializer",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/counter.cpp",
+          "text": "class Counter {\npublic:\n    Counter() = default;\n    int value() const { return n_; }\nprivate:\n    int n_{0};\n};\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_constructor_member_init_list",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/counter.cpp",
+          "text": "class Counter {\npublic:\n    Counter() : n_(0) {}\n    explicit Counter(int n) : n_(n) {}\n    int value() const { return n_; }\nprivate:\n    int n_;\n};\n"
+        }
+      ]
+    }
+  ]
+}

--- a/cpp/fixtures/no_c_style_cast_in_prod.json
+++ b/cpp/fixtures/no_c_style_cast_in_prod.json
@@ -1,0 +1,45 @@
+{
+  "predicate": "no_c_style_cast_in_prod",
+  "cases": [
+    {
+      "name": "warns_on_c_style_cast_to_int",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/measure.cpp",
+          "text": "#include <cstddef>\n\nint truncate(double x) {\n    return (int)x;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "warns_on_c_style_cast_to_pointer",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/buffer.cpp",
+          "text": "#include <cstddef>\n\nchar* as_chars(void* p) {\n    return (char*)p;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_named_casts",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/measure.cpp",
+          "text": "#include <cstddef>\n\nint truncate(double x) {\n    return static_cast<int>(x);\n}\n\nchar* as_chars(void* p) {\n    return reinterpret_cast<char*>(p);\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_constructor_call",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/measure.cpp",
+          "text": "#include <string>\n\nstd::string make() {\n    return std::string(\"hello\");\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/cpp/fixtures/no_naked_malloc_free.json
+++ b/cpp/fixtures/no_naked_malloc_free.json
@@ -1,0 +1,55 @@
+{
+  "predicate": "no_naked_malloc_free",
+  "cases": [
+    {
+      "name": "blocks_malloc_in_src",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/buffer.cpp",
+          "text": "#include <cstdlib>\n\nvoid* allocate(size_t bytes) {\n    return malloc(bytes);\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "blocks_free_in_src",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/buffer.cpp",
+          "text": "#include <cstdlib>\n\nvoid release(void* p) {\n    free(p);\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "blocks_calloc_realloc_in_src",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/grow.cpp",
+          "text": "#include <cstdlib>\n\nvoid* zero_alloc(size_t n) {\n    return calloc(n, sizeof(int));\n}\n\nvoid* grow(void* p, size_t bytes) {\n    return realloc(p, bytes);\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_vector_and_unique_ptr",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/buffer.cpp",
+          "text": "#include <memory>\n#include <vector>\n\nstd::vector<int> make_buffer(std::size_t n) {\n    return std::vector<int>(n);\n}\n\nstd::unique_ptr<int[]> make_array(std::size_t n) {\n    return std::make_unique<int[]>(n);\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_malloc_in_test",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "tests/buffer_test.cpp",
+          "text": "#include <cstdlib>\n\nvoid* legacy_alloc(size_t bytes) {\n    return malloc(bytes);\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/cpp/fixtures/no_raw_new_delete.json
+++ b/cpp/fixtures/no_raw_new_delete.json
@@ -1,0 +1,55 @@
+{
+  "predicate": "no_raw_new_delete",
+  "cases": [
+    {
+      "name": "blocks_raw_new_in_src",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/widget.cpp",
+          "text": "#include \"widget.h\"\n\nWidget* make_widget() {\n    return new Widget(42);\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "blocks_raw_delete_array_in_src",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/buffer.cpp",
+          "text": "void release(int* arr) {\n    delete[] arr;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_make_unique",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/widget.cpp",
+          "text": "#include <memory>\n#include \"widget.h\"\n\nstd::unique_ptr<Widget> make_widget() {\n    return std::make_unique<Widget>(42);\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_raw_new_in_test_path",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "tests/widget_test.cpp",
+          "text": "#include \"widget.h\"\n\nWidget* legacy_factory() {\n    return new Widget(0);\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_operator_new_overload",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/arena.cpp",
+          "text": "#include <cstddef>\n\nstruct Arena {\n    static void* operator new(std::size_t bytes);\n    static void operator delete(void* p) noexcept;\n};\n"
+        }
+      ]
+    }
+  ]
+}

--- a/cpp/fixtures/no_using_namespace_in_header.json
+++ b/cpp/fixtures/no_using_namespace_in_header.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "no_using_namespace_in_header",
+  "cases": [
+    {
+      "name": "blocks_using_namespace_std_in_header",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "include/widget/widget.hpp",
+          "text": "#pragma once\n\n#include <string>\n\nusing namespace std;\n\nstruct Widget {\n    string name;\n};\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_using_alias_in_header",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "include/widget/widget.hpp",
+          "text": "#pragma once\n\n#include <string>\n\nnamespace widget {\nusing String = std::string;\n\nstruct Widget {\n    String name;\n};\n}  // namespace widget\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_using_namespace_inside_cpp_source",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/widget.cpp",
+          "text": "#include \"widget/widget.hpp\"\n\nusing namespace std;\n\nvoid Widget::touch() {\n    name = string(\"hi\");\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/cpp/fixtures/prefer_nullptr_over_null.json
+++ b/cpp/fixtures/prefer_nullptr_over_null.json
@@ -1,0 +1,45 @@
+{
+  "predicate": "prefer_nullptr_over_null",
+  "cases": [
+    {
+      "name": "warns_on_null_assignment",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/widget.cpp",
+          "text": "#include \"widget.h\"\n#include <cstddef>\n\nWidget* find() {\n    Widget* p = NULL;\n    return p;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "warns_on_null_comparison",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/widget.cpp",
+          "text": "#include \"widget.h\"\n#include <cstddef>\n\nbool is_set(Widget* p) {\n    return p != NULL;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_nullptr_usage",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/widget.cpp",
+          "text": "#include \"widget.h\"\n\nWidget* find() {\n    Widget* p = nullptr;\n    return p;\n}\n\nbool is_set(Widget* p) {\n    return p != nullptr;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_null_in_test",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "tests/widget_test.cpp",
+          "text": "#include \"widget.h\"\n#include <cstddef>\n\nvoid legacy() {\n    Widget* p = NULL;\n    (void)p;\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/cpp/fixtures/prefer_using_over_typedef.json
+++ b/cpp/fixtures/prefer_using_over_typedef.json
@@ -1,0 +1,45 @@
+{
+  "predicate": "prefer_using_over_typedef",
+  "cases": [
+    {
+      "name": "warns_on_typedef_alias",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/types.cpp",
+          "text": "typedef int Counter;\n\nCounter zero() {\n    return 0;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "warns_on_typedef_function_pointer",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/callbacks.cpp",
+          "text": "typedef void (*Callback)(int);\n\nvoid noop(int) {}\n\nCallback default_callback() {\n    return noop;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_using_alias",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/types.cpp",
+          "text": "using Counter = int;\n\nCounter zero() {\n    return 0;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_using_alias_for_function_pointer",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/callbacks.cpp",
+          "text": "using Callback = void (*)(int);\n\nvoid noop(int) {}\n\nCallback default_callback() {\n    return noop;\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/cpp/fixtures/rule_of_five_consistency.json
+++ b/cpp/fixtures/rule_of_five_consistency.json
@@ -1,0 +1,45 @@
+{
+  "predicate": "rule_of_five_consistency",
+  "cases": [
+    {
+      "name": "blocks_class_with_only_destructor_declared",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/handle.cpp",
+          "text": "#include <cstdio>\n\nclass Handle {\npublic:\n    Handle() : fp_(nullptr) {}\n    ~Handle() {\n        if (fp_) std::fclose(fp_);\n    }\nprivate:\n    std::FILE* fp_;\n};\n"
+        }
+      ]
+    },
+    {
+      "name": "blocks_class_with_copy_but_no_move",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/owner.cpp",
+          "text": "class Owner {\npublic:\n    Owner();\n    Owner(const Owner&);\n    Owner& operator=(const Owner&);\n    ~Owner();\n    // Move members intentionally omitted\n};\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_rule_of_zero",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/value.cpp",
+          "text": "#include <string>\n#include <vector>\n\nclass Value {\npublic:\n    int id() const { return id_; }\nprivate:\n    int id_ = 0;\n    std::string name_;\n    std::vector<int> tags_;\n};\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_explicit_full_set",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/handle.cpp",
+          "text": "#include <cstdio>\n\nclass Handle {\npublic:\n    Handle() = default;\n    ~Handle() {\n        if (fp_) std::fclose(fp_);\n    }\n    Handle(const Handle&) = delete;\n    Handle& operator=(const Handle&) = delete;\n    Handle(Handle&& other) noexcept : fp_(other.fp_) { other.fp_ = nullptr; }\n    Handle& operator=(Handle&& other) noexcept {\n        if (this != &other) {\n            if (fp_) std::fclose(fp_);\n            fp_ = other.fp_;\n            other.fp_ = nullptr;\n        }\n        return *this;\n    }\nprivate:\n    std::FILE* fp_ = nullptr;\n};\n"
+        }
+      ]
+    }
+  ]
+}

--- a/cpp/invariants.harn
+++ b/cpp/invariants.harn
@@ -1,0 +1,360 @@
+let _EVIDENCE_RAW_NEW_DELETE = [
+  "https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#r11-avoid-calling-new-and-delete-explicitly",
+  "https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/owning-memory.html",
+  "https://en.cppreference.com/w/cpp/memory/unique_ptr",
+]
+
+let _EVIDENCE_NAKED_MALLOC = [
+  "https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#r10-avoid-malloc-and-free",
+  "https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/no-malloc.html",
+]
+
+let _EVIDENCE_NULLPTR = [
+  "https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es47-use-nullptr-rather-than-0-or-null",
+  "https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-nullptr.html",
+  "https://en.cppreference.com/w/cpp/language/nullptr",
+]
+
+let _EVIDENCE_INCLUDE_GUARD = [
+  "https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf8-use-include-guards-for-all-h-files",
+  "https://clang.llvm.org/extra/clang-tidy/checks/llvm/header-guard.html",
+  "https://en.cppreference.com/w/cpp/preprocessor/impl",
+]
+
+let _EVIDENCE_USING_NAMESPACE_HEADER = [
+  "https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf7-dont-write-using-namespace-at-global-scope-in-a-header-file",
+  "https://google.github.io/styleguide/cppguide.html#Namespaces",
+]
+
+let _EVIDENCE_C_STYLE_CAST = [
+  "https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#es49-if-you-must-use-a-cast-use-a-named-cast",
+  "https://clang.llvm.org/extra/clang-tidy/checks/google/readability-casting.html",
+  "https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-type-cstyle-cast.html",
+]
+
+let _EVIDENCE_USING_OVER_TYPEDEF = [
+  "https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#t43-prefer-using-over-typedef-for-defining-aliases",
+  "https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-using.html",
+]
+
+let _EVIDENCE_RULE_OF_FIVE = [
+  "https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c21-if-you-define-or-delete-any-default-operation-define-or-delete-them-all",
+  "https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/special-member-functions.html",
+  "https://en.cppreference.com/w/cpp/language/rule_of_three",
+]
+
+let _EVIDENCE_MEMBER_INIT = [
+  "https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#type6-always-initialize-a-member-variable",
+  "https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c48-prefer-default-member-initializers-to-member-initializers-in-constructors-for-constant-initializers",
+  "https://clang.llvm.org/extra/clang-tidy/checks/cppcoreguidelines/pro-type-member-init.html",
+]
+
+let _EVIDENCE_CONST_CORRECTNESS = [
+  "https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#con2-by-default-make-member-functions-const",
+  "https://clang.llvm.org/extra/clang-tidy/checks/readability/make-member-function-const.html",
+]
+
+fn is_cpp_source_path(path) {
+  return path.ends_with(".cpp")
+    || path.ends_with(".cxx")
+    || path.ends_with(".cc")
+    || path.ends_with(".c++")
+}
+
+fn is_cpp_header_path(path) {
+  return path.ends_with(".h")
+    || path.ends_with(".hpp")
+    || path.ends_with(".hh")
+    || path.ends_with(".hxx")
+    || path.ends_with(".h++")
+    || path.ends_with(".ipp")
+    || path.ends_with(".tpp")
+    || path.ends_with(".inl")
+}
+
+fn is_cpp_path(path) {
+  return is_cpp_source_path(path) || is_cpp_header_path(path)
+}
+
+fn segment_match(path, segment) {
+  return path.starts_with(segment) || path.contains("/" + segment)
+}
+
+fn is_test_path(path) {
+  return segment_match(path, "test/")
+    || segment_match(path, "tests/")
+    || segment_match(path, "Test/")
+    || segment_match(path, "Tests/")
+    || segment_match(path, "unittest/")
+    || segment_match(path, "unittests/")
+    || segment_match(path, "gtest/")
+    || path.ends_with("_test.cpp")
+    || path.ends_with("_tests.cpp")
+    || path.ends_with("Test.cpp")
+    || path.ends_with("Tests.cpp")
+    || path.ends_with("_test.cc")
+    || path.ends_with("Test.cc")
+    || path.ends_with("_test.cxx")
+}
+
+fn is_third_party_path(path) {
+  return segment_match(path, "third_party/")
+    || segment_match(path, "thirdparty/")
+    || segment_match(path, "vendor/")
+    || segment_match(path, "external/")
+    || segment_match(path, "extern/")
+    || segment_match(path, "deps/")
+    || segment_match(path, "build/")
+    || segment_match(path, "_build/")
+    || segment_match(path, ".deps/")
+    || path.contains("/cmake-build")
+    || path.starts_with("cmake-build")
+}
+
+fn is_example_or_bench_path(path) {
+  return segment_match(path, "example/")
+    || segment_match(path, "examples/")
+    || segment_match(path, "sample/")
+    || segment_match(path, "samples/")
+    || segment_match(path, "benchmark/")
+    || segment_match(path, "benchmarks/")
+    || segment_match(path, "bench/")
+    || segment_match(path, "demo/")
+    || segment_match(path, "demos/")
+    || segment_match(path, "fuzz/")
+}
+
+fn cpp_files(slice) {
+  return slice.files.filter({ file -> is_cpp_path(file.path) })
+}
+
+fn cpp_production_files(slice) {
+  return cpp_files(slice).filter(
+    { file -> !is_test_path(file.path)
+      && !is_third_party_path(file.path)
+      && !is_example_or_bench_path(file.path) },
+  )
+}
+
+fn cpp_header_files(slice) {
+  return slice.files.filter(
+    { file -> is_cpp_header_path(file.path) && !is_third_party_path(file.path) },
+  )
+}
+
+fn scan_files(files, pattern, flags) {
+  var findings = []
+  for file in files {
+    if regex_match(pattern, file.text, flags) != nil {
+      findings = findings.push({path: file.path, pattern: pattern})
+    }
+  }
+  return findings
+}
+
+fn scan_files_if(files, predicate) {
+  var findings = []
+  for file in files {
+    if predicate(file) {
+      findings = findings.push({path: file.path})
+    }
+  }
+  return findings
+}
+
+fn allow(rule) {
+  return {verdict: "Allow", rule: rule, findings: [], remediation: ""}
+}
+
+fn warn(rule, remediation, findings) {
+  return {verdict: "Warn", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block(rule, remediation, findings) {
+  return {verdict: "Block", rule: rule, findings: findings, remediation: remediation}
+}
+
+fn block_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return block(rule, remediation, findings)
+}
+
+fn warn_on_findings(rule, remediation, findings) {
+  if findings.none() {
+    return allow(rule)
+  }
+  return warn(rule, remediation, findings)
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_RAW_NEW_DELETE, confidence: 0.82, source_date: "2026-05-10")
+/** Blocks raw new and delete in production C++ paths in favor of smart pointers and RAII containers. */
+pub fn no_raw_new_delete(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    cpp_production_files(slice),
+    r"\bnew\s+[A-Za-z_]|\bdelete\b\s*(?:\[\s*\])?\s*[A-Za-z_]",
+    "s",
+  )
+  return block_on_findings(
+    "no_raw_new_delete",
+    "Use std::make_unique, std::make_shared, std::vector, or stack allocation instead of raw new/delete.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_NAKED_MALLOC, confidence: 0.82, source_date: "2026-05-10")
+/** Blocks malloc/calloc/realloc/free in production C++ paths in favor of RAII allocations. */
+pub fn no_naked_malloc_free(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    cpp_production_files(slice),
+    r"\b(?:malloc|calloc|realloc|free)\s*\(",
+    "s",
+  )
+  return block_on_findings(
+    "no_naked_malloc_free",
+    "Replace malloc/calloc/realloc/free with std::vector, std::unique_ptr, or std::pmr allocators.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_NULLPTR, confidence: 0.78, source_date: "2026-05-10")
+/** Warns when production C++ uses NULL instead of nullptr for null pointer constants. */
+pub fn prefer_nullptr_over_null(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    cpp_production_files(slice),
+    r"(?:=|==|!=|<|>|\(|,|\?|:|\breturn)\s*NULL\b|\bNULL\s*(?:==|!=|<|>|,|\)|\?|:|=)",
+    "s",
+  )
+  return warn_on_findings(
+    "prefer_nullptr_over_null",
+    "Replace NULL with nullptr; nullptr is type-safe and avoids overload-resolution ambiguity with integer 0.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_INCLUDE_GUARD, confidence: 0.86, source_date: "2026-05-10")
+/** Blocks C++ headers that lack #pragma once or an #ifndef/#define include guard. */
+pub fn header_include_guard_or_pragma_once(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_if(
+    cpp_header_files(slice),
+    { file -> regex_match(r"#\s*pragma\s+once", file.text, "i") == nil
+      && (regex_match(r"#\s*ifndef\s+\w+", file.text, "i") == nil
+      || regex_match(r"#\s*define\s+\w+", file.text, "i") == nil) },
+  )
+  return block_on_findings(
+    "header_include_guard_or_pragma_once",
+    "Add #pragma once or a unique #ifndef/#define/#endif guard so multiple includes do not duplicate definitions.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_USING_NAMESPACE_HEADER, confidence: 0.88, source_date: "2026-05-10")
+/** Blocks `using namespace` directives in C++ headers. */
+pub fn no_using_namespace_in_header(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    cpp_header_files(slice),
+    r"\busing\s+namespace\s+\S+\s*;",
+    "s",
+  )
+  return block_on_findings(
+    "no_using_namespace_in_header",
+    "Remove `using namespace` from the header; restrict it to .cpp source or function-local scope so includers keep their lookup clean.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_C_STYLE_CAST, confidence: 0.7, source_date: "2026-05-10")
+/** Warns when production C++ uses a C-style cast to a primitive type instead of a named cast. */
+pub fn no_c_style_cast_in_prod(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    cpp_production_files(slice),
+    r"\(\s*(?:const\s+|volatile\s+|unsigned\s+|signed\s+)*(?:char|short|int|long|float|double|bool|size_t|ssize_t|ptrdiff_t|u?int(?:8|16|32|64)_t|void|wchar_t|char(?:8|16|32)_t)\s*\*?\s*\)\s*[A-Za-z_(\-+&*]",
+    "s",
+  )
+  return warn_on_findings(
+    "no_c_style_cast_in_prod",
+    "Use static_cast, const_cast, reinterpret_cast, or dynamic_cast so the cast intent is explicit and grep-able.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_USING_OVER_TYPEDEF, confidence: 0.74, source_date: "2026-05-10")
+/** Warns when production C++ declares aliases with typedef instead of `using`. */
+pub fn prefer_using_over_typedef(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    cpp_production_files(slice),
+    r"(?m)^\s*typedef\s+",
+    "m",
+  )
+  return warn_on_findings(
+    "prefer_using_over_typedef",
+    "Use `using Alias = T;` instead of typedef; it reads left-to-right and supports template aliases.",
+    findings,
+  )
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_RULE_OF_FIVE, confidence: 0.66, source_date: "2026-05-10")
+/** Blocks classes that declare some special member functions while leaving others implicit, violating the Rule of Five. */
+pub fn rule_of_five_consistency(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when a changed C++ class definition declares one or more of the destructor, copy constructor, copy assignment operator, move constructor, or move assignment operator without explicitly declaring or =default/=delete the remaining special members. Allow classes that follow the Rule of Zero (no special members declared), classes whose remaining special members are inherited unchanged from a base that already declares them, and classes whose declaration carries a comment that documents why a specific member is intentionally implicit."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: cpp_production_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "rule_of_five_consistency",
+      "Declare or =default/=delete every special member when you declare any of them; partial sets invite slicing and double-frees.",
+      judgement.findings,
+    )
+  }
+  return allow("rule_of_five_consistency")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_MEMBER_INIT, confidence: 0.7, source_date: "2026-05-10")
+/** Blocks class members left without an in-class initializer or constructor initialization. */
+pub fn members_initialized(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when a changed C++ class adds or modifies a non-static data member of a non-class fundamental, pointer, enum, or array type that has neither an in-class default initializer nor initialization in every constructor's member initializer list, leaving the field with indeterminate value when an instance is constructed. Allow class-typed members whose own default constructor performs the required initialization, fields explicitly tagged for indeterminate state via a documented placement-new pattern, fields initialized by every base or delegating constructor in the change set, and union members which cannot carry an in-class initializer."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: cpp_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "members_initialized",
+      "Give the member an in-class default initializer (`Type field{};`) or initialize it in every constructor's member initializer list.",
+      judgement.findings,
+    )
+  }
+  return allow("members_initialized")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_CONST_CORRECTNESS, confidence: 0.6, source_date: "2026-05-10")
+/** Warns on public/protected member functions that do not modify *this but are not declared const. */
+pub fn const_correctness_on_pub_api(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when a changed C++ public or protected non-static member function does not write to any non-mutable data member of *this and does not call any non-const member function on *this, yet its declaration omits the trailing const qualifier. Allow virtual overrides whose base class signature is non-const, methods that lock a non-mutable mutex or update non-mutable cache state, methods that return *this or a non-const reference to a member to outside callers, and call operators on stateful function objects whose contract is documented as non-const."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: cpp_production_files(slice)})
+  if judgement.verdict == "Block" {
+    return warn(
+      "const_correctness_on_pub_api",
+      "Add the trailing const qualifier when the method is observably read-only on *this; mark members `mutable` only when they are truly logical-const.",
+      judgement.findings,
+    )
+  }
+  return allow("const_correctness_on_pub_api")
+}


### PR DESCRIPTION
## Summary

- Closes [#14](https://github.com/burin-labs/harn-canon/issues/14): adds a v0 seed predicate pack for plain C++ application and library code.
- 7 deterministic predicates: `no_raw_new_delete`, `no_naked_malloc_free`, `prefer_nullptr_over_null`, `header_include_guard_or_pragma_once`, `no_using_namespace_in_header`, `no_c_style_cast_in_prod`, `prefer_using_over_typedef`.
- 3 semantic predicates: `rule_of_five_consistency`, `members_initialized`, `const_correctness_on_pub_api`.
- Evidence is anchored on the ISO C++ Core Guidelines (R.10/R.11/ES.47/ES.49/SF.7/SF.8/T.43/C.21/C.48/Type.6/Con.2), LLVM clang-tidy checks, cppreference, and the Google C++ Style Guide. Every predicate's evidence list cites ≥2 independent sources scanned 2026-05-10.
- Each predicate has a fixture under `cpp/fixtures/` with at least one Block/Warn case and one Allow case; the verifier in this branch confirms all 29 deterministic fixture cases match the expected verdicts.

## Test plan

- [x] `cpp/invariants.harn` parses against the same conventions as the existing seed packs (csharp/sql/rust).
- [x] All 10 fixture JSON files validate as JSON.
- [x] All 7 deterministic predicates evaluated against their fixtures with a JS port of the regex helpers — 29/29 cases match expected verdicts (semantic predicates skipped, depend on judge).
- [x] Evidence URLs return 200 for ISO C++ Core Guidelines, clang-tidy, and Google C++ Style Guide; cppreference returns 403 to scripted curl due to Cloudflare bot protection but each evidence list has fallback authoritative sources from `isocpp.github.io` and `clang.llvm.org`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)