### PR TITLE
chore: PR template — end-to-end description + empirical test plan

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Description
+
+<!--
+Plain language, bullet points, succinct. Describe what this PR does
+END-TO-END: the behavior change an agent, user, or downstream repo actually
+sees — NOT a list of files or tests (the Files tab already shows those). If
+the flow or data path is non-obvious, add a small Mermaid diagram in a
+```mermaid fence.
+-->
+
+## Test plan
+
+<!--
+Not a raw count of passing tests — a green tally says nothing about whether
+the tests bind to real behavior. Make the intuitive case for why this change
+is correct:
+
+- What you verified EMPIRICALLY — tight verification loops, throwaway evals,
+  headless dogfoods, manual runs — and what actually happened.
+- Which load-bearing parts you are confident about, and why.
+- The honest blind spots: what remains unvalidated, and how/when it gets
+  validated (eval cell, live probe, follow-up PR).
+
+Manual test plans, automated checks, or both — whatever genuinely
+demonstrates correctness.
+-->


### PR DESCRIPTION
## Description

- Adds a repo PR template steering every future PR body toward a plain-language, end-to-end story of the behavior change (with a Mermaid diagram where the flow is non-obvious) instead of file/test listings the diff UI already shows.
- The Test plan section asks for an intuitive correctness argument — what was verified empirically and what the honest blind spots are — rather than raw passing-test counts, which say nothing about whether tests bind to real behavior.

## Test plan

- Rendered locally as Markdown; templates are inert config consumed only by GitHub's PR-creation UI, so the blast radius is the next PR's prefilled body. Validated end-to-end by this rollout's own follow-up PRs rendering the sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)