### PR TITLE
[codex] Complete canon seed pack coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,34 +7,18 @@ on:
   merge_group:
 
 jobs:
-  evidence-links:
-    name: Evidence link check (placeholder)
+  canon-validation:
+    name: Canon structure and fixture validation
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Placeholder
-        run: echo "Evidence-link validator will land once invariants.harn files exist."
-
-  fmt:
-    name: Predicate fmt (placeholder)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Placeholder
-        run: echo "harn fmt --check will run once predicate language ships."
-
-  fixture-replay:
-    name: Fixture replay (placeholder)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Placeholder
-        run: echo "Fixture allow/block replay will run once the Harn Flow runtime ships."
+      - name: Validate canon packs
+        run: python3 scripts/validate_canon.py
 
   ci-status:
     name: CI status
     if: always()
-    needs: [evidence-links, fmt, fixture-replay]
+    needs: [canon-validation]
     runs-on: ubuntu-latest
     steps:
       - name: Check for failures

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 *.swo
 .idea/
 .vscode/
+__pycache__/
+*.pyc
 target/
 node_modules/
 .harn/

--- a/README.md
+++ b/README.md
@@ -50,11 +50,13 @@ See the Harn Flow design docs for the full predicate language spec.
 - [Lua](./lua/) — v0 draft predicates for general-purpose Lua application and library code targeting Lua 5.2+ and LuaJIT.
 - [Markdown](./markdown/) — v0 draft predicates for prose Markdown files used for documentation, READMEs, and design notes.
 - [PHP](./php/) — v0 draft predicates for plain PHP application and library code.
+- [Protocol Buffers](./protobuf/) — v0 draft predicates for `.proto` files covering syntax versioning, package hygiene, field numbering, and compatibility.
 - [Python](./python/) — v0 draft predicates for Python application and library code.
 - [R](./r/) — v0 draft predicates for R analysis scripts, R Markdown / Quarto documents, and R packages.
 - [Ruby](./ruby/) — v0 draft predicates for Ruby application and library code.
 - [Rust](./rust/) — v0 draft predicates for Rust application and library code.
 - [Scala](./scala/) — v0 draft predicates for Scala 2 and Scala 3 source covering null safety, immutability, effect-system hygiene, and pattern-match exhaustiveness.
+- [Shell](./shell/) — v0 draft predicates for POSIX shell and Bash scripts covering strict mode, cleanup traps, eval hazards, and ShellCheck discipline.
 - [SQL](./sql/) — v0 draft predicates for schema, migration, and query safety.
 - [Swift](./swift/) — v0 draft predicates for Swift application and UI code.
 - [Terraform](./terraform/) — v0 draft predicates for Terraform configurations across AWS, Azure, and GCP providers.
@@ -62,6 +64,7 @@ See the Harn Flow design docs for the full predicate language spec.
 - [TypeScript](./typescript/) — v0 draft predicates for TypeScript and TSX code.
 - [XML](./xml/) — v0 draft predicates for XML payloads, XSD schemas, XSLT stylesheets, and related XML-shaped formats.
 - [YAML](./yaml/) — v0 draft predicates for plain YAML configuration covering parser footguns and unsafe deserialization tags.
+- [Zig](./zig/) — v0 draft predicates for Zig application and library code covering error handling, allocator lifetimes, build metadata, and explicit low-level operations.
 
 ## Status
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,8 +2,9 @@
 
 Design docs and evidence dossiers for the Harn Flow seed invariant packs.
 
