### PR TITLE
Polish repo guidance docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# AGENTS.md
+
+This repo stores Harn canon seed predicate packs. Keep changes small, explicit,
+and evidence-backed.
+
+## Repo Shape
+
+- Each pack lives at the repo root, for example `rust/`, `typescript/`, or
+  `harn/`.
+- A pack contains `invariants.harn`, `README.md`, and `fixtures/*.json`.
+- `scripts/validate_canon.py` is the local and CI structure gate.
+- `docs/` is only an index for shared policy and design notes. Pack-specific
+  rationale belongs in the pack README.
+
+## Editing Rules
+
+- Keep `invariants.harn`, the pack README, and fixtures in lockstep. Every
+  predicate needs a matching fixture file and a README row.
+- Preserve the `@archivist(evidence: _EVIDENCE_*, confidence: ...,
+  source_date: "...")` shape.
+- Evidence constants need at least two independent URLs and a `source_date`
+  within 18 months.
+- Do not hand-wave runtime behavior. Name the current limitation and the
+  exact predicate or harness that owns it.
+- Prefer direct prose in the spirit of slopwash.com: concrete nouns, short
+  sentences, no inflated positioning, no filler summaries.
+
+## Validation
+
+- Structure and fixtures: `python3 scripts/validate_canon.py`
+- Validator syntax: `python3 -m py_compile scripts/validate_canon.py`
+- Whitespace: `git diff --check`
+- Harn formatting: run `harn fmt --check <changed .harn files>` when touching
+  Harn files. Do not treat repo-wide `harn fmt --check .` as a clean gate until
+  the existing formatter limitations are fixed.
+
+## Git
+
+- Work on an isolated branch or worktree.
+- Rebase on `origin/main` before opening a PR.
+- Keep PRs focused. One language or stack per behavior change remains the
+  default shape for predicate work.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to harn-canon
 
-Thanks for contributing seed invariants! This repo intentionally moves slowly and reviews evidence carefully — the predicates here become the *defaults* shipped to every Harn Flow user opting into a stack, so quality matters more than quantity.
+This repo reviews seed invariants carefully. These predicates become the defaults for Harn Flow projects that opt into a stack, so evidence and fixtures matter more than volume.
 
 ## Scope per PR
 
@@ -12,25 +12,34 @@ Thanks for contributing seed invariants! This repo intentionally moves slowly an
 
 Every `@archivist(...)` attribute must include:
 
-- `evidence: _EVIDENCE_*` — a pack-local evidence constant with at least two independent URLs, no older than **18 months**. Prefer official language/framework/tool docs over blogs. Dead-link check runs in CI.
-- `confidence` — `0.0..1.0`, calibrated against the predicate's false-positive rate on fixtures.
-- `source_date` — ISO date of the evidence scan.
+- `evidence: _EVIDENCE_*` - a pack-local evidence constant with at least two independent URLs, no older than **18 months**. Prefer official language/framework/tool docs over blogs.
+- `confidence` - `0.0..1.0`, calibrated against the predicate's false-positive rate on fixtures.
+- `source_date` - ISO date of the evidence scan.
 
 If you can't meet the evidence bar, file an issue instead and we'll discuss whether to accept a lower-confidence predicate behind a `warn`-only verdict.
 
 ## Style
 
-- Use the existing `harn` formatter (`harn fmt`). Pre-commit hook in this repo enforces it once the toolchain lands.
+- Use the existing `harn` formatter (`harn fmt`) on changed Harn files when the current formatter can parse them.
 - Predicate function names use `snake_case` and describe the rule, not the fix: `no_floating_promises`, not `require_await`.
-- Remediation text in `InvariantResult` must be plain English, ≤200 chars, and actionable.
+- Remediation text must be plain English, ≤200 chars, and actionable.
 
 ## Review flow
 
-All PRs go through the merge queue. Required checks: fmt, lint, evidence-link validation, fixture replay. Approvals: at least one CODEOWNERS reviewer.
+Run `python3 scripts/validate_canon.py` before opening a PR. CI runs the same validator and checks:
+
+- expected pack directories
+- root README pack links
+- predicate counts and duplicate names
+- evidence count and freshness
+- fixture shape and allow/block coverage
+- pack README coverage for every predicate
+
+Approvals come from CODEOWNERS.
 
 ## Proposing a new language / stack
 
