### PR TITLE
Enforce trust model on contributed predicate packs

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,54 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Email **security@burinlabs.com** with the details. Encrypt with our public key
+if the report contains exploit material (key available on request).
+
+Please include:
+
+- a clear description of the issue and the impact (e.g. a malicious
+  predicate that survived review and ships in a pack, a CI bypass, a
+  validator gap that lets an unsafe predicate land)
+- a minimal reproduction (offending Harn snippet, PR that should have been
+  rejected, etc.)
+- any affected pack or predicate
+- whether the issue has been disclosed publicly or to other parties
+
+## Response window
+
+We aim to:
+
+- acknowledge new reports within **2 business days**
+- triage and confirm (or dispute) within **5 business days**
+- ship a fix or mitigation within **30 days** for confirmed issues, faster
+  for actively-exploited supply-chain bugs (e.g. a malicious predicate in a
+  shipped pack)
+
+## Scope
+
+In scope:
+
+- every `invariants.harn` predicate pack and its fixtures
+- the validator (`scripts/validate_canon.py`)
+- CI gates that enforce the trust model (see `CONTRIBUTING.md`)
+- the side-effect builtin ban and any way to bypass it
+
+Out of scope (report upstream):
+
+- vulnerabilities in `harn` itself ->
+  https://github.com/burin-labs/harn/security/policy
+- predicate false positives or false negatives that don't violate the trust
+  model -- file these as regular issues
+
+## Trust model recap
+
+Predicate packs are **trusted code** that runs on consumer machines when
+`harn lint` evaluates them. PRs are reviewed accordingly; predicates may
+not call side-effect builtins. See `CONTRIBUTING.md` for the full list.
+
+## Coordinated disclosure
+
+We support coordinated disclosure. Please give us the response window above
+before publishing details. We will credit reporters in the release notes for
+the fix unless asked otherwise.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
   merge_group:
 
+permissions:
+  contents: read
+
 jobs:
   canon-validation:
     name: Canon structure and fixture validation
@@ -14,6 +17,97 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Validate canon packs
         run: python3 scripts/validate_canon.py
+
+      - name: Reject side-effect builtins in predicates
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Predicate packs are TRUSTED CODE executed on consumer machines by
+          # `harn lint`. PRs may not introduce calls to side-effect builtins.
+          # See CONTRIBUTING.md "Trust model" for the rationale and the full
+          # forbidden list. The pattern requires `<name>\s*\(` so regex
+          # literals that just mention these names (e.g. the parallel-io
+          # predicate's own scan_without regex) are not false-positives.
+          if grep -nrE '\b(command_json|http_get|http_post|process_exec|secret_get|store_set|store_get)\s*\(' --include='*.harn' .; then
+            echo "::error::Predicate packs may not call side-effect builtins. See CONTRIBUTING.md \"Trust model\"." >&2
+            exit 1
+          fi
+          echo "No side-effect builtin calls in predicate packs."
+
+      - name: Install pinned Harn
+        shell: bash
+        env:
+          HARN_VERSION: "0.8.34"
+        run: |
+          set -euo pipefail
+          target="x86_64-unknown-linux-gnu"
+          tag="v${HARN_VERSION}"
+          asset_name="harn-${target}.tar.gz"
+          asset_url="https://github.com/burin-labs/harn/releases/download/${tag}/${asset_name}"
+          sums_url="https://github.com/burin-labs/harn/releases/download/${tag}/SHA256SUMS"
+          tmpdir="$(mktemp -d)"
+          curl -fsSL "${asset_url}" -o "${tmpdir}/harn.tar.gz"
+          curl -fsSL "${sums_url}" -o "${tmpdir}/SHA256SUMS"
+          expected_sum="$(awk -v name="${asset_name}" '$2 == name { print $1 }' "${tmpdir}/SHA256SUMS")"
+          if [ -z "${expected_sum}" ]; then
+            echo "::error::${asset_name} not listed in SHA256SUMS for ${tag}" >&2
+            exit 1
+          fi
+          actual_sum="$(sha256sum "${tmpdir}/harn.tar.gz" | awk '{ print $1 }')"
+          if [ "${actual_sum}" != "${expected_sum}" ]; then
+            echo "::error::sha256 mismatch for ${asset_name}: expected ${expected_sum}, got ${actual_sum}" >&2
+            exit 1
+          fi
+          tar -xzf "${tmpdir}/harn.tar.gz" -C "${tmpdir}"
+          mkdir -p "${HOME}/.local/bin"
+          install -m 755 "${tmpdir}/harn" "${HOME}/.local/bin/harn"
+          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+
+      - name: Harn check + lint predicate packs
+        shell: bash
+        run: |
+          set -euo pipefail
+          harn --version
+          # Known pre-existing parse failures (raw-string `\"` / `r'...'`
+          # syntax). These predicate packs ship today via validate_canon (a
+          # text-regex pass, not the Harn parser) but never actually parse.
+          # Tracked as a follow-up fix; until then we allow these files to
+          # fail so the new gate can land and catch *new* PRs that introduce
+          # unlintable Harn code. Remove entries as files are fixed; the
+          # eventual goal is an empty skip list.
+          declare -A KNOWN_BROKEN=(
+            ["./protobuf/invariants.harn"]=1
+            ["./terraform/invariants.harn"]=1
+            ["./zig/invariants.harn"]=1
+            ["./html/invariants.harn"]=1
+            ["./lua/invariants.harn"]=1
+            ["./xml/invariants.harn"]=1
+            ["./graphql/invariants.harn"]=1
+          )
+          failed=0
+          while IFS= read -r -d '' invariants; do
+            echo "==> ${invariants}"
+            check_ok=1
+            lint_ok=1
+            harn check "${invariants}" || check_ok=0
+            harn lint "${invariants}" || lint_ok=0
+            if [ "${check_ok}" -eq 0 ] || [ "${lint_ok}" -eq 0 ]; then
+              if [ -n "${KNOWN_BROKEN[${invariants}]:-}" ]; then
+                echo "::warning file=${invariants}::known pre-existing parse failure; tracked for follow-up"
+              else
+                if [ "${check_ok}" -eq 0 ]; then
+                  echo "::error file=${invariants}::harn check failed" >&2
+                fi
+                if [ "${lint_ok}" -eq 0 ]; then
+                  echo "::error file=${invariants}::harn lint failed" >&2
+                fi
+                failed=1
+              fi
+            fi
+          done < <(find . -name 'invariants.harn' -type f -not -path './.git/*' -print0)
+          if [ "${failed}" -ne 0 ]; then
+            exit 1
+          fi
 
   ci-status:
     name: CI status

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,37 @@ If you can't meet the evidence bar, file an issue instead and we'll discuss whet
 - Predicate function names use `snake_case` and describe the rule, not the fix: `no_floating_promises`, not `require_await`.
 - Remediation text must be plain English, ≤200 chars, and actionable.
 
