### PR TITLE
[codex] Extend Zig JSON map ownership invariant

### DIFF
--- a/zig/README.md
+++ b/zig/README.md
@@ -22,7 +22,7 @@ This pack covers Zig source (`.zig`) and the `build.zig.zon` package manifest. Z
 | `build_zon_min_zig_version_set` | deterministic | Warn | `build.zig.zon` should set `.minimum_zig_version` so toolchain assumptions stay machine-readable. |
 | `build_zon_dependency_hash_pinned` | deterministic | Block | URL-based dependency entries in `build.zig.zon` must declare a `.hash` so package fetches are content-verified. |
 | `no_std_json_parser_api` | deterministic | Block | Current Zig code should use `std.json.parseFromSlice` or `std.json.Scanner`, not the removed `std.json.Parser` type. |
-| `parsed_json_arrayhashmap_has_single_owner` | deterministic | Block | `std.json.ArrayHashMap` fields under a parsed JSON value should be cleaned up by `parsed.deinit()` only, not manual `.value...map.deinit(...)` calls. |
+| `parsed_json_arrayhashmap_has_single_owner` | deterministic | Block | `std.json.ArrayHashMap` ownership stays single-owner: parsed values deinit through `parsed.deinit()`, and duplicated manual keys need explicit key frees. |
 | `hashmap_count_uses_count_method` | deterministic | Block | Zig hash maps expose their element count through `.count()`; stale `.size` reads should not ship. |
 | `arraylist_uses_unmanaged_api` | deterministic | Block | Current `std.ArrayList(T)` values initialize with `.empty`; allocator-bearing calls happen on methods. |
 | `defer_block_closes_without_semicolon` | deterministic | Block | `defer { ... }` closes with `}` only; `};` after the block is a syntax error. |
@@ -41,7 +41,7 @@ Evidence scanned on 2026-05-10, 2026-06-23, and 2026-07-01.
 - The Zig Guide community handbook (`zig.guide`) for error-handling and allocator idioms.
 - Zig 0.16.0 release notes for the migration to unmanaged containers.
 - Zig standard library JSON source and current zig.guide JSON examples for `std.json.parseFromSlice`.
-- Zig standard library JSON parser and `std.json.ArrayHashMap` sources for parsed-value ownership and cleanup.
+- Zig standard library JSON parser, JSON hashmap, array-hash-map sources, and memory docs for `std.json.ArrayHashMap` ownership and cleanup.
 - Zig standard library hash map and array hash map sources, plus current zig.guide hash map examples, for the public `.count()` API on map values.
 - Zig language reference and zig.guide examples for `defer` semantics and block-form usage.
 - OWASP Secrets Management and Software Supply Chain Security cheat sheets, plus GitHub secret-scanning documentation, for the secret-handling and dependency-hash predicates.
@@ -56,7 +56,7 @@ Evidence scanned on 2026-05-10, 2026-06-23, and 2026-07-01.
 - `tests_use_testing_allocator` keys on the literal identifiers `page_allocator` and `c_allocator`. Aliased re-exports (`const A = std.heap.page_allocator;` re-exported under another name) will be missed.
 - `build_zon_dependency_hash_pinned` only flags URL-based entries that lack a hash; entries using `.path = ...` are skipped, matching the manifest schema.
 - `no_std_json_parser_api` is a token scan. A prose comment or string literal mentioning `std.json.Parser` will be blocked until the pack can use AST facts.
