### PR TITLE
ci: bump harn-canon runtime to 0.8.160

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install pinned Harn
         shell: bash
         env:
-          HARN_VERSION: "0.8.159"
+          HARN_VERSION: "0.8.160"
         run: |
           set -euo pipefail
           target="x86_64-unknown-linux-gnu"


### PR DESCRIPTION
## Summary
- bump harn-canon CI's pinned Harn runtime from `0.8.159` to `0.8.160`
- verified the `v0.8.160` release has the Linux asset and `SHA256SUMS` published

## Verification
- `python3 scripts/validate_canon.py`
- `python3 -m py_compile scripts/validate_canon.py`
- `git diff --check`

Co-Authored-By: Codex <codex@openai.com>