### PR TITLE
[codex] Add Zig doc comment placement invariant

### DIFF
--- a/scripts/validate_canon.py
+++ b/scripts/validate_canon.py
@@ -28,7 +28,7 @@ MIN_SEMANTIC = 2
 MAX_SEMANTIC = 3
 PACK_DETERMINISTIC_LIMITS = {
     # Zig carries current-stdlib migration predicates; keep the exception scoped.
-    "zig": (MIN_DETERMINISTIC, 13),
+    "zig": (MIN_DETERMINISTIC, 14),
 }
 VALID_EXPECTS = {"Allow", "Warn", "Block"}
 FIXTURE_KEYS = {"predicate", "cases"}

--- a/zig/README.md
+++ b/zig/README.md
@@ -27,6 +27,7 @@ This pack covers Zig source (`.zig`) and the `build.zig.zon` package manifest. Z
 | `enum_tags_use_tag_name_builtin` | deterministic | Block | Enum and tagged-union values use the `@tagName(value)` builtin for names, not stale `std.meta.tagToString(...)` calls. |
 | `arraylist_uses_unmanaged_api` | deterministic | Block | Current `std.ArrayList(T)` values initialize with `.empty`; allocator-bearing calls happen on methods. |
 | `defer_block_closes_without_semicolon` | deterministic | Block | `defer { ... }` closes with `}` only; `};` after the block is a syntax error. |
+| `doc_comments_attach_to_declarations` | deterministic | Block | `///` doc comments attach to declarations and fields; implementation notes before statements should use `//`. |
 | `allocator_lifetime_hygiene` | semantic | Block | Heap allocations need a matching `defer`/`errdefer` free or a documented ownership transfer. |
 | `no_hardcoded_secrets` | semantic | Block | Credentials, tokens, and private keys must not be embedded as string literals in Zig source. |
 | `integer_endianness_explicit` | semantic | Warn | Multi-byte integer I/O across a serialization boundary should name the endianness rather than relying on host byte order. |
@@ -46,6 +47,7 @@ Evidence scanned on 2026-05-10, 2026-06-23, 2026-07-01, and 2026-07-02.
 - Zig standard library hash map and array hash map sources, plus current zig.guide hash map examples, for the public `.count()` API on map values.
 - Zig language reference, Zig standard library `std.meta` source, and current zig.guide enum examples for `@tagName(value)` and `std.meta.stringToEnum`.
 - Zig language reference and zig.guide examples for `defer` semantics and block-form usage.
+- Zig language reference and zig.guide documentation-generation examples for doc-comment attachment sites.
 - OWASP Secrets Management and Software Supply Chain Security cheat sheets, plus GitHub secret-scanning documentation, for the secret-handling and dependency-hash predicates.
 
 ## Known False Positives and Negatives
@@ -63,6 +65,7 @@ Evidence scanned on 2026-05-10, 2026-06-23, 2026-07-01, and 2026-07-02.
 - `enum_tags_use_tag_name_builtin` is an exact token scan. A comment or string literal that mentions `std.meta.tagToString(` will be blocked until the pack can use AST facts.
 - `arraylist_uses_unmanaged_api` blocks `std.ArrayList(T).init(allocator)` in current Zig code. Projects pinned to older Zig releases may need to suppress or opt out of this predicate.
 - `defer_block_closes_without_semicolon` scans from a `defer {` opener to a line containing only `};`. A multiline struct literal inside a defer body that also has a standalone `};` line can false-positive.
+- `doc_comments_attach_to_declarations` is intentionally narrow. It blocks `///` immediately before statement-shaped lines such as `return`, `try`, `defer`, and `if`, but can miss misplaced doc comments before local `const` or `var` declarations to avoid false-positives on documented top-level declarations.
 - Semantic predicates depend on a cheap judge. They should stay high-threshold and cite concrete changed spans before blocking.
 
 ## Design Notes

