### PR TITLE
Add Go duplicate declaration canon

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -1,6 +1,6 @@
 # Go Seed Predicate Pack
 
-This pack covers Go modules, command packages, and reusable libraries. It targets high-signal review issues that changed source slices can catch cheaply: ignored errors, context propagation mistakes, library panics, overly broad exported APIs, lossy error wrapping, HTTP response leaks, weak randomness, goroutine lifetime leaks, and dependency vulnerability review.
+This pack covers Go modules, command packages, and reusable libraries. It targets high-signal review issues that changed source slices can catch cheaply: ignored errors, context propagation mistakes, library panics, overly broad exported APIs, lossy error wrapping, duplicate declarations, HTTP response leaks, weak randomness, goroutine lifetime leaks, and dependency vulnerability review.
 
 ## Stack Assumptions
 
@@ -9,7 +9,7 @@ This pack covers Go modules, command packages, and reusable libraries. It target
 - Generated Go files with the standard `// Code generated ... DO NOT EDIT.` marker are ignored by deterministic source predicates.
 - Deterministic predicates use file-text scans until Harn Flow exposes a stable Go AST query API.
 - Semantic predicates make one cheap judge call over changed Go/module files and use only evidence captured at authoring time.
-- Advisory rules return `Warn` when idiomatic exceptions are common. Blocking rules are reserved for ignored errors, library panics, likely response-body leaks, security-sensitive randomness, goroutine leaks, and missing dependency-vulnerability evidence.
+- Advisory rules return `Warn` when idiomatic exceptions are common. Blocking rules are reserved for ignored errors, library panics, duplicate declarations, likely response-body leaks, security-sensitive randomness, goroutine leaks, and missing dependency-vulnerability evidence.
 
 ## Predicate Coverage
 
@@ -22,6 +22,7 @@ This pack covers Go modules, command packages, and reusable libraries. It target
 | `no_empty_interface_in_api` | deterministic | Warn | Exported APIs should avoid `interface{}` and `any` when concrete types, type parameters, or small interfaces fit. |
 | `wrap_errors_with_percent_w` | deterministic | Warn | Error context should preserve unwrap chains when callers may use `errors.Is` or `errors.As`. |
 | `error_strings_not_capitalized` | deterministic | Warn | Error strings should compose cleanly when callers add context. |
+| `no_duplicate_declarations` | deterministic | Block | Package-level functions and receiver methods should have one declaration per package. |
 | `http_response_body_closed` | deterministic | Block | Successful HTTP responses must have their bodies closed to release resources. |
 | `no_math_rand_for_keys` | deterministic | Block | Security-sensitive keys, tokens, nonces, and secrets require `crypto/rand`, not `math/rand`. |
 | `goroutine_leak_guard` | semantic | Block | Long-lived goroutines need credible cancellation, shutdown, or bounded-lifetime evidence. |
@@ -29,9 +30,9 @@ This pack covers Go modules, command packages, and reusable libraries. It target
 
 ## Evidence
 
-Evidence scanned on 2026-05-08.
+Most evidence was scanned on 2026-05-08. The Go language spec declaration and method-declaration evidence was scanned on 2026-06-28.
 
-- Go docs and tutorials: Effective Go, Go error handling tutorial, Go 1.13 errors blog, package docs for `context`, `errors`, `fmt`, `io`, `net/http`, `crypto/rand`, and `math/rand`.
+- Go docs and tutorials: Effective Go, Go error handling tutorial, Go 1.13 errors blog, Go language spec declaration and method-declaration rules, and package docs for `context`, `errors`, `fmt`, `io`, `net/http`, `crypto/rand`, and `math/rand`.
 - Go Wiki: Code Review Comments for contexts, interfaces, panic guidance, crypto randomness, and error strings.
 - Go Blog: pipeline cancellation patterns for goroutine shutdown.
 - Staticcheck docs: correctness checks that include ignored-result and suspicious-code signals.
@@ -44,6 +45,7 @@ Evidence scanned on 2026-05-08.
 - `no_ignored_errors` intentionally catches obvious `_ = call()` and `value, _ := call()` shapes, but it cannot prove the discarded result has type `error`.
 - `context_first_arg` and `no_empty_interface_in_api` are advisory because generated bindings and required interface signatures may force non-idiomatic signatures.
 - `no_panic_in_library` ignores `package main` and tests, but it can still catch panics used for internal invariants. Prefer returning errors or documenting the public panic contract once suppressions exist.
+- `no_duplicate_declarations` is line-based and uses the file directory as the package key. It is aimed at agent edit churn that adds the same function or method twice; it may miss unusual multi-line signatures or flag rare mixed-package directories until an AST-backed predicate is available.
 - `http_response_body_closed` is conservative and file-scoped. It can miss helper-based close patterns or flag files that close through a different response variable.
 - `no_math_rand_for_keys` is keyword-based. Non-security simulations with token-like names may need a local allow once the predicate runtime supports suppressions.
 - Semantic predicates depend on the judge recognizing concrete changed spans. They should stay high-threshold and cite exact goroutine or dependency changes before blocking.

