### PR TITLE
ci: bump Harn canon runtime to 0.8.155

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install pinned Harn
         shell: bash
         env:
-          HARN_VERSION: "0.8.147"
+          HARN_VERSION: "0.8.155"
         run: |
           set -euo pipefail
           target="x86_64-unknown-linux-gnu"


### PR DESCRIPTION
## Summary
- move harn-canon CI fixture execution from Harn 0.8.147 to the current 0.8.155 release floor
- keep canon validation aligned with the runtime version now used by Burin and harn-cloud

## Verification
- python3 scripts/validate_canon.py
- python3 -m py_compile scripts/validate_canon.py scripts/execute_fixtures.py
- python3 scripts/execute_fixtures.py
- git diff --check