### PR TITLE
[codex] Fix raw regex strings in predicate packs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,22 +68,6 @@ jobs:
         run: |
           set -euo pipefail
           harn --version
-          # Known pre-existing parse failures (raw-string `\"` / `r'...'`
-          # syntax). These predicate packs ship today via validate_canon (a
-          # text-regex pass, not the Harn parser) but never actually parse.
-          # Tracked as a follow-up fix; until then we allow these files to
-          # fail so the new gate can land and catch *new* PRs that introduce
-          # unlintable Harn code. Remove entries as files are fixed; the
-          # eventual goal is an empty skip list.
-          declare -A KNOWN_BROKEN=(
-            ["./protobuf/invariants.harn"]=1
-            ["./terraform/invariants.harn"]=1
-            ["./zig/invariants.harn"]=1
-            ["./html/invariants.harn"]=1
-            ["./lua/invariants.harn"]=1
-            ["./xml/invariants.harn"]=1
-            ["./graphql/invariants.harn"]=1
-          )
           failed=0
           while IFS= read -r -d '' invariants; do
             echo "==> ${invariants}"
@@ -92,17 +76,13 @@ jobs:
             harn check "${invariants}" || check_ok=0
             harn lint "${invariants}" || lint_ok=0
             if [ "${check_ok}" -eq 0 ] || [ "${lint_ok}" -eq 0 ]; then
-              if [ -n "${KNOWN_BROKEN[${invariants}]:-}" ]; then
-                echo "::warning file=${invariants}::known pre-existing parse failure; tracked for follow-up"
-              else
-                if [ "${check_ok}" -eq 0 ]; then
-                  echo "::error file=${invariants}::harn check failed" >&2
-                fi
-                if [ "${lint_ok}" -eq 0 ]; then
-                  echo "::error file=${invariants}::harn lint failed" >&2
-                fi
-                failed=1
+              if [ "${check_ok}" -eq 0 ]; then
+                echo "::error file=${invariants}::harn check failed" >&2
               fi
+              if [ "${lint_ok}" -eq 0 ]; then
+                echo "::error file=${invariants}::harn lint failed" >&2
+              fi
+              failed=1
             fi
           done < <(find . -name 'invariants.harn' -type f -not -path './.git/*' -print0)
           if [ "${failed}" -ne 0 ]; then

--- a/graphql/invariants.harn
+++ b/graphql/invariants.harn
@@ -164,7 +164,7 @@ pub fn descriptions_on_public_types(slice, _ctx, _repo_at_base) {
       "m",
     )
       != nil