--- a/zig/fixtures/doc_comments_attach_to_declarations.json
+++ b/zig/fixtures/doc_comments_attach_to_declarations.json
@@ -1,0 +1,45 @@
+{
+  "predicate": "doc_comments_attach_to_declarations",
+  "cases": [
+    {
+      "name": "blocks_doc_comment_before_return_statement",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/schema.zig",
+          "text": "pub fn consumed(bytes: []const u8) usize {\n    /// Return the byte count consumed by the parser.\n    return bytes.len;\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "blocks_doc_comment_before_try_statement",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/schema.zig",
+          "text": "const Parser = struct {\n    pub fn parse(self: *Parser, bytes: []const u8) !void {\n        /// Parse the input into the current document.\n        try self.parseBytes(bytes);\n    }\n\n    fn parseBytes(self: *Parser, bytes: []const u8) !void {\n        _ = self;\n        _ = bytes;\n    }\n};\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_doc_comments_on_declarations_and_fields",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/schema.zig",
+          "text": "const Parser = struct {\n    /// Number of bytes consumed by the parser.\n    consumed: usize,\n\n    /// Parse bytes into the current document.\n    pub fn parse(bytes: []const u8) void {\n        // Implementation note, not generated API docs.\n        _ = bytes;\n    }\n};\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_doc_comments_on_enum_tags",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/schema.zig",
+          "text": "const Kind = enum {\n    /// String token.\n    string,\n    /// Number token.\n    number,\n};\n"
+        }
+      ]
+    }
+  ]
+}

--- a/zig/invariants.harn
+++ b/zig/invariants.harn
@@ -90,6 +90,11 @@ let _EVIDENCE_ARRAYLIST_UNMANAGED = [
 
 let _EVIDENCE_DEFER_BLOCK = ["https://ziglang.org/documentation/master/#defer", "https://zig.guide/language-basics/defer/"]
 
+let _EVIDENCE_DOC_COMMENTS = [
+  "https://ziglang.org/documentation/master/#Doc-Comments",
+  "https://zig.guide/build-system/generating-documentation/",
+]
+
 fn is_zig_path(path) {
   return path.ends_with(".zig")
 }
@@ -392,6 +397,23 @@ pub fn defer_block_closes_without_semicolon(slice, _ctx, _repo_at_base) {
   return block_on_findings(
     "defer_block_closes_without_semicolon",
     "Close `defer { ... }` with `}` only. The extra semicolon after the block is a Zig syntax error.",
+    findings,
+  )
+}
+
+@invariant
+@deterministic
+@archivist(evidence: _EVIDENCE_DOC_COMMENTS, confidence: 0.76, source_date: "2026-07-02")
+/** Blocks `///` used as an implementation note before a statement. */
+pub fn doc_comments_attach_to_declarations(slice, _ctx, _repo_at_base) {
+  let findings = scan_files_with_flags(
+    zig_files(slice),
+    r"(?m)^\s*///[^\n]*\n\s*(?:(?:return|if|while|for|switch|try|defer|errdefer|break|continue|unreachable)\b|@)",
+    "m",
+  )
+  return block_on_findings(
+    "doc_comments_attach_to_declarations",
+    "Use `//` for implementation notes inside function bodies. Reserve `///` for declarations, fields, enum tags, and other doc-comment attachment sites.",
     findings,
   )
 }


### PR DESCRIPTION
## Summary
- Add a Zig canon predicate for misplaced `///` doc comments used as implementation comments before statements.
- Fixture both blocked statement attachments and allowed declaration, field, and enum-tag docs.
- Keep the deterministic predicate ceiling exception scoped to the Zig pack.

## Validation
- `python3 scripts/validate_canon.py`
- `python3 -m py_compile scripts/validate_canon.py scripts/execute_fixtures.py`
- `harn fmt --check zig/invariants.harn`
- `harn check zig/invariants.harn`
- `python3 scripts/execute_fixtures.py --pack zig`
- `git diff --check`