+## Trust model
+
+**Predicate packs in this repo are trusted code that runs on consumer machines.**
+
+When a downstream project runs `harn lint`, every predicate in the pack it
+imports executes inside the linter. A malicious predicate can do anything
+Harn can do — exfiltrate environment, write files, spawn processes, hit the
+network. So PRs here are reviewed with that blast radius in mind.
+
+Hard rules:
+
+- Predicates may **not** call any side-effect builtin:
+  `command_json`, `http_get`, `http_post`, `process_exec`, `secret_get`,
+  `store_set`, `store_get`. CI greps for these and rejects PRs that
+  introduce calls to them. (Mentioning the name inside a regex literal
+  is fine — the grep requires a `(` after the name to catch only calls.)
+- Predicates **should** be pure functions of the slice they receive: they
+  pattern-match Harn source text and emit verdicts. No file I/O, no clock,
+  no env access.
+- `parallel each` / `parallel settle` is allowed inside meta-predicates that
+  describe these patterns in their `scan_without` regex, but the predicate
+  itself must not perform IO at the top level.
+- If you genuinely need to read a config file or a workspace setting,
+  propose a typed `ctx` extension in a separate PR against
+  [`burin-labs/harn`](https://github.com/burin-labs/harn) rather than
+  side-stepping the rule here.
+
+CI enforces the side-effect ban on every `*.harn` file in the repo. It also
+runs `harn check` and `harn lint` on every `invariants.harn` so PRs that
+add syntactically-malicious or unlintable Harn code fail before merge.
+
 ## Review flow
 
 Run `python3 scripts/validate_canon.py` before opening a PR. CI runs the same validator and checks:
@@ -35,6 +66,8 @@ Run `python3 scripts/validate_canon.py` before opening a PR. CI runs the same va
 - evidence count and freshness
 - fixture shape and allow/block coverage
 - pack README coverage for every predicate
+- side-effect builtin ban (see "Trust model" above)
+- `harn check` + `harn lint` pass on each `invariants.harn`
 
 Approvals come from CODEOWNERS.
 


### PR DESCRIPTION
## Summary

Three layered controls so a malicious or buggy predicate can't ship to consumers via this repo. From `/tmp/harn-security-sweep/findings/06-release-supply-chain.md`:

- **F6 (HIGH) -- side-effect builtin ban.** CI greps every `*.harn` file for calls to `command_json`, `http_get`, `http_post`, `process_exec`, `secret_get`, `store_set`, `store_get`. The pattern requires `<name>\s*\(` so regex literals that just *mention* these names (e.g. `parallel_io_sets_max_concurrent`'s own regex) are not false-positives. PRs that try to slip an IO call into a predicate body fail before merge.
- **F6 (HIGH) -- `harn check` + `harn lint` on every `invariants.harn`.** Installs the same pinned Harn release the rest of the org uses (sha256-verified against `SHA256SUMS`) and runs both static gates on every pack. 7 pre-existing files have raw-string regex bugs that never actually parsed (validate_canon.py only does a Python regex pass, not the Harn parser); these are allowlisted via `KNOWN_BROKEN` and tracked in #77. Drop entries as packs are fixed; goal is an empty allowlist.
- **F6 (HIGH) -- Trust model in `CONTRIBUTING.md`.** New section explains that predicate packs are trusted code executed on consumer machines, what side-effect builtins are forbidden, and how the CI gate works.
- **F15 (LOW) -- `.github/SECURITY.md`** documents disclosure channel.

## Deferred

- **F16** (CODEOWNERS bus factor 1) -- maintainer call when contributors join; flagged in the security-sweep return summary
- **F3** (org-level signed commits) -- org-wide, gh api action by maintainer

## Test plan

- [x] `python3 scripts/validate_canon.py` still passes (`Validated 34 packs, 331 predicates, and 331 fixtures`)
- [x] Side-effect grep returns empty on current `.harn` files
- [x] Local `harn check` + `harn lint` succeed on each of the 27 packs that are not in `KNOWN_BROKEN`
- [ ] CI run on this PR -- new install + check + lint steps must succeed