### PR TITLE
[codex] Tighten canon predicate fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Predicate files use Harn attributes to carry evidence:
 ```harn
 let _EVIDENCE_FLOATING_PROMISES = [
   "https://typescript-eslint.io/rules/no-floating-promises/",
-  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise",
+  "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/catch",
 ]
 
 @invariant

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -36,7 +36,7 @@ Evidence scanned on 2026-05-08.
 
 ## Known False Positives
 
-- Regex predicates are intentionally conservative and file-scoped. A file containing both an offending pattern and an allowed pattern may be allowed until AST-level matching lands.
+- Regex predicates are intentionally conservative and line-oriented until AST-level matching lands.
 - `no_floating_promises` only blocks obvious async surfaces such as `fetch`, `Promise.*`, `new Promise`, or `*Async` calls until promise-aware JavaScript analysis is available.
 - `strict_equality` is source-text based and does not inspect comments, strings, or project-specific `== null` conventions.
 - `no_implicit_globals` warns on top-level function declarations even inside CommonJS modules because source text alone cannot reliably distinguish browser script execution from module execution.

--- a/javascript/fixtures/no_floating_promises.json
+++ b/javascript/fixtures/no_floating_promises.json
@@ -12,6 +12,16 @@
       ]
     },
     {
+      "name": "blocks_bare_fetch_when_file_also_handles_other_promise",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/save.js",
+          "text": "export async function save() {\n  await fetch('/api/session');\n  fetch('/api/audit', { method: 'POST' });\n}\n"
+        }
+      ]
+    },
+    {
       "name": "allows_returned_fetch",
       "expect": "Allow",
       "files": [

--- a/javascript/invariants.harn
+++ b/javascript/invariants.harn
@@ -97,23 +97,6 @@ fn scan_files(files, pattern) {
   return findings
 }
 
-fn scan_files_if(files, predicate) {
-  var findings = []
-  for file in files {
-    if predicate(file.text) {
-      findings = findings.push({path: file.path})
-    }
-  }
-  return findings
-}
-
-fn scan_files_without(files, include_pattern, exclude_pattern) {
-  return scan_files_if(
-    files,
-    { text -> regex_match(include_pattern, text, "s") != nil && regex_match(exclude_pattern, text, "s") == nil },
-  )
-}
-
 fn allow(rule) {
   return {verdict: "Allow", rule: rule, findings: [], remediation: ""}
 }
@@ -147,10 +130,9 @@ fn warn_on_findings(rule, remediation, findings) {
  * Blocks obvious Promise-returning calls that are started as bare statements without await, return, void, or catch.
  */
 pub fn no_floating_promises(slice, _ctx, _repo_at_base) {
-  let findings = scan_files_without(
+  let findings = scan_files(
     javascript_files(slice),
     r"(?m)^\s*((fetch|[A-Za-z_$][A-Za-z0-9_$]*Async|[A-Za-z_$][A-Za-z0-9_$]*\.[A-Za-z_$][A-Za-z0-9_$]*Async|Promise\.[A-Za-z_$][A-Za-z0-9_$]*)\s*\([^;\n]*\)|new\s+Promise\s*\([^;\n]*\))\s*;",
-    r"\b(await|return|void)\s+[A-Za-z_$]|\.\s*catch\s*\(",
   )
   return block_on_findings(
     "no_floating_promises",

--- a/python/fixtures/context_mgr_for_files.json
+++ b/python/fixtures/context_mgr_for_files.json
@@ -12,6 +12,16 @@
       ]
     },
     {
+      "name": "warns_module_level_open_call",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "src/bootstrap.py",
+          "text": "open(\"settings.json\", encoding=\"utf-8\").read()\n"
+        }
+      ]
+    },
+    {
       "name": "allows_with_open",
       "expect": "Allow",
       "files": [

--- a/python/fixtures/no_bare_except.json
+++ b/python/fixtures/no_bare_except.json
@@ -12,6 +12,16 @@
       ]
     },
     {
+      "name": "blocks_inline_bare_except_body",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/service.py",
+          "text": "def load_user(repo, user_id):\n    try:\n        return repo.get(user_id)\n    except: return None\n"
+        }
+      ]
+    },
+    {
       "name": "allows_specific_exception",
       "expect": "Allow",
       "files": [

--- a/python/invariants.harn
+++ b/python/invariants.harn
@@ -122,7 +122,7 @@ fn warn_on_findings(rule, remediation, findings) {
 @archivist(evidence: _EVIDENCE_BARE_EXCEPT, confidence: 0.92, source_date: "2026-04-30")
 /** Blocks bare except clauses that catch BaseException. */
 pub fn no_bare_except(slice, _ctx, _repo_at_base) {
-  let findings = scan_files(python_files(slice), r"(?m)^\s*except\s*:\s*(#.*)?$", "m")
+  let findings = scan_files(python_files(slice), r"(?m)^\s*except\s*:", "m")
   return block_on_findings(
     "no_bare_except",
     "Catch a specific exception class, or Exception if system-exiting exceptions must propagate.",
@@ -186,7 +186,7 @@ pub fn no_mutable_default_arg(slice, _ctx, _repo_at_base) {
 pub fn context_mgr_for_files(slice, _ctx, _repo_at_base) {
   let findings = scan_files(
     python_files(slice),
-    r"(?m)^(?![^\n]*\bwith\s+open\s*\()[^\n]*[^._A-Za-z0-9]open\s*\(",
+    r"(?m)^(?![^\n]*\bwith\s+open\s*\()[^\n]*(^|[^._A-Za-z0-9])open\s*\(",
     "m",
   )
   return warn_on_findings(

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -37,7 +37,7 @@ Evidence scanned on 2026-04-26.
 
 ## Known False Positives
 
-- Regex predicates are intentionally conservative and file-scoped. A file containing both an offending pattern and an allowed pattern may be allowed until AST-level matching lands.
+- Regex predicates are intentionally conservative. A few remain file-scoped where structured matching needs AST-level support.
 - `no_floating_promises` only blocks obvious async surfaces such as `fetch`, `Promise.*`, `new Promise`, or `*Async` calls until TypeScript type information is available.
 - `strict_null_checks_required` currently blocks changed `tsconfig.json` files that turn strictness off. The intended runtime form should resolve the effective tsconfig for each touched TypeScript file.
 - `exhaustive_switch` warns on non-union switches because source text alone cannot distinguish union/enumeration switches from scalar switches.

--- a/typescript/fixtures/no_floating_promises.json
+++ b/typescript/fixtures/no_floating_promises.json
@@ -12,6 +12,16 @@
       ]
     },
     {
+      "name": "blocks_bare_promise_when_file_also_awaits_other_promise",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/save.ts",
+          "text": "async function run() {\n  await saveUserAsync();\n  saveAuditAsync();\n}\n"
+        }
+      ]
+    },
+    {
       "name": "allows_awaited_promise",
       "expect": "Allow",
       "files": [

--- a/typescript/fixtures/ts_comment_suppressions_have_description.json
+++ b/typescript/fixtures/ts_comment_suppressions_have_description.json
@@ -12,6 +12,26 @@
       ]
     },
     {
+      "name": "blocks_bare_suppression_even_when_file_has_described_expect_error",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/interop.ts",
+          "text": "// @ts-expect-error: upstream package omits the overload until v3 ships\nlegacyCall(42);\n// @ts-ignore\nlegacyCall(99);\n"
+        }
+      ]
+    },
+    {
+      "name": "blocks_short_expect_error_description",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/interop.ts",
+          "text": "// @ts-expect-error: bad\nlegacyCall(42);\n"
+        }
+      ]
+    },
+    {
       "name": "allows_described_expect_error",
       "expect": "Allow",
       "files": [

--- a/typescript/invariants.harn
+++ b/typescript/invariants.harn
@@ -146,10 +146,9 @@ fn warn_on_findings(rule, remediation, findings) {
  * Blocks Promise-returning calls that are started as bare statements without await, return, void, or catch.
  */
 pub fn no_floating_promises(slice, _ctx, _repo_at_base) {
-  let findings = scan_files_without(
+  let findings = scan_files(
     typescript_files(slice),
     r"(?m)^\s*((fetch|[A-Za-z_$][A-Za-z0-9_$]*Async|[A-Za-z_$][A-Za-z0-9_$]*\.[A-Za-z_$][A-Za-z0-9_$]*Async|Promise\.[A-Za-z_$][A-Za-z0-9_$]*)\s*\([^;\n]*\)|new\s+Promise\s*\([^;\n]*\))\s*;",
-    r"\b(await|return|void)\s+[A-Za-z_$]|\.\s*catch\s*\(",
   )
   return block_on_findings(
     "no_floating_promises",
@@ -225,10 +224,9 @@ pub fn exhaustive_switch(slice, _ctx, _repo_at_base) {
 @archivist(evidence: _EVIDENCE_TS_COMMENTS, confidence: 0.84, source_date: "2026-04-26")
 /** Blocks TypeScript suppression comments that omit a meaningful description. */
 pub fn ts_comment_suppressions_have_description(slice, _ctx, _repo_at_base) {
-  let findings = scan_files_without(
+  let findings = scan_files(
     typescript_files(slice),
-    r"@ts-(ignore|expect-error|nocheck)",
-    r"@ts-(ignore|expect-error):\s*.{10,}",
+    r"(?m)@ts-ignore\b|@ts-nocheck\b|@ts-expect-error\s*(?::\s*[^\n]{0,9})?$",
   )
   return block_on_findings(
     "ts_comment_suppressions_have_description",


### PR DESCRIPTION
## Summary

- tighten Python bare-except and unmanaged-open predicates with fixtures for missed inline/module-level cases
- fix JavaScript and TypeScript floating-promise checks so handled promises elsewhere in the same file do not mask bare promise statements
- tighten TypeScript suppression-comment matching and remove dead JavaScript scan helper drift
- refresh README examples/limitations to match the current canon syntax and behavior

## Validation

- `python3 scripts/validate_canon.py`
- changed-regex fixture checks for Python, JavaScript, and TypeScript cases
- fixture JSON parse sweep
- `git diff --check`