### PR TITLE
[codex] Tighten canon fixture validation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@ This repo reviews seed invariants carefully. These predicates become the default
 - **One language or stack per PR.** Don't bundle TypeScript + React + Next.js in the same change; split them.
 - **5–10 `@deterministic` predicates + 2–3 `@semantic` predicates** is the target bundle for a v0 pack. Less is fine; more should be split.
 - **Include fixtures.** Every predicate needs at least one fixture slice it blocks and one it allows. CI runs these.
+- Fixture cases need stable `snake_case` names, an `expect` value of `Allow`, `Warn`, or `Block`, and normalized relative file paths.
 
 ## Evidence bar
 

--- a/dockerfile/README.md
+++ b/dockerfile/README.md
@@ -39,10 +39,11 @@ Evidence scanned on 2026-05-09.
 ## Known False Positives
 
 - Regex predicates do not parse Dockerfiles. Inline comments, `\` line continuations across many lines, heredocs, and multi-stage `FROM ... AS build` aliases can confuse deterministic checks.
-- `no_latest_or_unpinned_base_image` allows digest pins (`@sha256:...`) and any explicit non-`latest` tag, and exempts `FROM scratch`. It does not catch `FROM --platform=$BUILDPLATFORM image` (no tag) because the leading `--platform` flag suppresses the unpinned match. Pin freshness still belongs in dependency management.
-- `apt_get_no_install_recommends` requires the `--no-install-recommends` flag on the same physical line as `apt-get install`; multi-line `RUN` blocks that put the flag on a continuation line will warn until a Dockerfile parser lands.
-- `apt_get_no_install_recommends` and `apt_get_clean_lists` are file-scoped and Debian/Ubuntu-specific. Alpine (`apk`), Red Hat (`dnf`/`microdnf`), and distroless images are not flagged; future packs should add per-distro predicates.
-- `prefer_copy_over_add` warns on every local-path `ADD`, including the legitimate "auto-extract local tarball" case. It does not warn on `ADD --chown=...` style flag forms because the leading `--` suppresses the match. Treat the warning as a prompt to confirm extraction is intended.
+- `no_latest_or_unpinned_base_image` allows digest pins (`@sha256:...`) and any explicit non-`latest` tag, and exempts `FROM scratch`. It handles common `FROM --flag=value image` forms, but full reference parsing still belongs in a Dockerfile parser. Pin freshness stays in dependency management.
+- `apt_get_no_install_recommends` checks each `RUN` instruction and allows the flag on continuation lines. Heredocs or generated shell fragments inside `RUN` can still confuse the regex until a Dockerfile parser lands.
+- `apt_get_no_install_recommends` and `apt_get_clean_lists` are Debian/Ubuntu-specific. Alpine (`apk`), Red Hat (`dnf`/`microdnf`), and distroless images are not flagged; future packs should add per-distro predicates.
+- `apt_get_clean_lists` checks that `/var/lib/apt/lists` cleanup happens in the same `RUN` instruction as `apt-get install`; it does not prove every package manager cache path was removed.
+- `prefer_copy_over_add` warns on every local-path `ADD`, including the legitimate "auto-extract local tarball" case. Common `ADD --flag=value src dest` forms are treated the same as unflagged local sources. Treat the warning as a prompt to confirm extraction is intended.
 - `non_root_user_set` cannot read base-image metadata, so it warns even when the base image (e.g., `node:*-alpine`, `nginxinc/nginx-unprivileged`) already sets a non-root `USER`. Multi-stage builds whose final stage drops privileges in a later `USER` directive are correctly allowed because the file as a whole contains a non-root `USER`. A repo-level allow can suppress this once the predicate runtime supports suppressions.
 - `no_secrets_in_env_or_arg` is keyword-based. `ARG` declarations without a default value (e.g., `ARG NPM_TOKEN`) and `ENV` values that reference shell or BuildKit substitutions (e.g., `ENV PASSWORD=$BUILD_PASSWORD`) are intentionally allowed because they expect runtime injection.
 - `use_exec_form_for_cmd_entrypoint` warns on the shell form across the file, including stages where shell expansion is genuinely required. Prefer wrapping the command in an explicit `bash -lc` exec-form invocation.
@@ -56,8 +57,8 @@ Each fixture in `fixtures/` contains one blocked or warned example and one allow
 {
   "predicate": "name",
   "cases": [
-    {"expect": "Block", "files": [{"path": "Dockerfile", "text": "..."}]},
-    {"expect": "Allow", "files": [{"path": "Dockerfile", "text": "..."}]}
+    {"name": "blocks_example", "expect": "Block", "files": [{"path": "Dockerfile", "text": "..."}]},
+    {"name": "allows_example", "expect": "Allow", "files": [{"path": "Dockerfile", "text": "..."}]}
   ]
 }
 ```