-- `parsed_json_arrayhashmap_has_single_owner` requires `std.json.ArrayHashMap`, `std.json.parseFromSlice`, and a manual `.value...map.deinit(...)` in the same changed file. It can miss helper-based cleanup and can block unusual code that intentionally copies a parsed value into a new owner before deiniting it.
+- `parsed_json_arrayhashmap_has_single_owner` has two file-local checks. The parsed-value check requires `std.json.ArrayHashMap`, `std.json.parseFromSlice`, and a manual `.value...map.deinit(...)` in the same changed file. The manual-key check looks for `allocator.dupe` or `dupeZ`, insertion through `.map.put(...)`, and `.map.deinit(...)` without an entry loop that frees `entry.key_ptr.*` or `entry.key`. It can miss helper-based cleanup in another file and can block unusual code that intentionally copies a parsed value into a new owner or uses a custom key-cleanup helper.
 - `hashmap_count_uses_count_method` requires a recognized Zig hash map type in the file and then scans for likely map-shaped `.size` reads such as `map.size`, `user_map.size`, or `.items.map.size`. It can miss unusually named map variables and can false-positive on a non-map field named `size` in the same changed file.
 - `arraylist_uses_unmanaged_api` blocks `std.ArrayList(T).init(allocator)` in current Zig code. Projects pinned to older Zig releases may need to suppress or opt out of this predicate.
 - `defer_block_closes_without_semicolon` scans from a `defer {` opener to a line containing only `};`. A multiline struct literal inside a defer body that also has a standalone `};` line can false-positive.

--- a/zig/fixtures/parsed_json_arrayhashmap_has_single_owner.json
+++ b/zig/fixtures/parsed_json_arrayhashmap_has_single_owner.json
@@ -20,6 +20,36 @@
           "text": "const std = @import(\"std\");\n\nconst Schema = struct {\n    items: std.json.ArrayHashMap(Item),\n};\n\nconst Item = struct { name: []const u8 };\n\npub fn parse(allocator: std.mem.Allocator, bytes: []const u8) !usize {\n    const parsed = try std.json.parseFromSlice(Schema, allocator, bytes, .{ .allocate = .alloc_always });\n    defer parsed.deinit();\n    return parsed.value.items.map.count();\n}\n"
         }
       ]
+    },
+    {
+      "name": "blocks_duped_key_without_free_loop",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/schema.zig",
+          "text": "const std = @import(\"std\");\n\nconst Item = struct { value: u32 };\n\npub fn build(allocator: std.mem.Allocator, raw: []const u8) !std.json.ArrayHashMap(Item) {\n    var items: std.json.ArrayHashMap(Item) = .{ .map = .empty };\n    errdefer items.map.deinit(allocator);\n\n    const key = try allocator.dupe(u8, raw);\n    try items.map.put(allocator, key, .{ .value = 1 });\n    return items;\n}\n\npub fn release(allocator: std.mem.Allocator, items: *std.json.ArrayHashMap(Item)) void {\n    items.map.deinit(allocator);\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_key_free_loop_before_deinit",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/schema.zig",
+          "text": "const std = @import(\"std\");\n\nconst Item = struct { value: u32 };\n\npub fn build(allocator: std.mem.Allocator, raw: []const u8) !std.json.ArrayHashMap(Item) {\n    var items: std.json.ArrayHashMap(Item) = .{ .map = .empty };\n    errdefer items.map.deinit(allocator);\n\n    const key = try allocator.dupe(u8, raw);\n    try items.map.put(allocator, key, .{ .value = 1 });\n    return items;\n}\n\npub fn release(allocator: std.mem.Allocator, items: *std.json.ArrayHashMap(Item)) void {\n    var iter = items.map.iterator();\n    while (iter.next()) |entry| {\n        allocator.free(entry.key_ptr.*);\n    }\n    items.map.deinit(allocator);\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_borrowed_static_key",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/schema.zig",
+          "text": "const std = @import(\"std\");\n\nconst Item = struct { value: u32 };\n\npub fn build(allocator: std.mem.Allocator) !std.json.ArrayHashMap(Item) {\n    var items: std.json.ArrayHashMap(Item) = .{ .map = .empty };\n    errdefer items.map.deinit(allocator);\n    try items.map.put(allocator, \"static-key\", .{ .value = 1 });\n    return items;\n}\n\npub fn release(allocator: std.mem.Allocator, items: *std.json.ArrayHashMap(Item)) void {\n    items.map.deinit(allocator);\n}\n"
+        }
+      ]
     }
   ]
 }