-- Canonical Harn Flow spec: lives in [`burin-labs/harn`](https://github.com/burin-labs/harn) (link to tracking epic will land here once the umbrella issue is filed).
-- Predicate language reference: see `burin-labs/harn` issue for the predicate-language ticket (`[flow] invariants.harn discovery + attribute schema`).
+- Canonical Harn Flow spec: lives in [`burin-labs/harn`](https://github.com/burin-labs/harn); the current Flow umbrella is [`burin-labs/harn#571`](https://github.com/burin-labs/harn/issues/571).
+- Predicate pack umbrella: [`burin-labs/harn-canon#1`](https://github.com/burin-labs/harn-canon/issues/1).
+- Predicate language reference: see the Flow predicate-language work tracked under the Harn Flow umbrella.
 - Evidence sourcing policy: see [CONTRIBUTING.md](../CONTRIBUTING.md).
 
 Per-language packs live in sibling directories at the repo root (e.g., `rust/`, `typescript/`, `swift/`). Each one ships its own `README.md` with pack-specific rationale.

--- a/json/README.md
+++ b/json/README.md
@@ -15,6 +15,7 @@ This pack covers strict JSON content quality before format-specific packs (npm `
 |---|---|---|---|
 | `no_trailing_commas` | deterministic | Block | Strict `.json` must follow RFC 8259, which forbids trailing commas. |
 | `no_comments_in_json` | deterministic | Block | Strict `.json` must not contain `//` or `/*` comment markers; rename to `.jsonc` or `.json5` if comments are required. |
+| `strings_use_double_quotes` | deterministic | Block | Strict `.json` object keys and string values must use double quotation marks, not single quotes. |
 | `no_bom_prefix` | deterministic | Warn | JSON files must not begin with a UTF-8 byte order mark. |
 | `no_nan_or_infinity_literals` | deterministic | Block | `NaN`, `Infinity`, and `-Infinity` are not valid JSON numbers. |
 | `no_hardcoded_secrets` | semantic | Block | Credentials, tokens, private keys, and production connection strings must not live in committed JSON values. |
@@ -23,7 +24,7 @@ This pack covers strict JSON content quality before format-specific packs (npm `
 
 ## Evidence
 
-Evidence scanned on 2026-05-09.
+Evidence scanned on 2026-05-09 and refreshed on 2026-05-15 for new predicates.
 
 - IETF RFC 8259 — JSON grammar (numbers, objects, strings), the explicit "no comments" stance, and the byte-order-mark prohibition.
 - json.org canonical syntax reference.
@@ -36,6 +37,7 @@ Evidence scanned on 2026-05-09.
 ## Known False Positives
 
 - Regex predicates are intentionally conservative and file-scoped. A literal `,]`, `//`, `/*`, `NaN`, or `Infinity` substring inside a JSON string value can trip the corresponding predicate until value-aware matching lands.
+- `strings_use_double_quotes` may flag a string value that itself contains a JSON-looking snippet with single quotes, because v0 scans raw file text rather than parsed string boundaries.
 - `no_trailing_commas` and `no_comments_in_json` apply only to `.json`; `.jsonc`, `.json5`, and the JSONC-by-convention paths listed above are exempt. Project-specific JSONC formats not on that list (for example, `tslint.json`) will need an explicit allowlist later.
 - `no_bom_prefix` triggers any time the file's first three bytes are the UTF-8 BOM, even when downstream tooling silently strips it. The verdict is `Warn` because the file usually still works but eventually breaks a parser somewhere.
 - `respects_declared_schema` only fires when a `$schema` reference is present and the violation is concretely visible in the slice; it is not a full JSON Schema validator.

--- a/json/fixtures/strings_use_double_quotes.json
+++ b/json/fixtures/strings_use_double_quotes.json
@@ -1,0 +1,45 @@
+{
+  "predicate": "strings_use_double_quotes",
+  "cases": [
+    {
+      "name": "blocks_single_quoted_key",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "config/app.json",
+          "text": "{\n  'port': 8080\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "blocks_single_quoted_value",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "config/app.json",
+          "text": "{\n  \"mode\": 'production'\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_apostrophe_inside_double_quoted_string",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "config/app.json",
+          "text": "{\n  \"owner\": \"team's service\",\n  \"mode\": \"production\"\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_json5_single_quotes_outside_strict_json",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "config/app.json5",
+          "text": "{\n  'mode': 'production',\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/json/invariants.harn
+++ b/json/invariants.harn
@@ -8,6 +8,11 @@ let _EVIDENCE_NO_COMMENTS = [
   "https://code.visualstudio.com/docs/languages/json#_json-with-comments",
 ]
 
+let _EVIDENCE_DOUBLE_QUOTED_STRINGS = [
+  "https://www.rfc-editor.org/rfc/rfc8259#section-7",
+  "https://www.json.org/json-en.html",
+]
+
 let _EVIDENCE_BOM = [
   "https://www.rfc-editor.org/rfc/rfc8259#section-8.1",
   "https://datatracker.ietf.org/doc/html/rfc8259#section-8.1",
@@ -125,6 +130,23 @@ pub fn no_comments_in_json(slice, _ctx, _repo_at_base) {
   return block_on_findings(
     "no_comments_in_json",
     "Remove the comment; rename the file to .jsonc or .json5 if comments are required.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_DOUBLE_QUOTED_STRINGS, confidence: 0.84, source_date: "2026-05-15")
+/** Blocks single-quoted strings in strict .json files; JSON strings must use double quotation marks. */
+pub fn strings_use_double_quotes(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(
+    strict_json_files(slice),
+    r"(?m)(?:^|[\{\[,:])\s*'[^'\n]*'",
+    "m",
+  )
+  return block_on_findings(
+    "strings_use_double_quotes",
+    "Use double quotes for JSON object keys and string values; single quotes are JSON5, not strict JSON.",
     findings,
   )
 }

--- a/scripts/validate_canon.py
+++ b/scripts/validate_canon.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+import calendar
+import datetime as dt
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+EXPECTED_PACKS = (
+    "c",
+    "cpp",
+    "csharp",
+    "css",
+    "dart",
+    "dockerfile",
+    "elixir",
+    "go",
+    "graphql",
+    "harn",
+    "haskell",
+    "html",
+    "java",
+    "javascript",
+    "json",
+    "kotlin",
+    "lua",
+    "markdown",
+    "php",
+    "protobuf",
+    "python",
+    "r",
+    "ruby",
+    "rust",
+    "scala",
+    "shell",
+    "sql",
+    "swift",
+    "terraform",
+    "toml",
+    "typescript",
+    "xml",
+    "yaml",
+    "zig",
+)
+
+MIN_DETERMINISTIC = 5
+MAX_DETERMINISTIC = 10
+MIN_SEMANTIC = 2
+MAX_SEMANTIC = 3
+VALID_EXPECTS = {"Allow", "Warn", "Block"}
+
+INVARIANT_RE = re.compile(
+    r"@invariant\s*"
+    r"@(?P<mode>deterministic|semantic)\s*"
+    r"@archivist\(\s*"
+    r"evidence:\s*(?P<evidence>_EVIDENCE_[A-Za-z0-9_]+)\s*,\s*"
+    r"confidence:\s*(?P<confidence>(?:0(?:\.\d+)?|1(?:\.0+)?))\s*,\s*"
+    r'source_date:\s*"(?P<source_date>\d{4}-\d{2}-\d{2})"\s*'
+    r"\).*?"
+    r"pub\s+fn\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*)\s*\(",
+    re.S,
+)
+EVIDENCE_RE = re.compile(r"let\s+(_EVIDENCE_[A-Za-z0-9_]+)\s*=\s*\[(.*?)\]", re.S)
+URL_RE = re.compile(r'"(https?://[^"]+)"')
+
+
+def shifted_months(day, months):
+    month_index = day.year * 12 + (day.month - 1) + months
+    year, zero_based_month = divmod(month_index, 12)
+    month = zero_based_month + 1
+    capped_day = min(day.day, calendar.monthrange(year, month)[1])
+    return dt.date(year, month, capped_day)
+
+
+def parse_invariants(path, errors):
+    text = path.read_text(encoding="utf-8")
+    entries = [match.groupdict() for match in INVARIANT_RE.finditer(text)]
+    invariant_count = len(re.findall(r"@invariant\b", text))
+    if invariant_count != len(entries):
+        errors.append(
+            f"{path.relative_to(ROOT)}: parsed {len(entries)} annotated pub fns but found {invariant_count} @invariant markers"
+        )
+
+    evidence_defs = {}
+    for name, body in EVIDENCE_RE.findall(text):
+        evidence_defs[name] = sorted(set(URL_RE.findall(body)))
+
+    return entries, evidence_defs
+
+
+def validate_evidence(pack, entries, evidence_defs, errors):
+    today = dt.date.today()
+    cutoff = shifted_months(today, -18)
+
+    for entry in entries:
+        predicate = entry["name"]
+        evidence_name = entry["evidence"]
+        urls = evidence_defs.get(evidence_name)
+        if urls is None:
+            errors.append(f"{pack}: {predicate} references missing evidence {evidence_name}")
+        elif len(urls) < 2:
+            errors.append(f"{pack}: {evidence_name} must list at least two evidence URLs")
+
+        confidence = float(entry["confidence"])
+        if not 0.0 <= confidence <= 1.0:
+            errors.append(f"{pack}: {predicate} confidence {confidence} is outside 0.0..1.0")
+
+        try:
+            source_date = dt.date.fromisoformat(entry["source_date"])
+        except ValueError:
+            errors.append(f"{pack}: {predicate} has invalid source_date {entry['source_date']}")
+            continue
+
+        if source_date > today:
+            errors.append(f"{pack}: {predicate} source_date {source_date} is in the future")
+        if source_date < cutoff:
+            errors.append(f"{pack}: {predicate} source_date {source_date} is older than 18 months")
+
+
+def validate_fixtures(pack_dir, predicate_names, errors):
+    fixtures_dir = pack_dir / "fixtures"
+    if not fixtures_dir.is_dir():
+        errors.append(f"{pack_dir.name}: missing fixtures/ directory")
+        return 0
+
+    fixture_files = sorted(fixtures_dir.glob("*.json"))
+    fixture_names = {path.stem for path in fixture_files}
+
+    missing = sorted(predicate_names - fixture_names)
+    extra = sorted(fixture_names - predicate_names)
+    if missing:
+        errors.append(f"{pack_dir.name}: missing fixture files for {', '.join(missing)}")
+    if extra:
+        errors.append(f"{pack_dir.name}: fixture files without predicates: {', '.join(extra)}")
+
+    for fixture_path in fixture_files:
+        rel_path = fixture_path.relative_to(ROOT)
+        try:
+            fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            errors.append(f"{rel_path}: invalid JSON: {exc}")
+            continue
+
+        if fixture.get("predicate") != fixture_path.stem:
+            errors.append(f"{rel_path}: predicate must match fixture file name")
+
+        cases = fixture.get("cases")
+        if not isinstance(cases, list) or not cases:
+            errors.append(f"{rel_path}: cases must be a non-empty list")
+            continue
+
+        expects = set()
+        for index, case in enumerate(cases):
+            expect = case.get("expect")
+            if expect not in VALID_EXPECTS:
+                errors.append(f"{rel_path}: case {index} has invalid expect {expect!r}")
+            else:
+                expects.add(expect)
+
+            files = case.get("files")
+            if not isinstance(files, list) or not files:
+                errors.append(f"{rel_path}: case {index} files must be a non-empty list")
+                continue
+
+            for file_index, file_fixture in enumerate(files):
+                if not isinstance(file_fixture.get("path"), str) or not file_fixture["path"]:
+                    errors.append(f"{rel_path}: case {index} file {file_index} needs a path")
+                if not isinstance(file_fixture.get("text"), str):
+                    errors.append(f"{rel_path}: case {index} file {file_index} needs text")
+
+        if "Allow" not in expects:
+            errors.append(f"{rel_path}: fixture must include at least one Allow case")
+        if not (expects & {"Warn", "Block"}):
+            errors.append(f"{rel_path}: fixture must include at least one Warn or Block case")
+
+    return len(fixture_files)
+
+
+def validate_readme_coverage(errors):
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    for pack in EXPECTED_PACKS:
+        if f"](./{pack}/)" not in readme:
+            errors.append(f"README.md: missing pack link for {pack}/")
+
+
+def main():
+    errors = []
+    expected = set(EXPECTED_PACKS)
+    actual = {path.name for path in ROOT.iterdir() if (path / "invariants.harn").is_file()}
+
+    for pack in sorted(expected - actual):
+        errors.append(f"{pack}: expected pack directory is missing")
+    for pack in sorted(actual - expected):
+        errors.append(f"{pack}: pack directory is not listed in EXPECTED_PACKS")
+
+    validate_readme_coverage(errors)
+
+    total_predicates = 0
+    total_fixtures = 0
+    for pack in EXPECTED_PACKS:
+        pack_dir = ROOT / pack
+        invariants_path = pack_dir / "invariants.harn"
+        readme_path = pack_dir / "README.md"
+
+        if not invariants_path.is_file() or not readme_path.is_file():
+            continue
+
+        entries, evidence_defs = parse_invariants(invariants_path, errors)
+        names = [entry["name"] for entry in entries]
+        duplicate_names = sorted({name for name in names if names.count(name) > 1})
+        if duplicate_names:
+            errors.append(f"{pack}: duplicate predicate names: {', '.join(duplicate_names)}")
+
+        deterministic = sum(1 for entry in entries if entry["mode"] == "deterministic")
+        semantic = sum(1 for entry in entries if entry["mode"] == "semantic")
+        if not MIN_DETERMINISTIC <= deterministic <= MAX_DETERMINISTIC:
+            errors.append(
+                f"{pack}: expected {MIN_DETERMINISTIC}-{MAX_DETERMINISTIC} deterministic predicates, found {deterministic}"
+            )
+        if not MIN_SEMANTIC <= semantic <= MAX_SEMANTIC:
+            errors.append(
+                f"{pack}: expected {MIN_SEMANTIC}-{MAX_SEMANTIC} semantic predicates, found {semantic}"
+            )
+
+        validate_evidence(pack, entries, evidence_defs, errors)
+        total_predicates += len(entries)
+        total_fixtures += validate_fixtures(pack_dir, set(names), errors)
+
+    if errors:
+        print("Canon validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print(
+        f"Validated {len(EXPECTED_PACKS)} packs, {total_predicates} predicates, and {total_fixtures} fixtures."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/toml/README.md
+++ b/toml/README.md
@@ -1,6 +1,6 @@
 # TOML Seed Predicate Pack
 
-This pack covers TOML configuration documents — Cargo manifests, `pyproject.toml`, tool configs, and any other `.toml` file. TOML has a small surface area, so this v0 ships fewer predicates than a full-language pack and focuses on rules drawn directly from the TOML 1.0 specification plus the dominant lowercase-keys convention used by the largest TOML ecosystems.
+This pack covers TOML configuration documents — Cargo manifests, `pyproject.toml`, tool configs, and any other `.toml` file. TOML has a small surface area, so this v0 focuses on rules drawn directly from the TOML 1.0 specification plus the dominant package-metadata conventions used by the largest TOML ecosystems.
 
 ## Stack Assumptions
 
@@ -14,16 +14,19 @@ This pack covers TOML configuration documents — Cargo manifests, `pyproject.to
 |---|---|---|---|
 | `no_duplicate_table_headers` | deterministic | Block | TOML 1.0 forbids defining the same standard table more than once. |
 | `no_trailing_comma_in_inline_table` | deterministic | Block | TOML 1.0 inline tables disallow a terminating comma after the last pair. |
+| `boolean_literals_are_lowercase` | deterministic | Block | TOML boolean literals are case-sensitive and must be lowercase `true` or `false`. |
 | `key_naming_convention` | deterministic | Warn | Bare keys with uppercase letters drift from the lowercase snake/kebab convention used by Cargo and PEP 621. |
 | `datetime_includes_offset` | deterministic | Warn | Datetime values without an offset are local-date-times and resolve differently across machines. |
 | `secrets_not_hardcoded_in_toml` | semantic | Block | Credentials and signing secrets belong in env vars or a secret manager, not committed config. |
+| `package_metadata_declares_license` | semantic | Warn | Publishable Cargo and Python package metadata should declare license information. |
 
 ## Evidence
 
-Evidence scanned on 2026-05-09.
+Evidence scanned on 2026-05-09 and refreshed on 2026-05-15 for new predicates.
 
 - TOML 1.0 specification (canonical reference for table, inline-table, key, and datetime grammar): the `toml.io` rendered spec and the `toml-lang/toml` 1.0.0 source.
 - Cargo manifest reference and PEP 621 `pyproject.toml` specification (lowercase / kebab-case key conventions adopted by the two largest TOML ecosystems).
+- Cargo manifest reference and PyPA project metadata specification for package license fields.
 - RFC 3339 (datetime grammar that TOML inherits, including the meaning of an absent offset).
 - OWASP Secrets Management Cheat Sheet, GitHub secret-scanning docs, and CWE-798 (hardcoded credentials).
 
@@ -32,9 +35,11 @@ Evidence scanned on 2026-05-09.
 - Regex predicates do not parse TOML. Unusual whitespace, comments inside complex values, or inline tables split across (technically invalid) lines may confuse the deterministic checks.
 - `no_duplicate_table_headers` relies on a regex backreference and is intentionally narrow: it catches `[a.b]` repeated verbatim but does not catch the harder case of a dotted key (e.g. `a.b.c = 1`) implicitly redefining a table established with `[a.b]`. Implicit-redefinition detection needs a real parser and is left for a future revision.
 - `no_trailing_comma_in_inline_table` only inspects single-line inline tables (the only shape TOML 1.0 permits). Inline tables that have been illegally split across lines will not be flagged here — the parser will reject them first.
+- `boolean_literals_are_lowercase` inspects direct values after `=`. Boolean-looking strings inside quoted values or arrays are ignored.
 - `key_naming_convention` flags any bare key containing an uppercase ASCII letter. Projects that intentionally use mixed case (Hugo's `[Params]` style is one example) can suppress per-finding once the predicate runtime exposes suppressions.
 - `datetime_includes_offset` only inspects datetime literals that appear directly on the right-hand side of `=`. Datetime values nested inside arrays or inline tables on separate lines are not flagged in v0.
 - `secrets_not_hardcoded_in_toml` depends on the judge recognizing concrete credential-shaped strings. It should remain high-threshold and cite exact lines before blocking; placeholders, env-var references, and clearly fake fixtures must allow.
+- `package_metadata_declares_license` is intentionally Warn-level because private workspaces, unpublished examples, and inherited workspace metadata can be legitimate.
 
 ## Future Predicates
 

--- a/toml/fixtures/boolean_literals_are_lowercase.json
+++ b/toml/fixtures/boolean_literals_are_lowercase.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "boolean_literals_are_lowercase",
+  "cases": [
+    {
+      "name": "blocks_titlecase_boolean",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "config.toml",
+          "text": "enabled = True\n"
+        }
+      ]
+    },
+    {
+      "name": "blocks_uppercase_boolean",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "config.toml",
+          "text": "enabled = FALSE\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_lowercase_boolean_and_strings",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "config.toml",
+          "text": "enabled = true\nlabel = \"True\"\n"
+        }
+      ]
+    }
+  ]
+}

--- a/toml/fixtures/package_metadata_declares_license.json
+++ b/toml/fixtures/package_metadata_declares_license.json
@@ -1,0 +1,35 @@
+{
+  "predicate": "package_metadata_declares_license",
+  "cases": [
+    {
+      "name": "warns_on_publishable_cargo_package_without_license",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "Cargo.toml",
+          "text": "[package]\nname = \"widget-core\"\nversion = \"0.1.0\"\nedition = \"2021\"\ndescription = \"Reusable widget primitives\"\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_cargo_package_with_license",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "Cargo.toml",
+          "text": "[package]\nname = \"widget-core\"\nversion = \"0.1.0\"\nedition = \"2021\"\nlicense = \"MIT OR Apache-2.0\"\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_private_workspace_without_package_metadata",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "Cargo.toml",
+          "text": "[workspace]\nmembers = [\"crates/*\"]\n"
+        }
+      ]
+    }
+  ]
+}

--- a/toml/invariants.harn
+++ b/toml/invariants.harn
@@ -9,6 +9,11 @@ let _EVIDENCE_INLINE_TABLE_COMMA = [
   "https://github.com/toml-lang/toml/blob/1.0.0/toml.md",
 ]
 
+let _EVIDENCE_BOOLEAN_LITERALS = [
+  "https://toml.io/en/v1.0.0#boolean",
+  "https://github.com/toml-lang/toml/blob/1.0.0/toml.md#boolean",
+]
+
 let _EVIDENCE_KEY_NAMING = [
   "https://toml.io/en/v1.0.0#keys",
   "https://doc.rust-lang.org/cargo/reference/manifest.html",
@@ -25,6 +30,12 @@ let _EVIDENCE_SECRETS = [
   "https://cheatsheetseries.owasp.org/cheatsheets/Secrets_Management_Cheat_Sheet.html",
   "https://docs.github.com/code-security/secret-scanning/about-secret-scanning",
   "https://cwe.mitre.org/data/definitions/798.html",
+]
+
+let _EVIDENCE_PACKAGE_LICENSE = [
+  "https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields",
+  "https://packaging.python.org/en/latest/specifications/pyproject-toml/#license",
+  "https://packaging.python.org/en/latest/specifications/pyproject-toml/#license-files",
 ]
 
 fn toml_files(slice) {
@@ -99,6 +110,19 @@ pub fn no_trailing_comma_in_inline_table(slice, _ctx, _repo_at_base) {
 
 @invariant
 @deterministic
+@archivist(evidence: _EVIDENCE_BOOLEAN_LITERALS, confidence: 0.86, source_date: "2026-05-15")
+/** Blocks uppercase or titlecase boolean literals; TOML booleans are lowercase true and false. */
+pub fn boolean_literals_are_lowercase(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(toml_files(slice), r"(?m)=[ \t]*(?:True|False|TRUE|FALSE)\b", "m")
+  return block_on_findings(
+    "boolean_literals_are_lowercase",
+    "Use lowercase true or false; TOML booleans are case-sensitive.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
 @archivist(evidence: _EVIDENCE_KEY_NAMING, confidence: 0.66, source_date: "2026-05-09")
 /** Warns on bare keys that contain uppercase letters; prefer snake_case or kebab-case. */
 pub fn key_naming_convention(slice, _ctx, _repo_at_base) {
@@ -146,4 +170,21 @@ pub fn secrets_not_hardcoded_in_toml(slice, ctx, _repo_at_base) {
     )
   }
   return allow("secrets_not_hardcoded_in_toml")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_PACKAGE_LICENSE, confidence: 0.6, source_date: "2026-05-15")
+/** Warns when publishable Cargo or Python package metadata omits license information. */
+pub fn package_metadata_declares_license(slice, ctx, _repo_at_base) {
+  let rubric = "Warn only when a changed Cargo.toml [package] or pyproject.toml [project] clearly describes a publishable package and omits license metadata (license, license-file, or license-files). Allow private workspaces, tool-only configs, and package metadata that inherits license information from a workspace."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: toml_files(slice)})
+  if judgement.verdict == "Warn" || judgement.verdict == "Block" {
+    return warn(
+      "package_metadata_declares_license",
+      "Add license metadata, or mark the package private if it is not intended for publication.",
+      judgement.findings,
+    )
+  }
+  return allow("package_metadata_declares_license")
 }


### PR DESCRIPTION
## Summary
- Add enforceable canon validation for expected pack directories, README coverage, predicate counts, evidence metadata, and fixture schema.
- Fill the remaining JSON and TOML predicate-count gaps with evidence-backed rules and fixtures.
- Replace placeholder CI with the validator and refresh umbrella docs for issue #1.

## Validation
- `python3 scripts/validate_canon.py`
- `python3 -m compileall scripts/validate_canon.py`
- `git diff --check`
- `git diff --cached --check`

Closes #1