### PR TITLE
Polish Harn canon OAuth and channel coverage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Thanks for contributing seed invariants! This repo intentionally moves slowly an
 
 Every `@archivist(...)` attribute must include:
 
-- `evidence = [urls]` — at least two independent sources, no older than **18 months**. Prefer official language/framework/tool docs over blogs. Dead-link check runs in CI.
+- `evidence: _EVIDENCE_*` — a pack-local evidence constant with at least two independent URLs, no older than **18 months**. Prefer official language/framework/tool docs over blogs. Dead-link check runs in CI.
 - `confidence` — `0.0..1.0`, calibrated against the predicate's false-positive rate on fixtures.
 - `source_date` — ISO date of the evidence scan.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # harn-canon
 
-Seed **invariant** libraries for [Harn Flow](https://github.com/burin-labs/harn) — the agent-native shipping substrate built into the [Harn language](https://github.com/burin-labs/harn).
-
-> A repo's *canon* is the living body of best practices it expects changes to respect. The Archivist persona authors the canon. The Ship Captain persona enforces it.
+Seed **invariant** libraries for [Harn Flow](https://github.com/burin-labs/harn). Each pack defines review predicates, evidence, and fixtures that projects can opt into by language or stack.
 
 ## What lives here
 
@@ -15,15 +13,16 @@ Per-language and per-stack **starter predicate packs** that any project can opt 
 Predicate files use Harn attributes to carry evidence:
 
 ```harn
+let _EVIDENCE_FLOATING_PROMISES = [
+  "https://typescript-eslint.io/rules/no-floating-promises/",
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise",
+]
+
 @invariant
 @deterministic
-@archivist(
-  evidence = ["https://typescript-eslint.io/rules/no-floating-promises/"],
-  confidence = 0.9,
-  source_date = "2026-04-24",
-)
-fn no_floating_promises(slice: Slice, ctx: Context, repo_at_base: Repo) -> InvariantResult {
-  // …
+@archivist(evidence: _EVIDENCE_FLOATING_PROMISES, confidence: 0.9, source_date: "2026-04-24")
+pub fn no_floating_promises(slice, _ctx, _repo_at_base) {
+  // Predicate body omitted.
 }
 ```
 
@@ -68,7 +67,7 @@ See the Harn Flow design docs for the full predicate language spec.
 
 ## Status
 
-🚧 **Early — design-first.** The predicate language, `InvariantResult` type, and runtime harness are still being specified in `burin-labs/harn`. This repo exists now to:
+**Early - design-first.** The predicate language, `InvariantResult` type, and runtime harness are still being specified in `burin-labs/harn`. This repo exists now to:
 
 1. Reserve the namespace and let contributors start drafting seed predicates.
 2. Collect evidence and discussion per-language independently of the core substrate schedule.

--- a/harn/README.md
+++ b/harn/README.md
@@ -21,20 +21,25 @@ This pack covers Harn scripts, Flow workflows, and agent-facing Harn modules. It
 | `dynamic_boundaries_use_unknown` | deterministic | Warn | Dynamic JSON/LLM/tool boundaries should use `unknown` plus schema narrowing, not `any`. |
 | `tests_mock_time_for_sleep` | deterministic | Warn | Tests that exercise time, sleep, retry, or deadlines should use mock time. |
 | `prefer_enumerate_over_index_loops` | deterministic | Warn | Prefer direct iteration or `.enumerate()` over `range(len(xs))` loops. |
+| `emit_channel_sets_stable_id` | deterministic | Warn | Durable channel emits should carry a stable id for replay and retry dedupe. |
+| `oauth_redirect_uris_are_https_or_loopback` | deterministic | Block | OAuth dynamic registration metadata must not use plain HTTP web redirect URIs. |
 | `llm_prompts_do_not_embed_secrets` | semantic | Block | Prompts must not embed secrets, credentials, or sensitive customer data. |
+| `oauth_audit_payloads_redact_tokens` | semantic | Block | OAuth audit, transcript, log, and span payloads must redact credentials and tokens. |
 | `acp_tool_side_effects_are_honest` | semantic | Block | ACP tool metadata must describe the strongest side effect a tool can perform. |
 
 ## Evidence
 
-Evidence scanned on 2026-04-26.
+Evidence scanned on 2026-04-26 and refreshed for Harn channel/OAuth surfaces on 2026-05-19.
 
 - Harn quick reference: attributes, strings, typing, iteration, JSON querying, concurrency, and time mocking.
 - Harn builtins reference: JSON/schema helpers, list methods, string helpers, and regex functions.
-- Harn changelog: `llm_call_structured`, schema retries, and removed legacy transcript options.
+- Harn changelog: `llm_call_structured`, schema retries, removed legacy transcript options, durable channel receipts, and `std/oauth/*` client/dynamic-registration redaction contracts.
 - OpenAI Structured Outputs guide: schema-backed model outputs and strict structured output behavior.
 - OpenAI and Anthropic rate-limit guidance: short bursts and uncapped concurrency can trip provider limits.
 - JSON Schema object reference: `properties`, `required`, and `additionalProperties` object validation.
 - OWASP, OpenAI, and Microsoft AI security guidance: prompt-injection, system-prompt leakage, sensitive-information disclosure, and excessive-agency risks.
+- RFC 7591 and RFC 8252: OAuth dynamic client registration validation and native-app loopback redirect exceptions.
+- OWASP Logging Cheat Sheet: data that should be excluded from application logs.
 
 ## Known False Positives
 
@@ -42,6 +47,8 @@ Evidence scanned on 2026-04-26.
 - `parallel_io_sets_max_concurrent` warns on helper calls whose names look like external IO, even when a wrapper has its own limiter.
 - `schema_objects_reject_unknown_properties` assumes closed schemas by default; extension-point schemas should document intentional `additional_properties`.
 - `dynamic_boundaries_use_unknown` is advisory because some low-level generic helpers legitimately use `any`.
+- `emit_channel_sets_stable_id` is text-level and may miss ids assembled by wrapper functions; wrappers should carry their own focused invariants.
+- `oauth_redirect_uris_are_https_or_loopback` catches literal metadata only. Runtime metadata still relies on `std/oauth/dynamic_registration` validation.
 - The semantic predicates depend on a cheap judge. They should stay high-threshold and cite concrete spans before blocking.
 
 ## Fixtures

--- a/harn/fixtures/emit_channel_sets_stable_id.json
+++ b/harn/fixtures/emit_channel_sets_stable_id.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "emit_channel_sets_stable_id",
+  "cases": [
+    {
+      "name": "warns_emit_without_idempotency_id",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "agent/channels.harn",
+          "text": "fn publish(summary) {\n  return emit_channel(\"review.ready\", {summary: summary})\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_emit_with_stable_id",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "agent/channels.harn",
+          "text": "fn publish(pr_id, summary) {\n  return emit_channel(\"review.ready\", {summary: summary}, {id: \"review-ready-${pr_id}\"})\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/harn/fixtures/oauth_audit_payloads_redact_tokens.json
+++ b/harn/fixtures/oauth_audit_payloads_redact_tokens.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "oauth_audit_payloads_redact_tokens",
+  "cases": [
+    {
+      "name": "blocks_oauth_secret_in_audit_payload",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "auth/dynreg.harn",
+          "text": "import { register_client } from \"std/oauth/dynamic_registration\"\n\nfn register(store, metadata) {\n  let registered = register_client(store, metadata)\n  emit_audit(\"oauth.dynreg.audit\", \"client_registered\", {client_id: registered.client_id, client_secret: registered.client_secret})\n  return registered.client_id\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_redacted_oauth_audit_shape",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "auth/dynreg.harn",
+          "text": "import { register_client } from \"std/oauth/dynamic_registration\"\n\nfn register(store, metadata) {\n  let registered = register_client(store, metadata)\n  emit_audit(\"oauth.dynreg.audit\", \"client_registered\", {client_id: registered.client_id, has_client_secret: registered.client_secret != nil})\n  return registered.client_id\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/harn/fixtures/oauth_redirect_uris_are_https_or_loopback.json
+++ b/harn/fixtures/oauth_redirect_uris_are_https_or_loopback.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "oauth_redirect_uris_are_https_or_loopback",
+  "cases": [
+    {
+      "name": "blocks_plain_http_web_redirect_uri",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "auth/metadata.harn",
+          "text": "import { client_metadata } from \"std/oauth/dynamic_registration\"\n\nlet metadata = client_metadata({redirect_uris: [\"http://app.example/callback\"]})\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_https_and_loopback_redirect_uris",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "auth/metadata.harn",
+          "text": "import { client_metadata } from \"std/oauth/dynamic_registration\"\n\nlet metadata = client_metadata({redirect_uris: [\"https://app.example/callback\", \"http://127.0.0.1:3987/callback\"]})\n"
+        }
+      ]
+    }
+  ]
+}

--- a/harn/invariants.harn
+++ b/harn/invariants.harn
@@ -42,6 +42,23 @@ let _EVIDENCE_ITERATION = [
   "https://harnlang.com/builtins.html#list-methods",
 ]
 
+let _EVIDENCE_CHANNEL_IDEMPOTENCY = [
+  "https://github.com/burin-labs/harn/blob/main/CHANGELOG.md#unreleased",
+  "https://harnlang.com/builtins.html",
+]
+
+let _EVIDENCE_OAUTH_DYNAMIC_REGISTRATION = [
+  "https://github.com/burin-labs/harn/blob/main/CHANGELOG.md#unreleased",
+  "https://www.rfc-editor.org/rfc/rfc7591.html#section-5.1",
+  "https://www.rfc-editor.org/rfc/rfc8252.html#section-7.3",
+]
+
+let _EVIDENCE_OAUTH_REDACTION = [
+  "https://github.com/burin-labs/harn/blob/main/CHANGELOG.md#unreleased",
+  "https://www.rfc-editor.org/rfc/rfc7591.html#section-3.2.1",
+  "https://cheatsheetseries.owasp.org/cheatsheets/Logging_Cheat_Sheet.html#data-to-exclude",
+]
+
 let _EVIDENCE_PROMPT_SECRETS = [
   "https://genai.owasp.org/llmrisk/llm07-insecure-plugin-design/",
   "https://openai.com/index/prompt-injections/",
@@ -137,9 +154,9 @@ pub fn llm_call_schema_sets_schema_retries(slice, _ctx, _repo_at_base) {
   let findings = scan_if(
     slice,
     { text -> regex_match(r"llm_call\s*\(", text, "s") != nil
-    && (contains(text, "output_schema:") || contains(text, "response_schema:")
-    || contains(text, "schema:"))
-    && !contains(text, "schema_retries:") },
+      && (contains(text, "output_schema:") || contains(text, "response_schema:")
+      || contains(text, "schema:"))
+      && !contains(text, "schema_retries:") },
   )
   return block_on_findings(
     "llm_call_schema_sets_schema_retries",
@@ -199,9 +216,9 @@ pub fn schema_objects_reject_unknown_properties(slice, _ctx, _repo_at_base) {
   let findings = scan_if(
     slice,
     { text -> (contains(text, "type: \"dict\"") || contains(text, "type:\"dict\""))
-    && contains(text, "properties:")
-    && contains(text, "required:")
-    && !contains(text, "additional_properties:") },
+      && contains(text, "properties:")
+      && contains(text, "required:")
+      && !contains(text, "additional_properties:") },
   )
   return warn_on_findings(
     "schema_objects_reject_unknown_properties",
@@ -254,6 +271,37 @@ pub fn prefer_enumerate_over_index_loops(slice, _ctx, _repo_at_base) {
 }
 
 @invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_CHANNEL_IDEMPOTENCY, confidence: 0.72, source_date: "2026-05-19")
+/** Warns when durable channel emits omit a stable idempotency id. */
+pub fn emit_channel_sets_stable_id(slice, _ctx, _repo_at_base) {
+  let findings = scan_if(
+    slice,
+    { text -> regex_match(r"emit_channel\s*\(", text, "s") != nil
+      && (regex_match(r"emit_channel\s*\([^)]*,\s*\{(?:(?!\bid\s*:)[^}])*\}\s*\)", text, "s") != nil
+      || regex_match(r"emit_channel\s*\([^)]*,\s*[^,)]*\)", text, "s") != nil) },
+  )
+  return warn_on_findings(
+    "emit_channel_sets_stable_id",
+    "Pass a stable id in emit_channel opts so retries and replay dedupe the event.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_OAUTH_DYNAMIC_REGISTRATION, confidence: 0.78, source_date: "2026-05-19")
+/** Blocks obvious non-loopback HTTP redirect URIs in OAuth dynamic registration metadata. */
+pub fn oauth_redirect_uris_are_https_or_loopback(slice, _ctx, _repo_at_base) {
+  return block_on_match(
+    slice,
+    "oauth_redirect_uris_are_https_or_loopback",
+    r"redirect_uris?\s*:\s*\[[^\]]*\x22http://(?!127\.0\.0\.1|localhost|\[::1\])",
+    "Use HTTPS redirect URIs, except RFC 8252 loopback callbacks for native apps.",
+  )
+}
+
+@invariant
 @semantic
 @archivist(evidence: _EVIDENCE_PROMPT_SECRETS, confidence: 0.67, source_date: "2026-04-26")
 /** Blocks prompts that embed secrets or sensitive customer data. */
@@ -268,6 +316,23 @@ pub fn llm_prompts_do_not_embed_secrets(slice, ctx, _repo_at_base) {
     )
   }
   return allow("llm_prompts_do_not_embed_secrets")
+}
+
+@invariant
+@semantic
+@archivist(evidence: _EVIDENCE_OAUTH_REDACTION, confidence: 0.68, source_date: "2026-05-19")
+/** Blocks OAuth client secrets and tokens from audit, transcript, log, or span payloads. */
+pub fn oauth_audit_payloads_redact_tokens(slice, ctx, _repo_at_base) {
+  let rubric = "Block only when changed Harn code writes OAuth client_secret, access_token, refresh_token, device_code, or authorization code values into logs, audit events, transcripts, span attributes, errors, or channel payloads instead of redacting or recording presence/count metadata."
+  let judgement = ctx.semantic_judge({rubric: rubric, files: harn_files(slice)})
+  if judgement.verdict == "Block" {
+    return block(
+      "oauth_audit_payloads_redact_tokens",
+      "Redact OAuth credentials in observability payloads; record only presence, counts, or stable ids.",
+      judgement.findings,
+    )
+  }
+  return allow("oauth_audit_payloads_redact_tokens")
 }
 
 @invariant

--- a/scripts/validate_canon.py
+++ b/scripts/validate_canon.py
@@ -185,6 +185,14 @@ def validate_readme_coverage(errors):
             errors.append(f"README.md: missing pack link for {pack}/")
 
 
+def validate_pack_readme_coverage(pack_dir, predicate_names, errors):
+    readme_path = pack_dir / "README.md"
+    readme = readme_path.read_text(encoding="utf-8")
+    missing = sorted(name for name in predicate_names if name not in readme)
+    if missing:
+        errors.append(f"{readme_path.relative_to(ROOT)}: missing predicate coverage for {', '.join(missing)}")
+
+
 def main():
     errors = []
     expected = set(EXPECTED_PACKS)
@@ -225,6 +233,7 @@ def main():
             )
 
         validate_evidence(pack, entries, evidence_defs, errors)
+        validate_pack_readme_coverage(pack_dir, set(names), errors)
         total_predicates += len(entries)
         total_fixtures += validate_fixtures(pack_dir, set(names), errors)
 


### PR DESCRIPTION
## Summary

- add Harn canon coverage for durable channel emit idempotency, OAuth redirect URI validation, and OAuth credential redaction in observability payloads
- add fixtures for the new Harn predicates and refresh the Harn pack README evidence/false-positive notes
- tighten canon validation so each pack README must mention every predicate it ships
- polish root docs to match the current `@archivist(evidence: _EVIDENCE_*)` style and remove vague positioning copy

## Validation

- `python3 scripts/validate_canon.py`
- `harn fmt --check harn/invariants.harn`
- `python3 -m py_compile scripts/validate_canon.py`
- `git diff --check`

Note: repo-wide `harn fmt --check .` is not yet a clean gate; existing untouched packs either need formatting or hit current formatter parse limits on regex strings.