--- a/zig/invariants.harn
+++ b/zig/invariants.harn
@@ -66,6 +66,8 @@ let _EVIDENCE_JSON_PARSE_FROM_SLICE = [
 let _EVIDENCE_JSON_ARRAYHASHMAP_OWNERSHIP = [
   "https://github.com/ziglang/zig/blob/master/lib/std/json/static.zig",
   "https://github.com/ziglang/zig/blob/master/lib/std/json/hashmap.zig",
+  "https://github.com/ziglang/zig/blob/master/lib/std/array_hash_map.zig",
+  "https://ziglang.org/documentation/master/#Memory",
   "https://zig.guide/standard-library/json/",
 ]
 
@@ -294,23 +296,30 @@ pub fn no_std_json_parser_api(slice, _ctx, _repo_at_base) {
 
 @invariant
 @deterministic
-@archivist(evidence: _EVIDENCE_JSON_ARRAYHASHMAP_OWNERSHIP, confidence: 0.74, source_date: "2026-06-23")
-/** Blocks manual deinit of std.json.ArrayHashMap fields owned by a Parsed(T) value. */
+@archivist(evidence: _EVIDENCE_JSON_ARRAYHASHMAP_OWNERSHIP, confidence: 0.74, source_date: "2026-07-01")
+/**
+ * Blocks split ownership for std.json.ArrayHashMap: parsed values deinit through Parsed(T),
+ * and duplicated manual keys need an explicit key-free loop before map deinit.
+ */
 pub fn parsed_json_arrayhashmap_has_single_owner(slice, _ctx, _repo_at_base) {
   let findings = scan_files_if(
     zig_files(slice),
     { file -> regex_match(r"\bstd\.json\.ArrayHashMap\b", file.text, "s") != nil
-      && regex_match(r"\bstd\.json\.parseFromSlice\b", file.text, "s") != nil
+      && ((regex_match(r"\bstd\.json\.parseFromSlice\b", file.text, "s") != nil
       && regex_match(
       r"\b[A-Za-z_][A-Za-z0-9_]*\.value(?:\.[A-Za-z_][A-Za-z0-9_]*){0,8}\.map\.deinit\s*\(",
       file.text,
       "s",
     )
-      != nil },
+      != nil)
+      || (regex_match(r"\b[A-Za-z_][A-Za-z0-9_]*\.dupeZ?\s*\(\s*u8\b", file.text, "s") != nil
+      && regex_match(r"\.map\.put\s*\(", file.text, "s") != nil
+      && regex_match(r"\.map\.deinit\s*\(", file.text, "s") != nil
+      && regex_match(r"\bfree\s*\([^)]*(?:\.key_ptr\.\*|\.key)\s*\)", file.text, "s") == nil)) },
   )
   return block_on_findings(
     "parsed_json_arrayhashmap_has_single_owner",
-    "Do not manually deinit `std.json.ArrayHashMap` fields under `parsed.value`; call `parsed.deinit()` exactly once so the JSON parser's ownership stays single-owner.",
+    "Keep `std.json.ArrayHashMap` ownership single-owner: use `parsed.deinit()` for parsed values, and free every duplicated manual key before `map.deinit(allocator)`.",
     findings,
   )
 }


### PR DESCRIPTION
## Summary

Extends the Zig `parsed_json_arrayhashmap_has_single_owner` invariant to cover the remaining JSON ArrayHashMap key-ownership residual: duplicated keys inserted into a manual `std.json.ArrayHashMap` need an explicit key-free loop before `map.deinit(allocator)`.

This keeps the Zig pack under the existing 12 deterministic predicate ceiling by folding the behavior into the existing ArrayHashMap ownership predicate instead of adding a thirteenth predicate.

## Details

- Expands the ArrayHashMap ownership evidence to include `std/array_hash_map.zig` and Zig memory docs.
- Adds fixture cases for:
  - blocked `allocator.dupe(u8, ...)` key inserted via `.map.put(...)` and deinitialized without freeing keys
  - allowed key-free loop over `entry.key_ptr.*`
  - allowed borrowed/static key insertion with no duplicated key ownership
- Updates the Zig README row and false-positive notes for the broader file-local check.

## Local validation

- `python3 scripts/validate_canon.py`
- `python3 -m py_compile scripts/validate_canon.py scripts/execute_fixtures.py`
- `harn fmt --check zig/invariants.harn`
- `python3 scripts/execute_fixtures.py --pack zig`
- `git diff --check`
- `git diff --check HEAD~1..HEAD`