-Open an issue with the `area/stack` label and a brief rationale (who uses it, what the killer 5 predicates would be, evidence sources you've already scoped). Get a 👍 from a maintainer before starting — this avoids overlapping drafts.
+Open an issue with the `area/stack` label and a brief rationale: who uses it, the first predicates to ship, and evidence sources already scoped. Wait for maintainer agreement before starting so drafts do not overlap.
 
 ## Licensing
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Seed **invariant** libraries for [Harn Flow](https://github.com/burin-labs/harn)
 
 ## What lives here
 
-Per-language and per-stack **starter predicate packs** that any project can opt into. Each pack is a directory containing:
+Per-language and per-stack predicate packs. Each pack is a directory containing:
 
 - `invariants.harn` — Harn functions annotated with `@invariant` and either `@deterministic` (pure, 50 ms budget) or `@semantic` (one cheap LLM judge call, 2 s budget, evidence pre-baked at authoring time).
 - `README.md` — purpose, stack assumptions, evidence sources, coverage examples, known false positives.
@@ -26,7 +26,7 @@ pub fn no_floating_promises(slice, _ctx, _repo_at_base) {
 }
 ```
 
-See the Harn Flow design docs for the full predicate language spec.
+The predicate runtime lives in the [Harn](https://github.com/burin-labs/harn) repo.
 
 ## Packs
 
@@ -67,11 +67,9 @@ See the Harn Flow design docs for the full predicate language spec.
 
 ## Status
 
-**Early - design-first.** The predicate language, `InvariantResult` type, and runtime harness are still being specified in `burin-labs/harn`. This repo exists now to:
+**Early - design-first.** All v0 seed packs are present. The runtime is still evolving in `burin-labs/harn`, so this repo keeps the pack corpus evidence-rich and fixture-backed.
 
-1. Reserve the namespace and let contributors start drafting seed predicates.
-2. Collect evidence and discussion per-language independently of the core substrate schedule.
-3. Surface a clear contribution path: pick a language, draft 5–10 deterministic + 2–3 semantic predicates, open a PR.
+Use this repo to review pack shape, evidence, and fixture coverage independently of runtime work in Harn.
 
 ## Contributing
 

--- a/c/README.md
+++ b/c/README.md
@@ -4,7 +4,7 @@ This pack covers plain C source and header files for hosted application and libr
 
 ## Stack Assumptions
 
-- C source files use `.c`; C headers use `.h`. Files containing only C++ (`.cc`, `.cpp`, `.cxx`, `.hpp`) are out of scope for this pack — see a future C++ pack for those.
+- C source files use `.c`; C headers use `.h`. Files containing only C++ (`.cc`, `.cpp`, `.cxx`, `.hpp`) are out of scope for this pack; use the C++ pack for those.
 - Production paths exclude any path under `test/`, `tests/`, `unittest/`, `unittests/`, and any file matching `*_test.c`, `*_tests.c`, or `test_main.c`.
 - Generated C files marked with a top-level `Code generated ... DO NOT EDIT` or `Auto-generated ... DO NOT EDIT` comment are ignored by deterministic source predicates.
 - Deterministic predicates use file-text regex scans because Harn Flow does not yet expose a stable C AST or preprocessor query API.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,10 +1,9 @@
 # harn-canon docs
 
-Design docs and evidence dossiers for the Harn Flow seed invariant packs.
+Shared notes for the Harn Flow seed invariant packs.
 
-- Canonical Harn Flow spec: lives in [`burin-labs/harn`](https://github.com/burin-labs/harn); the current Flow umbrella is [`burin-labs/harn#571`](https://github.com/burin-labs/harn/issues/571).
-- Predicate pack umbrella: [`burin-labs/harn-canon#1`](https://github.com/burin-labs/harn-canon/issues/1).
-- Predicate language reference: see the Flow predicate-language work tracked under the Harn Flow umbrella.
+- Predicate runtime and language work lives in [`burin-labs/harn`](https://github.com/burin-labs/harn).
 - Evidence sourcing policy: see [CONTRIBUTING.md](../CONTRIBUTING.md).
+- Repo-local agent guidance: see [AGENTS.md](../AGENTS.md).
 
 Per-language packs live in sibling directories at the repo root (e.g., `rust/`, `typescript/`, `swift/`). Each one ships its own `README.md` with pack-specific rationale.

--- a/harn/README.md
+++ b/harn/README.md
@@ -5,7 +5,7 @@ This pack covers Harn scripts, Flow workflows, and agent-facing Harn modules. It
 ## Stack Assumptions
 
 - Files use the `.harn` extension and current Harn syntax.
-- The Flow predicate runtime provides `Slice`, `Context`, `Repo`, and `ctx.semantic_judge(...)` as described by the Harn Flow umbrella.
+- The Flow predicate runtime provides `Slice`, `Context`, `Repo`, and `ctx.semantic_judge(...)` through Harn.
 - Deterministic predicates run over changed Harn source text. They prefer conservative warnings when regex matching can produce false positives.
 - Semantic predicates are strict-gate candidates only when the judge can cite a concrete changed span.
 

--- a/zig/README.md
+++ b/zig/README.md
@@ -50,7 +50,7 @@ Evidence scanned on 2026-05-10.
 ## Design Notes
 
 - `const_by_default` is omitted: the Zig compiler already emits a hard error on `var` declarations that are never reassigned. A predicate would be redundant with the toolchain.
-- `error_union_propagation` as written in the parent issue is partly handled by the compiler (which rejects calls to fallible functions whose result is discarded outside an explicit `_ = ...` slot). The remaining hand-rolled escape — `catch {}` and `catch unreachable` — is covered by `no_silent_error_swallow` and `no_catch_unreachable_in_prod`.
+- `error_union_propagation` is partly handled by the compiler, which rejects discarded fallible results outside an explicit `_ = ...` slot. The remaining hand-rolled escapes, `catch {}` and `catch unreachable`, are covered by `no_silent_error_swallow` and `no_catch_unreachable_in_prod`.
 - `build.zig.zon` predicates intentionally use `.hash`-presence as a supply-chain proxy. The Zig package manager uses the hash as the source of truth, so a missing hash is a security issue, not a style nit.
 
 ## Fixtures


### PR DESCRIPTION
## Summary

- add a concise repo-local AGENTS.md for Harn canon work
- remove stale issue pointers and inaccurate CI/review claims from docs
- tighten pack notes that referenced future or parent-issue state that is no longer current

## Validation

- python3 scripts/validate_canon.py
- python3 -m py_compile scripts/validate_canon.py
- git diff --check
- markdown heading/link/whitespace sanity scan
- external Markdown link HEAD check

No .harn files changed, so harn fmt was not applicable.