--- a/go/fixtures/no_duplicate_declarations.json
+++ b/go/fixtures/no_duplicate_declarations.json
@@ -1,0 +1,47 @@
+{
+  "predicate": "no_duplicate_declarations",
+  "cases": [
+    {
+      "name": "blocks_duplicate_receiver_method_in_same_package",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "internal/engine/engine.go",
+          "text": "package engine\n\nimport \"context\"\n\ntype Engine struct{}\n\nfunc (e *Engine) ListProjects(ctx context.Context) ([]string, error) {\n\treturn nil, nil\n}\n"
+        },
+        {
+          "path": "internal/engine/engine_status.go",
+          "text": "package engine\n\nimport \"context\"\n\nfunc (e *Engine) ListProjects(ctx context.Context) ([]string, error) {\n\treturn []string{}, nil\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "blocks_duplicate_package_function_in_same_package",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "pkg/client/status.go",
+          "text": "package client\n\nfunc NewStatus() string {\n\treturn \"ok\"\n}\n"
+        },
+        {
+          "path": "pkg/client/status_extra.go",
+          "text": "package client\n\nfunc NewStatus() string {\n\treturn \"ready\"\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_same_name_in_different_packages",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "pkg/client/status.go",
+          "text": "package client\n\nfunc NewStatus() string {\n\treturn \"ok\"\n}\n"
+        },
+        {
+          "path": "internal/daemon/status.go",
+          "text": "package daemon\n\nfunc NewStatus() string {\n\treturn \"ready\"\n}\n"
+        }
+      ]
+    }
+  ]
+}

--- a/go/invariants.harn
+++ b/go/invariants.harn
@@ -39,6 +39,8 @@ let _EVIDENCE_DEP_SECURITY = [
   "https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates",
 ]
 
+let _EVIDENCE_UNIQUE_DECLARATIONS = ["https://go.dev/ref/spec#Declarations_and_scope", "https://go.dev/ref/spec#Method_declarations"]
+
 fn is_go_path(path) {
   return path.ends_with(".go")
 }
@@ -65,9 +67,7 @@ fn production_go_files(slice) {
 
 fn library_go_files(slice) {
   return production_go_files(slice)
-    .filter(
-    { file -> regex_match(r"(?m)^\s*package\s+main\s*$", file.text, "m") == nil },
-  )
+    .filter({ file -> regex_match(r"(?m)^\s*package\s+main\s*$", file.text, "m") == nil })
 }
 
 fn go_project_files(slice) {
@@ -99,6 +99,67 @@ fn scan_files_if(files, predicate) {
     if predicate(file) {
       findings = findings
         .push({path: file.path})
+    }
+  }
+  return findings
+}
+
+fn go_package_dir(path) {
+  let normalized = (path ?? "").replace("\\", "/")
+  let parts = normalized.split("/")
+  if len(parts) <= 1 {
+    return "."
+  }
+  return join(parts[0:len(parts) - 1], "/")
+}
+
+fn go_receiver_type(receiver) {
+  let normalized = regex_replace(r"\s+", " ", receiver.replace("*", " ").trim()) ?? receiver
+  let parts = normalized.split(" ").filter({ part -> part != "" })
+  if parts.none() {
+    return ""
+  }
+  return parts[len(parts) - 1] ?? ""
+}
+
+fn go_declaration_key(path, line) {
+  let trimmed = (line ?? "").trim()
+  if !trimmed.starts_with("func ") {
+    return ""
+  }
+  let package_dir = go_package_dir(path)
+  var rest = trimmed[5:].trim()
+  if rest.starts_with("(") {
+    let receiver = rest[1:].split(")")[0] ?? ""
+    let receiver_type = go_receiver_type(receiver)
+    let after_receiver = rest.split(")")[1] ?? ""
+    let name = (after_receiver.trim().split("(")[0] ?? "").trim()
+    if receiver_type == "" || name == "" {
+      return ""
+    }
+    return "${package_dir}|method|${receiver_type}.${name}"
+  }
+  let name = (rest.split("(")[0] ?? "").trim()
+  if name == "" {
+    return ""
+  }
+  return "${package_dir}|func|${name}"
+}
+
+fn go_duplicate_declaration_findings(files) {
+  var seen = {}
+  var findings = []
+  for file in files {
+    for line in file.text.split("\n") {
+      let key = go_declaration_key(file.path, line)
+      if key != "" {
+        let first_path = seen[key]
+        if first_path != nil {
+          findings = findings.push({path: file.path, declaration: key, first_path: first_path})
+        } else {
+          seen = seen + {[key]: file.path}
+        }
+      }
     }
   }
   return findings
@@ -233,6 +294,19 @@ pub fn error_strings_not_capitalized(slice, _ctx, _repo_at_base) {
   return warn_on_findings(
     "error_strings_not_capitalized",
     "Start error strings with lowercase text unless the first token is a proper noun or acronym.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_UNIQUE_DECLARATIONS, confidence: 0.7, source_date: "2026-06-28")
+/** Blocks duplicate package-level functions or receiver methods in production Go files. */
+pub fn no_duplicate_declarations(slice, _ctx, _repo_at_base) {
+  let findings = go_duplicate_declaration_findings(production_go_files(slice))
+  return block_on_findings(
+    "no_duplicate_declarations",
+    "Keep one declaration for each package-level function or receiver method; merge helpers instead of adding duplicate declarations.",
     findings,
   )
 }


### PR DESCRIPTION
## Summary
- add a deterministic Go canon predicate that blocks duplicate package-level functions and receiver methods within a production package directory
- add fixture coverage for duplicate receiver methods, duplicate package functions, and same-name declarations in different packages
- update the Go pack README coverage, evidence, and false-positive notes

## Why
Structured debugger analysis of the latest go-feat near-flip failure (`eval-go-feat-20260629-001503-4b96833c-499-t2`) showed the model repeatedly introduced duplicate `Engine.ListProjects` declarations while repairing compile errors. This predicate captures that edit-churn class as a reusable Go invariant.

## Verification
- `python3 scripts/validate_canon.py`
- `python3 -m py_compile scripts/validate_canon.py`
- `harn fmt --check go/invariants.harn`
- `git diff --check`