### PR TITLE
ci: run canon checks on Harn 0.8.43

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install pinned Harn
         shell: bash
         env:
-          HARN_VERSION: "0.8.34"
+          HARN_VERSION: "0.8.43"
         run: |
           set -euo pipefail
           target="x86_64-unknown-linux-gnu"


### PR DESCRIPTION
## Summary
- update harn-canon CI to install Harn 0.8.43, matching the current downstream fleet pin

## Verification
- python3 scripts/validate_canon.py
- python3 -m py_compile scripts/validate_canon.py
- actionlint .github/workflows/*.yml
- git diff --check
- for each canon pack: harn check invariants.harn and harn lint invariants.harn