### PR TITLE
Add Zig 0.16 canon predicates

### DIFF
--- a/zig/README.md
+++ b/zig/README.md
@@ -1,10 +1,10 @@
 # Zig Seed Predicate Pack
 
-This pack covers Zig source (`.zig`) and the `build.zig.zon` package manifest. Zig is a young, rapidly evolving language; v0 focuses on the highest-signal review issues that survive across the recent stable releases (0.13.x and 0.14.x): silent error-handling shortcuts, unjustified unsafe casts, `@panic` in library paths, test-time leak detection, and supply-chain hygiene in the package manifest.
+This pack covers Zig source (`.zig`) and the `build.zig.zon` package manifest. Zig is a young, rapidly evolving language; v0 focuses on the highest-signal review issues that survive across the recent stable releases and current 0.16 toolchains: silent error-handling shortcuts, stale standard-library API shapes, unjustified unsafe casts, `@panic` in library paths, test-time leak detection, and supply-chain hygiene in the package manifest.
 
 ## Stack Assumptions
 
-- Source predicates target Zig 0.13.x and 0.14.x. Older releases predate `build.zig.zon` and the modern cast/error builtins; the predicates here are not expected to be useful below 0.12.
+- Source predicates target Zig 0.15.x and 0.16.x. Older releases predate `build.zig.zon` and the modern cast/error/container APIs; the predicates here are not expected to be useful below 0.12.
 - Production paths exclude `_test.zig` and `test_*.zig` files plus `tests/`, `test/`, `testdata/`, `examples/`, and `example/` directories. Test-block heuristics rely on the convention that test declarations appear at the top level of a file.
 - `build.zig.zon` predicates filter on the literal filename. Generated lock files and vendored caches are not in scope for v0.
 - Deterministic predicates operate on changed source text. Zig has no published stable AST query API yet, so regex-based matching is intentionally conservative — the pack errs toward false negatives rather than false positives.
@@ -21,6 +21,9 @@ This pack covers Zig source (`.zig`) and the `build.zig.zon` package manifest. Z
 | `tests_use_testing_allocator` | deterministic | Warn | Test files that allocate via `page_allocator` or `c_allocator` skip leak detection; default to `std.testing.allocator`. |
 | `build_zon_min_zig_version_set` | deterministic | Warn | `build.zig.zon` should set `.minimum_zig_version` so toolchain assumptions stay machine-readable. |
 | `build_zon_dependency_hash_pinned` | deterministic | Block | URL-based dependency entries in `build.zig.zon` must declare a `.hash` so package fetches are content-verified. |
+| `no_std_json_parser_api` | deterministic | Block | Current Zig code should use `std.json.parseFromSlice` or `std.json.Scanner`, not the removed `std.json.Parser` type. |
+| `arraylist_uses_unmanaged_api` | deterministic | Block | Current `std.ArrayList(T)` values initialize with `.empty`; allocator-bearing calls happen on methods. |
+| `defer_block_closes_without_semicolon` | deterministic | Block | `defer { ... }` closes with `}` only; `};` after the block is a syntax error. |
 | `allocator_lifetime_hygiene` | semantic | Block | Heap allocations need a matching `defer`/`errdefer` free or a documented ownership transfer. |
 | `no_hardcoded_secrets` | semantic | Block | Credentials, tokens, and private keys must not be embedded as string literals in Zig source. |
 | `integer_endianness_explicit` | semantic | Warn | Multi-byte integer I/O across a serialization boundary should name the endianness rather than relying on host byte order. |
@@ -34,6 +37,9 @@ Evidence scanned on 2026-05-10.
 - Zig source `doc/build.zig.zon.md` for the manifest schema, including `.minimum_zig_version` (advisory) and the `.hash` requirement on URL-based dependencies.
 - Zig Build System tutorial (`ziglang.org/learn/build-system`) for package-manager workflow guidance.
 - The Zig Guide community handbook (`zig.guide`) for error-handling and allocator idioms.
+- Zig 0.16.0 release notes for the migration to unmanaged containers.
+- Zig standard library JSON source and current zig.guide JSON examples for `std.json.parseFromSlice`.
+- Zig language reference and zig.guide examples for `defer` semantics and block-form usage.
 - OWASP Secrets Management and Software Supply Chain Security cheat sheets, plus GitHub secret-scanning documentation, for the secret-handling and dependency-hash predicates.
 
 ## Known False Positives and Negatives