--- a/dockerfile/fixtures/apt_get_clean_lists.json
+++ b/dockerfile/fixtures/apt_get_clean_lists.json
@@ -20,6 +20,16 @@
           "text": "FROM debian:12.7-slim\nRUN apt-get update \\\n  && apt-get install -y --no-install-recommends curl ca-certificates \\\n  && rm -rf /var/lib/apt/lists/*\nUSER 1000\nCMD [\"/usr/bin/curl\", \"--version\"]\n"
         }
       ]
+    },
+    {
+      "name": "warns_when_lists_cleaned_in_later_layer",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "Dockerfile",
+          "text": "FROM debian:12.7-slim\nRUN apt-get update \\\n  && apt-get install -y --no-install-recommends curl ca-certificates\nRUN rm -rf /var/lib/apt/lists/*\nUSER 1000\nCMD [\"/usr/bin/curl\", \"--version\"]\n"
+        }
+      ]
     }
   ]
 }

--- a/dockerfile/fixtures/apt_get_no_install_recommends.json
+++ b/dockerfile/fixtures/apt_get_no_install_recommends.json
@@ -20,6 +20,16 @@
           "text": "FROM debian:12.7-slim\nRUN apt-get update \\\n  && apt-get install -y --no-install-recommends curl ca-certificates \\\n  && rm -rf /var/lib/apt/lists/*\nUSER 1000\nCMD [\"/usr/bin/curl\", \"--version\"]\n"
         }
       ]
+    },
+    {
+      "name": "allows_flag_on_continuation_line",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "Dockerfile",
+          "text": "FROM debian:12.7-slim\nRUN apt-get update \\\n  && apt-get install -y \\\n    --no-install-recommends curl ca-certificates \\\n  && rm -rf /var/lib/apt/lists/*\nUSER 1000\nCMD [\"/usr/bin/curl\", \"--version\"]\n"
+        }
+      ]
     }
   ]
 }

