### PR TITLE
ci: bound canon validation jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
   canon-validation:
     name: Canon structure and fixture validation
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Validate canon packs
@@ -97,6 +98,7 @@ jobs:
     if: always()
     needs: [canon-validation]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Check for failures
         run: |


### PR DESCRIPTION
## Summary
- add explicit job-level timeouts to the canon validation workflow
- bound the branch-protection CI status rollup separately

## Verification
- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- YAML audit confirms all workflow jobs have `timeout-minutes`