@@ -45,6 +51,9 @@ Evidence scanned on 2026-05-10.
 - `no_panic_in_production` does not distinguish CLI `main()` from library code. Top-level binaries that legitimately panic on unrecoverable startup failures should suppress the warning per call site.
 - `tests_use_testing_allocator` keys on the literal identifiers `page_allocator` and `c_allocator`. Aliased re-exports (`const A = std.heap.page_allocator;` re-exported under another name) will be missed.
 - `build_zon_dependency_hash_pinned` only flags URL-based entries that lack a hash; entries using `.path = ...` are skipped, matching the manifest schema.
+- `no_std_json_parser_api` is a token scan. A prose comment or string literal mentioning `std.json.Parser` will be blocked until the pack can use AST facts.
+- `arraylist_uses_unmanaged_api` blocks `std.ArrayList(T).init(allocator)` in current Zig code. Projects pinned to older Zig releases may need to suppress or opt out of this predicate.
+- `defer_block_closes_without_semicolon` scans from a `defer {` opener to a line containing only `};`. A multiline struct literal inside a defer body that also has a standalone `};` line can false-positive.
 - Semantic predicates depend on a cheap judge. They should stay high-threshold and cite concrete changed spans before blocking.
 
 ## Design Notes

--- a/zig/fixtures/arraylist_uses_unmanaged_api.json
+++ b/zig/fixtures/arraylist_uses_unmanaged_api.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "arraylist_uses_unmanaged_api",
+  "cases": [
+    {
+      "name": "blocks_managed_arraylist_init",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/schema.zig",
+          "text": "const std = @import(\"std\");\n\npub fn collect(allocator: std.mem.Allocator) ![]u8 {\n    var out = std.ArrayList(u8).init(allocator);\n    defer out.deinit();\n    try out.append('x');\n    return out.toOwnedSlice();\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_unmanaged_arraylist_empty",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/schema.zig",
+          "text": "const std = @import(\"std\");\n\npub fn collect(allocator: std.mem.Allocator) ![]u8 {\n    var out: std.ArrayList(u8) = .empty;\n    defer out.deinit(allocator);\n    try out.append(allocator, 'x');\n    return try out.toOwnedSlice(allocator);\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/zig/fixtures/defer_block_closes_without_semicolon.json
+++ b/zig/fixtures/defer_block_closes_without_semicolon.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "defer_block_closes_without_semicolon",
+  "cases": [
+    {
+      "name": "blocks_defer_block_with_semicolon_closer",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/schema.zig",
+          "text": "const std = @import(\"std\");\n\npub fn write() void {\n    defer {\n        std.debug.print(\"done\", .{});\n    };\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_defer_block_without_semicolon_closer",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/schema.zig",
+          "text": "const std = @import(\"std\");\n\npub fn write() void {\n    defer {\n        std.debug.print(\"done\", .{});\n    }\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/zig/fixtures/no_std_json_parser_api.json
+++ b/zig/fixtures/no_std_json_parser_api.json
@@ -1,0 +1,25 @@
+{
+  "predicate": "no_std_json_parser_api",
+  "cases": [
+    {
+      "name": "blocks_removed_std_json_parser",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/schema.zig",
+          "text": "const std = @import(\"std\");\n\npub fn parse(bytes: []const u8) !void {\n    var parser = std.json.Parser.init(std.testing.allocator, false);\n    defer parser.deinit();\n    _ = try parser.parse(bytes);\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_parse_from_slice",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/schema.zig",
+          "text": "const std = @import(\"std\");\n\nconst Schema = struct { name: []const u8 };\n\npub fn parse(allocator: std.mem.Allocator, bytes: []const u8) !Schema {\n    const parsed = try std.json.parseFromSlice(Schema, allocator, bytes, .{});\n    defer parsed.deinit();\n    return parsed.value;\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/zig/invariants.harn
+++ b/zig/invariants.harn
@@ -58,6 +58,18 @@ let _EVIDENCE_ENDIANNESS = [
   "https://ziglang.org/documentation/master/#byteSwap",
 ]
 
+let _EVIDENCE_JSON_PARSE_FROM_SLICE = [
+  "https://github.com/ziglang/zig/blob/master/lib/std/json.zig",
+  "https://zig.guide/standard-library/json/",
+]
+
+let _EVIDENCE_ARRAYLIST_UNMANAGED = [
+  "https://ziglang.org/download/0.16.0/release-notes.html#Migration-to-Unmanaged-Containers",
+  "https://github.com/ziglang/zig/blob/master/lib/std/array_list.zig",
+]
+
+let _EVIDENCE_DEFER_BLOCK = ["https://ziglang.org/documentation/master/#defer", "https://zig.guide/language-basics/defer/"]
+
 fn is_zig_path(path) {
   return path.ends_with(".zig")
 }
@@ -88,6 +100,16 @@ fn scan_files(files, pattern) {
   var findings = []
   for file in files {
     if regex_match(pattern, file.text, "s") != nil {
+      findings = findings.push({path: file.path, pattern: pattern})
+    }
+  }
+  return findings
+}
+
+fn scan_files_with_flags(files, pattern, flags) {
+  var findings = []
+  for file in files {
+    if regex_match(pattern, file.text, flags) != nil {
       findings = findings.push({path: file.path, pattern: pattern})
     }
   }
@@ -135,10 +157,7 @@ fn warn_on_findings(rule, remediation, findings) {
 @archivist(evidence: _EVIDENCE_ERROR_SWALLOW, confidence: 0.84, source_date: "2026-05-10")
 /** Blocks empty catch blocks that silently swallow error unions. */
 pub fn no_silent_error_swallow(slice, _ctx, _repo_at_base) {
-  let findings = scan_files(
-    zig_files(slice),
-    r"catch(\s*\{\s*\}|\s*\|[^|\n]*\|\s*\{\s*\})",
-  )
+  let findings = scan_files(zig_files(slice), r"catch(\s*\{\s*\}|\s*\|[^|\n]*\|\s*\{\s*\})")
   return block_on_findings(
     "no_silent_error_swallow",
     "Handle the error explicitly: log it, propagate with try, or capture and convert it before continuing.",
@@ -151,10 +170,7 @@ pub fn no_silent_error_swallow(slice, _ctx, _repo_at_base) {
 @archivist(evidence: _EVIDENCE_CATCH_UNREACHABLE, confidence: 0.7, source_date: "2026-05-10")
 /** Warns on `catch unreachable` in production source. */
 pub fn no_catch_unreachable_in_prod(slice, _ctx, _repo_at_base) {
-  let findings = scan_files(
-    production_zig_files(slice),
-    r"catch\b[^;{]*\bunreachable\b",
-  )
+  let findings = scan_files(production_zig_files(slice), r"catch\b[^;{]*\bunreachable\b")
   return warn_on_findings(
     "no_catch_unreachable_in_prod",
     "Replace `catch unreachable` with explicit error handling, or restructure so the call cannot fail and document the invariant at the call site.",
@@ -167,10 +183,7 @@ pub fn no_catch_unreachable_in_prod(slice, _ctx, _repo_at_base) {
 @archivist(evidence: _EVIDENCE_UNSAFE_CASTS, confidence: 0.6, source_date: "2026-05-10")
 /** Warns on unchecked or reinterpreting cast builtins that lack an inline justification comment. */
 pub fn unsafe_cast_has_justification(slice, _ctx, _repo_at_base) {
-  let findings = scan_files(
-    zig_files(slice),
-    r"(?m)^(?!.*//).*@(truncate|ptrCast|alignCast|bitCast|intCast)\s*\(",
-  )
+  let findings = scan_files(zig_files(slice), r"(?m)^(?!.*//).*@(truncate|ptrCast|alignCast|bitCast|intCast)\s*\(")
   return warn_on_findings(
     "unsafe_cast_has_justification",
     "Add an inline `//` comment on the cast line explaining why it is sound: bounds, alignment guarantee, representation invariant, or upstream check.",
@@ -194,7 +207,9 @@ pub fn no_panic_in_production(slice, _ctx, _repo_at_base) {
 @invariant
 @deterministic
 @archivist(evidence: _EVIDENCE_TESTING_ALLOC, confidence: 0.66, source_date: "2026-05-10")
-/** Warns when test files use `page_allocator` or `c_allocator` instead of `std.testing.allocator`. */
+/**
+ * Warns when test files use `page_allocator` or `c_allocator` instead of `std.testing.allocator`.
+ */
 pub fn tests_use_testing_allocator(slice, _ctx, _repo_at_base) {
   let findings = scan_files_if(
     zig_files(slice),
@@ -242,6 +257,47 @@ pub fn build_zon_dependency_hash_pinned(slice, _ctx, _repo_at_base) {
 }
 
 @invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_JSON_PARSE_FROM_SLICE, confidence: 0.8, source_date: "2026-06-23")
+/**
+ * Blocks the removed std.json.Parser API in favor of the current parseFromSlice or Scanner APIs.
+ */
+pub fn no_std_json_parser_api(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(zig_files(slice), r"\bstd\.json\.Parser\b")
+  return block_on_findings(
+    "no_std_json_parser_api",
+    "Replace `std.json.Parser` with `std.json.parseFromSlice(T, allocator, bytes, .{})` for typed parsing, or use `std.json.Scanner` for token-level parsing.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_ARRAYLIST_UNMANAGED, confidence: 0.78, source_date: "2026-06-23")
+/** Blocks the old managed std.ArrayList(T).init(allocator) spelling in current Zig code. */
+pub fn arraylist_uses_unmanaged_api(slice, _ctx, _repo_at_base) {
+  let findings = scan_files(zig_files(slice), r"\bstd\.ArrayList\s*\([^\n]+?\)\.init\s*\(")
+  return block_on_findings(
+    "arraylist_uses_unmanaged_api",
+    "Initialize current `std.ArrayList(T)` values with `.empty`; pass the allocator to methods such as `append`, `toOwnedSlice`, and `deinit`.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_DEFER_BLOCK, confidence: 0.82, source_date: "2026-06-23")
+/** Blocks `defer { ... };` closers; a Zig defer block closes with `}` only. */
+pub fn defer_block_closes_without_semicolon(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_with_flags(zig_files(slice), r"(?m)^\s*defer\s*\{\s*$[\s\S]*?^\s*\};\s*$", "ms")
+  return block_on_findings(
+    "defer_block_closes_without_semicolon",
+    "Close `defer { ... }` with `}` only. The extra semicolon after the block is a Zig syntax error.",
+    findings,
+  )
+}
+
+@invariant
 @semantic
 @archivist(evidence: _EVIDENCE_ALLOCATOR_LIFETIME, confidence: 0.62, source_date: "2026-05-10")
 /** Blocks heap allocations whose result is not freed, transferred, or guarded by defer/errdefer. */
@@ -278,7 +334,9 @@ pub fn no_hardcoded_secrets(slice, ctx, _repo_at_base) {
 @invariant
 @semantic
 @archivist(evidence: _EVIDENCE_ENDIANNESS, confidence: 0.6, source_date: "2026-05-10")
-/** Warns when multi-byte integer I/O across a serialization boundary does not name an endianness. */
+/**
+ * Warns when multi-byte integer I/O across a serialization boundary does not name an endianness.
+ */
 pub fn integer_endianness_explicit(slice, ctx, _repo_at_base) {
   let rubric = "Warn only when changed Zig code reads or writes a multi-byte integer across a serialization boundary (file, network socket, on-disk buffer, IPC frame, byte slice from an external source) and the call site does not name an endianness — for example std.mem.readInt/writeInt called without a `.little`, `.big`, or `.native` argument; @bitCast over a []u8 slice without an endianness comment; or @ptrCast on byte arrays going to or from network/file I/O. Allow purely in-memory @bitCast that does not cross a serialization boundary, and allow code that already calls std.mem.nativeTo* / *ToNative or @byteSwap with a documented byte order."
   let judgement = ctx.semantic_judge({rubric: rubric, files: zig_files(slice)})


### PR DESCRIPTION
## Summary
- add deterministic Zig canon predicates for three recurrent Zig 0.16 failure modes: removed std.json.Parser, unmanaged std.ArrayList(T), and defer block semicolon closers
- add matching fixtures for block/allow behavior
- update the Zig pack README with current toolchain assumptions, evidence, and false-positive notes

## Why
Burin hard-cell transcript mining found cheap-model runs repeatedly landing on stale Zig APIs and `defer { ... };` syntax. Encoding these as reusable harn-canon predicates gives downstream harnesses and repair loops a durable source of stack knowledge instead of one-off prompt hints.

## Validation
- harn fmt --check zig/invariants.harn
- harn check zig/invariants.harn
- python3 scripts/validate_canon.py
- python3 -m py_compile scripts/validate_canon.py
- git diff --check