--- a/dockerfile/fixtures/no_latest_or_unpinned_base_image.json
+++ b/dockerfile/fixtures/no_latest_or_unpinned_base_image.json
@@ -22,6 +22,16 @@
       ]
     },
     {
+      "name": "blocks_missing_tag_with_from_flag",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "Dockerfile",
+          "text": "FROM --platform=$BUILDPLATFORM golang AS build\nWORKDIR /src\nCOPY . .\nRUN go build ./cmd/server\n"
+        }
+      ]
+    },
+    {
       "name": "allows_pinned_tag",
       "expect": "Allow",
       "files": [

--- a/dockerfile/fixtures/prefer_copy_over_add.json
+++ b/dockerfile/fixtures/prefer_copy_over_add.json
@@ -22,6 +22,16 @@
       ]
     },
     {
+      "name": "warns_on_local_path_add_with_flags",
+      "expect": "Warn",
+      "files": [
+        {
+          "path": "Dockerfile",
+          "text": "FROM python:3.12.7-slim\nRUN useradd --system --uid 1000 app\nWORKDIR /app\nADD --chown=app:app src/ /app/\nUSER app\nCMD [\"python\", \"-m\", \"app\"]\n"
+        }
+      ]
+    },
+    {
       "name": "allows_add_for_remote_url",
       "expect": "Allow",
       "files": [

--- a/dockerfile/invariants.harn
+++ b/dockerfile/invariants.harn
@@ -113,8 +113,8 @@ fn warn_on_findings(rule, remediation, findings) {
 pub fn no_latest_or_unpinned_base_image(slice, _ctx, _repo_at_base) {
   let findings = scan_files_if(
     dockerfile_files(slice),
-    { text -> regex_match(r"(?mi)^\s*FROM\s+[^\s#]+:latest(\s|$)", text, "m") != nil
-      || regex_match(r"(?mi)^\s*FROM\s+(?!--)(?!scratch\b)[^\s#:@]+(\s+AS\s+\S+)?\s*$", text, "m") != nil },
+    { text -> regex_match(r"(?mi)^\s*FROM\s+(?:--[A-Za-z0-9_-]+(?:=\S+)?\s+)*(?!--)[^\s#]+:latest(\s|$)", text, "m") != nil
+      || regex_match(r"(?mi)^\s*FROM\s+(?:--[A-Za-z0-9_-]+(?:=\S+)?\s+)*(?!--)(?!scratch\b)[^\s#:@]+(\s+AS\s+\S+)?\s*$", text, "m") != nil },
   )
   return block_on_findings(
     "no_latest_or_unpinned_base_image",
@@ -128,10 +128,9 @@ pub fn no_latest_or_unpinned_base_image(slice, _ctx, _repo_at_base) {
 @archivist(evidence: _EVIDENCE_APT_RECOMMENDS, confidence: 0.74, source_date: "2026-05-09")
 /** Warns on apt-get install invocations that omit --no-install-recommends. */
 pub fn apt_get_no_install_recommends(slice, _ctx, _repo_at_base) {
-  let findings = scan_files_if(
+  let findings = scan_files(
     dockerfile_files(slice),
-    { text -> regex_match(r"apt-get\s+install\b", text, "s") != nil
-      && regex_match(r"apt-get\s+install\b[^\n]*--no-install-recommends", text, "s") == nil },
+    r"(?ims)^\s*RUN\b(?=(?:(?!^\s*(?:ADD|ARG|CMD|COPY|ENTRYPOINT|ENV|EXPOSE|FROM|HEALTHCHECK|LABEL|ONBUILD|RUN|SHELL|STOPSIGNAL|USER|VOLUME|WORKDIR)\b).)*\bapt-get\s+install\b)(?!(?:(?!^\s*(?:ADD|ARG|CMD|COPY|ENTRYPOINT|ENV|EXPOSE|FROM|HEALTHCHECK|LABEL|ONBUILD|RUN|SHELL|STOPSIGNAL|USER|VOLUME|WORKDIR)\b).)*--no-install-recommends).+",
   )
   return warn_on_findings(
     "apt_get_no_install_recommends",
@@ -145,10 +144,9 @@ pub fn apt_get_no_install_recommends(slice, _ctx, _repo_at_base) {
 @archivist(evidence: _EVIDENCE_APT_CLEAN, confidence: 0.78, source_date: "2026-05-09")
 /** Warns when apt-get install runs without removing /var/lib/apt/lists in the same layer. */
 pub fn apt_get_clean_lists(slice, _ctx, _repo_at_base) {
-  let findings = scan_files_if(
+  let findings = scan_files(
     dockerfile_files(slice),
-    { text -> regex_match(r"apt-get\s+install\b", text, "s") != nil
-      && regex_match(r"rm\s+-rf\s+/var/lib/apt/lists", text, "s") == nil },
+    r"(?ims)^\s*RUN\b(?=(?:(?!^\s*(?:ADD|ARG|CMD|COPY|ENTRYPOINT|ENV|EXPOSE|FROM|HEALTHCHECK|LABEL|ONBUILD|RUN|SHELL|STOPSIGNAL|USER|VOLUME|WORKDIR)\b).)*\bapt-get\s+install\b)(?!(?:(?!^\s*(?:ADD|ARG|CMD|COPY|ENTRYPOINT|ENV|EXPOSE|FROM|HEALTHCHECK|LABEL|ONBUILD|RUN|SHELL|STOPSIGNAL|USER|VOLUME|WORKDIR)\b).)*\brm\s+-rf\s+/var/lib/apt/lists).+",
   )
   return warn_on_findings(
     "apt_get_clean_lists",
@@ -164,7 +162,7 @@ pub fn apt_get_clean_lists(slice, _ctx, _repo_at_base) {
 pub fn prefer_copy_over_add(slice, _ctx, _repo_at_base) {
   let findings = scan_files(
     dockerfile_files(slice),
-    r"(?mi)^\s*ADD\s+(?!--)(?!https?://)(?!git@)(?!git://)\S+",
+    r"(?mi)^\s*ADD\s+(?:--[A-Za-z0-9_-]+(?:=\S+)?\s+)*(?!--)(?!https?://)(?!git@)(?!git://)\S+",
   )
   return warn_on_findings(
     "prefer_copy_over_add",

--- a/r/fixtures/package_namespace_discipline.json
+++ b/r/fixtures/package_namespace_discipline.json
@@ -32,7 +32,7 @@
       ]
     },
     {
-      "name": "allows_importFrom_roxygen",
+      "name": "allows_import_from_roxygen",
       "expect": "Allow",
       "files": [
         {

--- a/r/fixtures/use_logical_constants.json
+++ b/r/fixtures/use_logical_constants.json
@@ -2,7 +2,7 @@
   "predicate": "use_logical_constants",
   "cases": [
     {
-      "name": "warns_on_T_as_default",
+      "name": "warns_on_t_as_default",
       "expect": "Warn",
       "files": [
         {
@@ -12,7 +12,7 @@
       ]
     },
     {
-      "name": "warns_on_F_in_comparison",
+      "name": "warns_on_f_in_comparison",
       "expect": "Warn",
       "files": [
         {
@@ -22,7 +22,7 @@
       ]
     },
     {
-      "name": "allows_TRUE_FALSE",
+      "name": "allows_true_false",
       "expect": "Allow",
       "files": [
         {

--- a/scripts/validate_canon.py
+++ b/scripts/validate_canon.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import calendar
+from collections import Counter
 import datetime as dt
 import json
 import re
@@ -50,6 +51,9 @@ MAX_DETERMINISTIC = 10
 MIN_SEMANTIC = 2
 MAX_SEMANTIC = 3
 VALID_EXPECTS = {"Allow", "Warn", "Block"}
+FIXTURE_KEYS = {"predicate", "cases"}
+CASE_KEYS = {"name", "expect", "files"}
+FILE_KEYS = {"path", "text"}
 
 INVARIANT_RE = re.compile(
     r"@invariant\s*"
@@ -64,6 +68,7 @@ INVARIANT_RE = re.compile(
 )
 EVIDENCE_RE = re.compile(r"let\s+(_EVIDENCE_[A-Za-z0-9_]+)\s*=\s*\[(.*?)\]", re.S)
 URL_RE = re.compile(r'"(https?://[^"]+)"')
+FIXTURE_CASE_NAME_RE = re.compile(r"[a-z][a-z0-9_]*\Z")
 
 
 def shifted_months(day, months):
@@ -72,6 +77,25 @@ def shifted_months(day, months):
     month = zero_based_month + 1
     capped_day = min(day.day, calendar.monthrange(year, month)[1])
     return dt.date(year, month, capped_day)
+
+
+def duplicate_values(values):
+    return sorted(value for value, count in Counter(values).items() if count > 1)
+
+
+def validate_allowed_keys(rel_path, location, value, allowed, errors):
+    unknown = sorted(set(value) - allowed)
+    if unknown:
+        errors.append(f"{rel_path}: {location} has unknown keys: {', '.join(unknown)}")
+
+
+def is_normalized_relative_path(value):
+    parts = value.split("/")
+    return (
+        not value.startswith("/")
+        and "\\" not in value
+        and all(part not in {"", ".", ".."} for part in parts)
+    )
 
 
 def parse_invariants(path, errors):
@@ -143,6 +167,10 @@ def validate_fixtures(pack_dir, predicate_names, errors):
             errors.append(f"{rel_path}: invalid JSON: {exc}")
             continue
 
+        if not isinstance(fixture, dict):
+            errors.append(f"{rel_path}: fixture must be an object")
+            continue
+
         if fixture.get("predicate") != fixture_path.stem:
             errors.append(f"{rel_path}: predicate must match fixture file name")
 
@@ -150,9 +178,24 @@ def validate_fixtures(pack_dir, predicate_names, errors):
         if not isinstance(cases, list) or not cases:
             errors.append(f"{rel_path}: cases must be a non-empty list")
             continue
+        validate_allowed_keys(rel_path, "fixture", fixture, FIXTURE_KEYS, errors)
 
         expects = set()
+        case_names = []
         for index, case in enumerate(cases):
+            if not isinstance(case, dict):
+                errors.append(f"{rel_path}: case {index} must be an object")
+                continue
+            validate_allowed_keys(rel_path, f"case {index}", case, CASE_KEYS, errors)
+
+            case_name = case.get("name")
+            if not isinstance(case_name, str) or not case_name:
+                errors.append(f"{rel_path}: case {index} needs a name")
+            elif FIXTURE_CASE_NAME_RE.fullmatch(case_name) is None:
+                errors.append(f"{rel_path}: case {index} name must be snake_case")
+            else:
+                case_names.append(case_name)
+
             expect = case.get("expect")
             if expect not in VALID_EXPECTS:
                 errors.append(f"{rel_path}: case {index} has invalid expect {expect!r}")
@@ -165,10 +208,30 @@ def validate_fixtures(pack_dir, predicate_names, errors):
                 continue
 
             for file_index, file_fixture in enumerate(files):
-                if not isinstance(file_fixture.get("path"), str) or not file_fixture["path"]:
+                if not isinstance(file_fixture, dict):
+                    errors.append(f"{rel_path}: case {index} file {file_index} must be an object")
+                    continue
+                validate_allowed_keys(
+                    rel_path,
+                    f"case {index} file {file_index}",
+                    file_fixture,
+                    FILE_KEYS,
+                    errors,
+                )
+
+                file_path = file_fixture.get("path")
+                if not isinstance(file_path, str) or not file_path:
                     errors.append(f"{rel_path}: case {index} file {file_index} needs a path")
+                elif not is_normalized_relative_path(file_path):
+                    errors.append(
+                        f"{rel_path}: case {index} file {file_index} path must be normalized and relative"
+                    )
                 if not isinstance(file_fixture.get("text"), str):
                     errors.append(f"{rel_path}: case {index} file {file_index} needs text")
+
+        duplicate_case_names = duplicate_values(case_names)
+        if duplicate_case_names:
+            errors.append(f"{rel_path}: duplicate case names: {', '.join(duplicate_case_names)}")
 
         if "Allow" not in expects:
             errors.append(f"{rel_path}: fixture must include at least one Allow case")
@@ -217,7 +280,7 @@ def main():
 
         entries, evidence_defs = parse_invariants(invariants_path, errors)
         names = [entry["name"] for entry in entries]
-        duplicate_names = sorted({name for name in names if names.count(name) > 1})
+        duplicate_names = duplicate_values(names)
         if duplicate_names:
             errors.append(f"{pack}: duplicate predicate names: {', '.join(duplicate_names)}")
 


### PR DESCRIPTION
## Summary
- tighten Dockerfile predicates for flagged FROM/ADD forms and RUN-scoped apt install checks
- add fixtures for missed Dockerfile edge cases and normalize R fixture case names
- harden canon fixture validation for object shape, duplicate case names, unknown keys, and normalized relative paths

## Root Cause
Some Dockerfile regexes treated optional instruction flags as source/image tokens or reasoned at file/line scope instead of per RUN instruction. The canon validator also trusted fixture object shapes and did not enforce stable case names or normalized paths.

## Verification
- python3 scripts/validate_canon.py
- targeted Dockerfile regex replay against deterministic fixture cases
- validator negative-path checks with a temporary malformed pack