-      && regex_match(r"\"\"\"|^\s*\"[^\"]+\"", file.text, "m") == nil },
+      && regex_match("\"\"\"|^\\s*\"[^\"]+\"", file.text, "m") == nil },
   )
   return warn_on_findings(
     "descriptions_on_public_types",

--- a/html/invariants.harn
+++ b/html/invariants.harn
@@ -145,7 +145,7 @@ pub fn documents_specify_lang(slice, _ctx, _repo_at_base) {
 pub fn no_inline_event_handlers(slice, _ctx, _repo_at_base) {
   let findings = scan_files(
     html_files(slice),
-    r"(?i)<[a-z][a-z0-9-]*\b[^>]*\son[a-z]+\s*=\s*[\"']",
+    "(?i)<[a-z][a-z0-9-]*\\b[^>]*\\son[a-z]+\\s*=\\s*[\"']",
     "s",
   )
   return block_on_findings(
@@ -162,7 +162,7 @@ pub fn no_inline_event_handlers(slice, _ctx, _repo_at_base) {
 pub fn no_inline_styles(slice, _ctx, _repo_at_base) {
   let findings = scan_files(
     html_files(slice),
-    r"(?i)<[a-z][a-z0-9-]*\b[^>]*\sstyle\s*=\s*[\"']",
+    "(?i)<[a-z][a-z0-9-]*\\b[^>]*\\sstyle\\s*=\\s*[\"']",
     "s",
   )
   return warn_on_findings(
@@ -179,7 +179,7 @@ pub fn no_inline_styles(slice, _ctx, _repo_at_base) {
 pub fn prefer_semantic_landmarks(slice, _ctx, _repo_at_base) {
   let findings = scan_files(
     html_files(slice),
-    r"(?i)<div\b[^>]*\b(?:class|id)\s*=\s*[\"'][^\"']*\b(?:nav|navbar|navigation|header|main-?content|main|footer|sidebar|article|aside)\b[^\"']*[\"']",
+    "(?i)<div\\b[^>]*\\b(?:class|id)\\s*=\\s*[\"'][^\"']*\\b(?:nav|navbar|navigation|header|main-?content|main|footer|sidebar|article|aside)\\b[^\"']*[\"']",
     "s",
   )
   return warn_on_findings(
@@ -196,7 +196,7 @@ pub fn prefer_semantic_landmarks(slice, _ctx, _repo_at_base) {
 pub fn target_blank_uses_rel_noopener(slice, _ctx, _repo_at_base) {
   let findings = scan_files(
     html_files(slice),
-    r"(?i)<a\b(?![^>]*\brel\s*=\s*[\"'][^\"']*\b(?:noopener|noreferrer)\b)[^>]*\btarget\s*=\s*[\"']?_blank[\"']?",
+    "(?i)<a\\b(?![^>]*\\brel\\s*=\\s*[\"'][^\"']*\\b(?:noopener|noreferrer)\\b)[^>]*\\btarget\\s*=\\s*[\"']?_blank[\"']?",
     "s",
   )
   return block_on_findings(

--- a/lua/invariants.harn
+++ b/lua/invariants.harn
@@ -186,7 +186,7 @@ pub fn no_loadstring_or_loadfile(slice, _ctx, _repo_at_base) {
   let findings = scan_files_without(
     lua_files(slice),
     r"(?m)(^|[^A-Za-z0-9_.:])(loadstring|load|loadfile|dofile)\s*\(",
-    r"(?m)(^|[^A-Za-z0-9_.:])(loadstring|load|loadfile|dofile)\s*\(\s*(['\"]|\[\[|\[=)",
+    "(?m)(^|[^A-Za-z0-9_.:])(loadstring|load|loadfile|dofile)\\s*\\(\\s*(['\"]|\\[\\[|\\[=)",
   )
   return block_on_findings(
     "no_loadstring_or_loadfile",
@@ -220,7 +220,7 @@ pub fn no_unsafe_os_command(slice, _ctx, _repo_at_base) {
   let findings = scan_files_without(
     lua_files(slice),
     r"\b(os\.execute|io\.popen)\s*\(",
-    r"\b(os\.execute|io\.popen)\s*\(\s*(['\"]|\[\[|\[=)",
+    "\\b(os\\.execute|io\\.popen)\\s*\\(\\s*(['\"]|\\[\\[|\\[=)",
   )
   return block_on_findings(
     "no_unsafe_os_command",
@@ -252,7 +252,7 @@ pub fn module_returns_value(slice, _ctx, _repo_at_base) {
 pub fn require_assigned_to_local(slice, _ctx, _repo_at_base) {
   let findings = scan_files(
     production_lua_files(slice),
-    r"(?m)^[ \t]*require\s*[\(\"'\[]",
+    "(?m)^[ \\t]*require\\s*[\\(\"'\\[]",
     "m",
   )
   return warn_on_findings(

--- a/protobuf/invariants.harn
+++ b/protobuf/invariants.harn
@@ -118,8 +118,8 @@ fn warn_on_findings(rule, remediation, findings) {
 pub fn explicit_syntax_version(slice, _ctx, _repo_at_base) {
   let findings = scan_files_if(
     first_party_proto_files(slice),
-    { file -> regex_match(r"(?m)^\s*syntax\s*=\s*\"proto[23]\"\s*;", file.text, "m") == nil
-      && regex_match(r"(?m)^\s*edition\s*=\s*\"\d{4}\"\s*;", file.text, "m") == nil },
+    { file -> regex_match("(?m)^\\s*syntax\\s*=\\s*\"proto[23]\"\\s*;", file.text, "m") == nil
+      && regex_match("(?m)^\\s*edition\\s*=\\s*\"\\d{4}\"\\s*;", file.text, "m") == nil },
   )
   return block_on_findings(
     "explicit_syntax_version",
@@ -151,7 +151,7 @@ pub fn package_declaration_required(slice, _ctx, _repo_at_base) {
 pub fn no_required_in_proto3(slice, _ctx, _repo_at_base) {
   let findings = scan_files_if(
     first_party_proto_files(slice),
-    { file -> regex_match(r"(?m)^\s*syntax\s*=\s*\"proto3\"\s*;", file.text, "m") != nil
+    { file -> regex_match("(?m)^\\s*syntax\\s*=\\s*\"proto3\"\\s*;", file.text, "m") != nil
       && regex_match(r"(?m)^\s*required\s+[A-Za-z_][A-Za-z0-9_.]*\s+[A-Za-z_][A-Za-z0-9_]*\s*=\s*\d+", file.text, "m")
       != nil },
   )

--- a/terraform/invariants.harn
+++ b/terraform/invariants.harn
@@ -118,7 +118,7 @@ fn warn_on_findings(rule, remediation, findings) {
 pub fn required_tags_on_resources(slice, _ctx, _repo_at_base) {
   let findings = scan_files_if(
     production_tf_files(slice),
-    { text -> regex_match(r'(?m)^\s*resource\s+"(aws_|azurerm_|google_)', text, "m") != nil
+    { text -> regex_match("(?m)^\\s*resource\\s+\"(aws_|azurerm_|google_)", text, "m") != nil
       && (regex_match(r"(?i)\bowner\b", text, "s") == nil
       || regex_match(r"(?i)\b(env|environment)\b", text, "s") == nil
       || regex_match(r"(?i)\b(costcenter|cost[_-]?center)\b", text, "s") == nil) },
@@ -137,7 +137,7 @@ pub fn required_tags_on_resources(slice, _ctx, _repo_at_base) {
 pub fn variable_type_constraints_explicit(slice, _ctx, _repo_at_base) {
   let findings = scan_files_if(
     production_tf_files(slice),
-    { text -> regex_match(r'(?m)^\s*variable\s+"[^"]+"\s*\{', text, "m") != nil
+    { text -> regex_match("(?m)^\\s*variable\\s+\"[^\"]+\"\\s*\\{", text, "m") != nil
       && regex_match(r"(?m)^\s*type\s*=", text, "m") == nil },
   )
   return warn_on_findings(
@@ -156,7 +156,7 @@ pub fn remote_state_backend_configured(slice, _ctx, _repo_at_base) {
   for file in production_tf_files(slice) {
     if !contains(file.path, "/modules/")
       && regex_match(r"required_providers\s*\{", file.text, "s") != nil
-      && regex_match(r'(?m)^\s*backend\s+"[^"]+"\s*\{', file.text, "m") == nil {
+      && regex_match("(?m)^\\s*backend\\s+\"[^\"]+\"\\s*\\{", file.text, "m") == nil {
       findings = findings.push({path: file.path})
     }
   }
@@ -174,11 +174,11 @@ pub fn remote_state_backend_configured(slice, _ctx, _repo_at_base) {
 pub fn module_registry_version_pinned(slice, _ctx, _repo_at_base) {
   let findings = scan_files_if(
     production_tf_files(slice),
-    { text -> regex_match(r'(?m)^\s*module\s+"[^"]+"\s*\{', text, "m") != nil
-      && regex_match(r'source\s*=\s*"[A-Za-z0-9_-][A-Za-z0-9_.-]*(?:/[A-Za-z0-9_.-]+){2,3}"', text, "s")
+    { text -> regex_match("(?m)^\\s*module\\s+\"[^\"]+\"\\s*\\{", text, "m") != nil
+      && regex_match("source\\s*=\\s*\"[A-Za-z0-9_-][A-Za-z0-9_.-]*(?:/[A-Za-z0-9_.-]+){2,3}\"", text, "s")
       != nil
       && regex_match(
-      r'source\s*=\s*"(?:\./|\.\./|git::|s3::|gcs::|hg::|github\.com/|bitbucket\.org/|gitlab\.com/|https?://)',
+      "source\\s*=\\s*\"(?:\\./|\\.\\./|git::|s3::|gcs::|hg::|github\\.com/|bitbucket\\.org/|gitlab\\.com/|https?://)",
       text,
       "s",
     )
@@ -217,7 +217,7 @@ pub fn outputs_with_secret_names_marked_sensitive(slice, _ctx, _repo_at_base) {
   let findings = scan_files_if(
     production_tf_files(slice),
     { text -> regex_match(
-      r'(?im)^\s*output\s+"[A-Za-z0-9_-]*(?:password|secret|token|api[_-]?key|private[_-]?key|credential)[A-Za-z0-9_-]*"\s*\{',
+      "(?im)^\\s*output\\s+\"[A-Za-z0-9_-]*(?:password|secret|token|api[_-]?key|private[_-]?key|credential)[A-Za-z0-9_-]*\"\\s*\\{",
       text,
       "m",
     )

--- a/xml/invariants.harn
+++ b/xml/invariants.harn
@@ -155,7 +155,7 @@ pub fn no_external_entity_references(slice, _ctx, _repo_at_base) {
 pub fn xml_declares_utf8(slice, _ctx, _repo_at_base) {
   let findings = scan_files_if(
     xml_files(slice),
-    { file -> regex_match(r"^\s*<\?xml\b[^?]*encoding\s*=\s*[\"']utf-8[\"'][^?]*\?>", file.text, "is")
+    { file -> regex_match("^\\s*<\\?xml\\b[^?]*encoding\\s*=\\s*[\"']utf-8[\"'][^?]*\\?>", file.text, "is")
       == nil },
   )
   return warn_on_findings(
@@ -207,7 +207,7 @@ pub fn xsd_has_target_namespace(slice, _ctx, _repo_at_base) {
 pub fn xslt_no_external_documents(slice, _ctx, _repo_at_base) {
   let findings = scan_files(
     xslt_files(slice),
-    r"<\s*xsl:(include|import)\b[^>]*\bhref\s*=\s*[\"'](https?|ftp|file)://|\bdocument\s*\(\s*[\"'](https?|ftp|file)://",
+    "<\\s*xsl:(include|import)\\b[^>]*\\bhref\\s*=\\s*[\"'](https?|ftp|file)://|\\bdocument\\s*\\(\\s*[\"'](https?|ftp|file)://",
     "is",
   )
   return block_on_findings(

--- a/zig/invariants.harn
+++ b/zig/invariants.harn
@@ -232,7 +232,7 @@ pub fn build_zon_min_zig_version_set(slice, _ctx, _repo_at_base) {
 pub fn build_zon_dependency_hash_pinned(slice, _ctx, _repo_at_base) {
   let findings = scan_files(
     build_zon_files(slice),
-    r'\.\{(?:(?!\.hash)[^{}])*\.url\s*=\s*"[^"]+"(?:(?!\.hash)[^{}])*\}',
+    "\\.\\{(?:(?!\\.hash)[^{}])*\\.url\\s*=\\s*\"[^\"]+\"(?:(?!\\.hash)[^{}])*\\}",
   )
   return block_on_findings(
     "build_zon_dependency_hash_pinned",


### PR DESCRIPTION
## Summary

- Convert the broken raw-string regex literals in the seven issue #77 predicate packs to parser-valid normal Harn strings.
- Remove the `KNOWN_BROKEN` parser/linter allowlist from CI so unparseable packs fail directly.

## Root Cause

The affected packs used `r"..."` raw strings containing `\"` or unsupported `r'...'` literals. Harn raw strings are delimited only by `r"..."`, so those forms either closed early or never lexed as raw strings.

## Validation

- `python3 scripts/validate_canon.py`
- `python3 -m py_compile scripts/validate_canon.py`
- `git diff --check`
- Side-effect builtin grep from CI
- `harn check` and `harn lint` for the seven fixed pack files using local Harn 0.8.39
- Full `harn check` + `harn lint` sweep over every `invariants.harn` using local Harn 0.8.39
- Full `harn check` + `harn lint` sweep over every `invariants.harn` using pinned Harn 0.8.34, matching CI

Fixes #77.
