### PR TITLE
ci: bump Harn runtime to 0.8.156

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install pinned Harn
         shell: bash
         env:
-          HARN_VERSION: "0.8.155"
+          HARN_VERSION: "0.8.156"
         run: |
           set -euo pipefail
           target="x86_64-unknown-linux-gnu"


### PR DESCRIPTION
## Summary
- bump harn-canon CI's pinned Harn runtime from 0.8.155 to 0.8.156
- keep canon predicate validation aligned with the currently published Harn runtime used by Burin/harn-cloud

## Validation
- `python3 -m py_compile scripts/validate_canon.py`
- `python3 scripts/validate_canon.py`
- `git diff --check`
- verified the `v0.8.156` release exposes `harn-x86_64-unknown-linux-gnu.tar.gz` and `SHA256SUMS`
