### PR TITLE
Validate Flow semantic fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@ Seed **invariant** libraries for [Harn Flow](https://github.com/burin-labs/harn)
 
 Per-language and per-stack predicate packs. Each pack is a directory containing:
 
-- `invariants.harn` — Harn functions annotated with `@invariant` and either `@deterministic` (pure, 50 ms budget) or `@semantic` (one cheap LLM judge call, 2 s budget, evidence pre-baked at authoring time).
+- `invariants.harn` — Harn functions annotated with `@invariant` and either
+  `@deterministic` (pure, 50 ms budget) or
+  `@semantic(fallback: predicate_name)` (one cheap LLM judge call, 2 s budget,
+  evidence pre-baked at authoring time, plus a same-pack deterministic fallback
+  for replay/runtime discovery).
 - `README.md` — purpose, stack assumptions, evidence sources, coverage examples, known false positives.
 - `fixtures/` — small atom/slice fixtures the predicates are expected to allow or block, used by CI.
 

--- a/c/invariants.harn
+++ b/c/invariants.harn
@@ -88,7 +88,12 @@ fn is_test_path(path) {
 }
 
 fn is_generated_c(file) {
-  return regex_match(r"(?im)^\s*(?://|/\*|\*)\s*(?:Code\s+generated|Auto-?generated|GENERATED FILE)[^\n]*DO NOT EDIT", file.text, "m") != nil
+  return regex_match(
+    r"(?im)^\s*(?://|/\*|\*)\s*(?:Code\s+generated|Auto-?generated|GENERATED FILE)[^\n]*DO NOT EDIT",
+    file.text,
+    "m",
+  )
+    != nil
 }
 
 fn c_files(slice) {
@@ -177,7 +182,9 @@ fn warn_on_findings(rule, remediation, findings) {
 @invariant
 @deterministic
 @archivist(evidence: _EVIDENCE_GETS, confidence: 0.95, source_date: "2026-05-10")
-/** Blocks gets, which has no length-bounded form and was removed from the C standard library in C11. */
+/**
+ * Blocks gets, which has no length-bounded form and was removed from the C standard library in C11.
+ */
 pub fn no_gets(slice, _ctx, _repo_at_base) {
   let findings = scan_files(production_c_files(slice), r"\bgets\s*\(", "s")
   return block_on_findings(
@@ -192,11 +199,7 @@ pub fn no_gets(slice, _ctx, _repo_at_base) {
 @archivist(evidence: _EVIDENCE_BOUNDED_STRING_OPS, confidence: 0.7, source_date: "2026-05-10")
 /** Warns on unbounded string and formatted-input calls that prefer length-bounded variants. */
 pub fn bounded_string_ops(slice, _ctx, _repo_at_base) {
-  let findings = scan_files(
-    production_c_files(slice),
-    r"\b(?:strcpy|strcat|sprintf|vsprintf|scanf)\s*\(",
-    "s",
-  )
+  let findings = scan_files(production_c_files(slice), r"\b(?:strcpy|strcat|sprintf|vsprintf|scanf)\s*\(", "s")
   return warn_on_findings(
     "bounded_string_ops",
     "Prefer strncpy/strlcpy, strncat/strlcat, snprintf/vsnprintf, or fgets+sscanf with explicit lengths.",
@@ -224,21 +227,20 @@ pub fn no_void_main(slice, _ctx, _repo_at_base) {
 pub fn no_format_string_from_variable(slice, _ctx, _repo_at_base) {
   let findings = scan_files_if(
     production_c_files(slice),
-    { file -> regex_match(
-      r"\b(?:printf|vprintf|sprintf|vsprintf)\s*\(\s*[A-Za-z_]\w*\s*[,)]",
-      file.text,
-      "s",
-    ) != nil
+    { file -> regex_match(r"\b(?:printf|vprintf|sprintf|vsprintf)\s*\(\s*[A-Za-z_]\w*\s*[,)]", file.text, "s")
+      != nil
       || regex_match(
       r"\b(?:fprintf|dprintf|vfprintf|syslog)\s*\(\s*[^,)\n]+,\s*[A-Za-z_]\w*\s*[,)]",
       file.text,
       "s",
-    ) != nil
+    )
+      != nil
       || regex_match(
       r"\b(?:snprintf|vsnprintf)\s*\(\s*[^,)\n]+,\s*[^,)\n]+,\s*[A-Za-z_]\w*\s*[,)]",
       file.text,
       "s",
-    ) != nil },
+    )
+      != nil },
   )
   return block_on_findings(
     "no_format_string_from_variable",
@@ -252,11 +254,7 @@ pub fn no_format_string_from_variable(slice, _ctx, _repo_at_base) {
 @archivist(evidence: _EVIDENCE_UNSAFE_TMPFILE, confidence: 0.9, source_date: "2026-05-10")
 /** Blocks tmpnam, tempnam, and mktemp; they create races between name choice and file open. */
 pub fn no_unsafe_tmpfile(slice, _ctx, _repo_at_base) {
-  let findings = scan_files(
-    production_c_files(slice),
-    r"\b(?:tmpnam|tempnam|mktemp)\s*\(",
-    "s",
-  )
+  let findings = scan_files(production_c_files(slice), r"\b(?:tmpnam|tempnam|mktemp)\s*\(", "s")
   return block_on_findings(
     "no_unsafe_tmpfile",
     "Use mkstemp, mkostemp, or tmpfile, which atomically create the file with the returned name.",
@@ -269,11 +267,7 @@ pub fn no_unsafe_tmpfile(slice, _ctx, _repo_at_base) {
 @archivist(evidence: _EVIDENCE_ATOI_FAMILY, confidence: 0.78, source_date: "2026-05-10")
 /** Warns on atoi, atol, atoll, and atof, which silently swallow conversion errors and overflow. */
 pub fn no_atoi_family(slice, _ctx, _repo_at_base) {
-  let findings = scan_files(
-    production_c_files(slice),
-    r"\b(?:atoi|atol|atoll|atof)\s*\(",
-    "s",
-  )
+  let findings = scan_files(production_c_files(slice), r"\b(?:atoi|atol|atoll|atof)\s*\(", "s")
   return warn_on_findings(
     "no_atoi_family",
     "Use strtol/strtoul/strtod with errno and endptr checks so invalid input and overflow are detectable.",
@@ -293,7 +287,8 @@ pub fn c_header_has_include_guard(slice, _ctx, _repo_at_base) {
       r"(?ms)^\s*#\s*ifndef\s+\w+\s*\n\s*#\s*define\s+\w+\b.*^\s*#\s*endif\b",
       file.text,
       "ms",
-    ) == nil },
+    )
+      == nil },
   )
   return warn_on_findings(
     "c_header_has_include_guard",
@@ -305,13 +300,11 @@ pub fn c_header_has_include_guard(slice, _ctx, _repo_at_base) {
 @invariant
 @deterministic
 @archivist(evidence: _EVIDENCE_ALLOCA, confidence: 0.72, source_date: "2026-05-10")
-/** Warns on alloca and variable-length arrays sized by user input; both can silently overflow the stack. */
+/**
+ * Warns on alloca and variable-length arrays sized by user input; both can silently overflow the stack.
+ */
 pub fn no_alloca(slice, _ctx, _repo_at_base) {
-  let findings = scan_files(
-    production_c_files(slice),
-    r"\b(?:alloca|_alloca|__builtin_alloca)\s*\(",
-    "s",
-  )
+  let findings = scan_files(production_c_files(slice), r"\b(?:alloca|_alloca|__builtin_alloca)\s*\(", "s")
   return warn_on_findings(
     "no_alloca",
     "Use a fixed-size buffer, malloc with a checked size cap, or a stack-bounded helper; alloca is unportable and unchecked.",
@@ -320,7 +313,7 @@ pub fn no_alloca(slice, _ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_gets)
 @archivist(evidence: _EVIDENCE_ALLOC_NULL_CHECK, confidence: 0.64, source_date: "2026-05-10")
 /** Blocks heap allocation paths that lack a NULL-return check before the result is dereferenced. */
 pub fn allocation_return_checked(slice, ctx, _repo_at_base) {
@@ -337,9 +330,11 @@ pub fn allocation_return_checked(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_gets)
 @archivist(evidence: _EVIDENCE_STATIC_ANALYZER, confidence: 0.6, source_date: "2026-05-10")
-/** Blocks meaningful C source changes that ship without evidence of a static-analysis or sanitizer path. */
+/**
+ * Blocks meaningful C source changes that ship without evidence of a static-analysis or sanitizer path.
+ */
 pub fn static_analyzer_clean(slice, ctx, _repo_at_base) {
   let rubric = "Block only when changed C source materially adds or rewrites pointer arithmetic, manual memory management, file or socket I/O, parsing, concurrency primitives, or unsafe casts, and the slice plus repo configuration shows no evidence of clang-analyzer, scan-build, clang-tidy, cppcheck, an Address/Undefined/Memory/Thread sanitizer build mode, or an equivalent static-analysis or dynamic-analysis pipeline being applied to the changed code. Allow trivial refactors, comment-only edits, and changes to projects that already wire one of these tools into CI or developer tooling."
   let judgement = ctx.semantic_judge({rubric: rubric, files: c_project_files(slice)})
@@ -354,9 +349,11 @@ pub fn static_analyzer_clean(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_gets)
 @archivist(evidence: _EVIDENCE_DEP_SECURITY, confidence: 0.6, source_date: "2026-05-10")
-/** Blocks C dependency or build-system changes that omit advisory or vulnerability-check evidence. */
+/**
+ * Blocks C dependency or build-system changes that omit advisory or vulnerability-check evidence.
+ */
 pub fn c_dependency_security_checked(slice, ctx, _repo_at_base) {
   let rubric = "Block only when C build or dependency metadata changed, such as CMakeLists.txt, *.cmake, Makefile, *.mk, conanfile.txt, conanfile.py, vcpkg.json, meson.build, or C-targeted CI workflows, and the slice provides no evidence that vulnerability review was considered: NVD/CVE lookup, OSV, Dependabot, vendored-source pinning with documented update cadence, or a tool such as cargo-audit-style scanning for native deps. Allow pure source changes, formatting-only changes, and dependency changes that add or preserve a clear vulnerability-check path."
   let judgement = ctx.semantic_judge({rubric: rubric, files: c_project_files(slice)})

--- a/cpp/invariants.harn
+++ b/cpp/invariants.harn
@@ -129,7 +129,8 @@ fn cpp_files(slice) {
 }
 
 fn cpp_production_files(slice) {
-  return cpp_files(slice).filter(
+  return cpp_files(slice)
+    .filter(
     { file -> !is_test_path(file.path)
       && !is_third_party_path(file.path)
       && !is_example_or_bench_path(file.path) },
@@ -137,9 +138,8 @@ fn cpp_production_files(slice) {
 }
 
 fn cpp_header_files(slice) {
-  return slice.files.filter(
-    { file -> is_cpp_header_path(file.path) && !is_third_party_path(file.path) },
-  )
+  return slice.files
+    .filter({ file -> is_cpp_header_path(file.path) && !is_third_party_path(file.path) })
 }
 
 fn scan_files(files, pattern, flags) {
@@ -191,7 +191,9 @@ fn warn_on_findings(rule, remediation, findings) {
 @invariant
 @deterministic
 @archivist(evidence: _EVIDENCE_RAW_NEW_DELETE, confidence: 0.82, source_date: "2026-05-10")
-/** Blocks raw new and delete in production C++ paths in favor of smart pointers and RAII containers. */
+/**
+ * Blocks raw new and delete in production C++ paths in favor of smart pointers and RAII containers.
+ */
 pub fn no_raw_new_delete(slice, _ctx, _repo_at_base) {
   let findings = scan_files(
     cpp_production_files(slice),
@@ -210,11 +212,7 @@ pub fn no_raw_new_delete(slice, _ctx, _repo_at_base) {
 @archivist(evidence: _EVIDENCE_NAKED_MALLOC, confidence: 0.82, source_date: "2026-05-10")
 /** Blocks malloc/calloc/realloc/free in production C++ paths in favor of RAII allocations. */
 pub fn no_naked_malloc_free(slice, _ctx, _repo_at_base) {
-  let findings = scan_files(
-    cpp_production_files(slice),
-    r"\b(?:malloc|calloc|realloc|free)\s*\(",
-    "s",
-  )
+  let findings = scan_files(cpp_production_files(slice), r"\b(?:malloc|calloc|realloc|free)\s*\(", "s")
   return block_on_findings(
     "no_naked_malloc_free",
     "Replace malloc/calloc/realloc/free with std::vector, std::unique_ptr, or std::pmr allocators.",
@@ -262,11 +260,7 @@ pub fn header_include_guard_or_pragma_once(slice, _ctx, _repo_at_base) {
 @archivist(evidence: _EVIDENCE_USING_NAMESPACE_HEADER, confidence: 0.88, source_date: "2026-05-10")
 /** Blocks `using namespace` directives in C++ headers. */
 pub fn no_using_namespace_in_header(slice, _ctx, _repo_at_base) {
-  let findings = scan_files(
-    cpp_header_files(slice),
-    r"\busing\s+namespace\s+\S+\s*;",
-    "s",
-  )
+  let findings = scan_files(cpp_header_files(slice), r"\busing\s+namespace\s+\S+\s*;", "s")
   return block_on_findings(
     "no_using_namespace_in_header",
     "Remove `using namespace` from the header; restrict it to .cpp source or function-local scope so includers keep their lookup clean.",
@@ -296,11 +290,7 @@ pub fn no_c_style_cast_in_prod(slice, _ctx, _repo_at_base) {
 @archivist(evidence: _EVIDENCE_USING_OVER_TYPEDEF, confidence: 0.74, source_date: "2026-05-10")
 /** Warns when production C++ declares aliases with typedef instead of `using`. */
 pub fn prefer_using_over_typedef(slice, _ctx, _repo_at_base) {
-  let findings = scan_files(
-    cpp_production_files(slice),
-    r"(?m)^\s*typedef\s+",
-    "m",
-  )
+  let findings = scan_files(cpp_production_files(slice), r"(?m)^\s*typedef\s+", "m")
   return warn_on_findings(
     "prefer_using_over_typedef",
     "Use `using Alias = T;` instead of typedef; it reads left-to-right and supports template aliases.",
@@ -309,9 +299,11 @@ pub fn prefer_using_over_typedef(slice, _ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_raw_new_delete)
 @archivist(evidence: _EVIDENCE_RULE_OF_FIVE, confidence: 0.66, source_date: "2026-05-10")
-/** Blocks classes that declare some special member functions while leaving others implicit, violating the Rule of Five. */
+/**
+ * Blocks classes that declare some special member functions while leaving others implicit, violating the Rule of Five.
+ */
 pub fn rule_of_five_consistency(slice, ctx, _repo_at_base) {
   let rubric = "Block only when a changed C++ class definition declares one or more of the destructor, copy constructor, copy assignment operator, move constructor, or move assignment operator without explicitly declaring or =default/=delete the remaining special members. Allow classes that follow the Rule of Zero (no special members declared), classes whose remaining special members are inherited unchanged from a base that already declares them, and classes whose declaration carries a comment that documents why a specific member is intentionally implicit."
   let judgement = ctx.semantic_judge({rubric: rubric, files: cpp_production_files(slice)})
@@ -326,7 +318,7 @@ pub fn rule_of_five_consistency(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_raw_new_delete)
 @archivist(evidence: _EVIDENCE_MEMBER_INIT, confidence: 0.7, source_date: "2026-05-10")
 /** Blocks class members left without an in-class initializer or constructor initialization. */
 pub fn members_initialized(slice, ctx, _repo_at_base) {
@@ -343,9 +335,11 @@ pub fn members_initialized(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_raw_new_delete)
 @archivist(evidence: _EVIDENCE_CONST_CORRECTNESS, confidence: 0.6, source_date: "2026-05-10")
-/** Warns on public/protected member functions that do not modify *this but are not declared const. */
+/**
+ * Warns on public/protected member functions that do not modify *this but are not declared const.
+ */
 pub fn const_correctness_on_pub_api(slice, ctx, _repo_at_base) {
   let rubric = "Block only when a changed C++ public or protected non-static member function does not write to any non-mutable data member of *this and does not call any non-const member function on *this, yet its declaration omits the trailing const qualifier. Allow virtual overrides whose base class signature is non-const, methods that lock a non-mutable mutex or update non-mutable cache state, methods that return *this or a non-const reference to a member to outside callers, and call operators on stateful function objects whose contract is documented as non-const."
   let judgement = ctx.semantic_judge({rubric: rubric, files: cpp_production_files(slice)})

--- a/csharp/invariants.harn
+++ b/csharp/invariants.harn
@@ -319,7 +319,7 @@ pub fn no_console_write_in_prod_path(slice, _ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: nullable_reference_types_enabled)
 @archivist(evidence: _EVIDENCE_SQL_PARAMETERS, confidence: 0.68, source_date: "2026-05-08")
 /** Blocks SQL commands assembled with untrusted string interpolation or concatenation. */
 pub fn sql_commands_use_parameters(slice, ctx, _repo_at_base) {
@@ -336,7 +336,7 @@ pub fn sql_commands_use_parameters(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: nullable_reference_types_enabled)
 @archivist(evidence: _EVIDENCE_SECRETS, confidence: 0.68, source_date: "2026-05-08")
 /** Blocks hardcoded credentials, tokens, private keys, and production connection strings. */
 pub fn no_hardcoded_secrets(slice, ctx, _repo_at_base) {
@@ -353,7 +353,7 @@ pub fn no_hardcoded_secrets(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: nullable_reference_types_enabled)
 @archivist(evidence: _EVIDENCE_SENSITIVE_LOGS, confidence: 0.64, source_date: "2026-05-08")
 /** Blocks logging of secrets, authorization material, or sensitive user data. */
 pub fn no_sensitive_data_in_logs(slice, ctx, _repo_at_base) {

--- a/css/invariants.harn
+++ b/css/invariants.harn
@@ -206,7 +206,7 @@ pub fn font_size_uses_relative_units(slice, _ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_important_without_comment)
 @archivist(evidence: _EVIDENCE_FOCUS_INDICATOR, confidence: 0.66, source_date: "2026-05-09")
 /** Blocks suppressing the default focus outline without supplying a visible replacement. */
 pub fn accessible_focus_indicator(slice, ctx, _repo_at_base) {
@@ -223,7 +223,7 @@ pub fn accessible_focus_indicator(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_important_without_comment)
 @archivist(evidence: _EVIDENCE_REDUCED_MOTION, confidence: 0.62, source_date: "2026-05-09")
 /** Blocks new non-trivial animations or transitions that ignore `prefers-reduced-motion`. */
 pub fn respect_prefers_reduced_motion(slice, ctx, _repo_at_base) {

--- a/dart/invariants.harn
+++ b/dart/invariants.harn
@@ -268,7 +268,7 @@ pub fn no_relative_lib_imports(slice, _ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_null_safety_opt_out)
 @archivist(evidence: _EVIDENCE_IMMUTABLE_WIDGET, confidence: 0.66, source_date: "2026-05-10")
 /** Blocks Flutter Widget subclasses that hold mutable instance state. */
 pub fn widget_state_is_immutable(slice, ctx, _repo_at_base) {
@@ -285,7 +285,7 @@ pub fn widget_state_is_immutable(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_null_safety_opt_out)
 @archivist(evidence: _EVIDENCE_UNAWAITED_FUTURES, confidence: 0.62, source_date: "2026-05-10")
 /** Blocks discarded Futures inside async bodies without intentional fire-and-forget. */
 pub fn unawaited_futures_are_intentional(slice, ctx, _repo_at_base) {
@@ -302,7 +302,7 @@ pub fn unawaited_futures_are_intentional(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_null_safety_opt_out)
 @archivist(evidence: _EVIDENCE_EFFECTIVE_DART_DOCS, confidence: 0.6, source_date: "2026-05-10")
 /** Blocks new public Dart APIs in lib/ that lack /// doc comments. */
 pub fn effective_dart_documents_public_apis(slice, ctx, _repo_at_base) {

--- a/dockerfile/invariants.harn
+++ b/dockerfile/invariants.harn
@@ -292,7 +292,7 @@ pub fn use_exec_form_for_cmd_entrypoint(slice, _ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_latest_or_unpinned_base_image)
 @archivist(evidence: _EVIDENCE_MULTI_STAGE, confidence: 0.66, source_date: "2026-05-09")
 /** Blocks single-stage Dockerfiles that ship build toolchains into the runtime image. */
 pub fn multi_stage_build_preferred(slice, ctx, _repo_at_base) {
@@ -309,7 +309,7 @@ pub fn multi_stage_build_preferred(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_latest_or_unpinned_base_image)
 @archivist(evidence: _EVIDENCE_MINIMIZE_LAYERS, confidence: 0.6, source_date: "2026-05-09")
 /** Warns when consecutive RUN steps could be merged to shrink the image and cache surface. */
 pub fn minimize_layer_count(slice, ctx, _repo_at_base) {

--- a/elixir/invariants.harn
+++ b/elixir/invariants.harn
@@ -1,7 +1,4 @@
-let _EVIDENCE_DEBUG_HELPERS = [
-  "https://hexdocs.pm/credo/Credo.Check.Warning.IoInspect.html",
-  "https://hexdocs.pm/elixir/IO.html",
-]
+let _EVIDENCE_DEBUG_HELPERS = ["https://hexdocs.pm/credo/Credo.Check.Warning.IoInspect.html", "https://hexdocs.pm/elixir/IO.html"]
 
 let _EVIDENCE_DBG_MACRO = [
   "https://hexdocs.pm/credo/Credo.Check.Warning.Dbg.html",
@@ -141,11 +138,7 @@ pub fn no_io_inspect(slice, _ctx, _repo_at_base) {
 @archivist(evidence: _EVIDENCE_DBG_MACRO, confidence: 0.84, source_date: "2026-05-10")
 /** Blocks dbg/0 and dbg/1 calls left in production Elixir source. */
 pub fn no_dbg_macro(slice, _ctx, _repo_at_base) {
-  let findings = scan_files(
-    production_elixir_files(slice),
-    r"(?m)(^|[^\w\.:])dbg\s*\(",
-    "m",
-  )
+  let findings = scan_files(production_elixir_files(slice), r"(?m)(^|[^\w\.:])dbg\s*\(", "m")
   return block_on_findings(
     "no_dbg_macro",
     "Remove dbg/0 and dbg/1 calls before merging; they are interactive-debug tooling, not production logging.",
@@ -158,11 +151,7 @@ pub fn no_dbg_macro(slice, _ctx, _repo_at_base) {
 @archivist(evidence: _EVIDENCE_IEX_PRY, confidence: 0.86, source_date: "2026-05-10")
 /** Blocks IEx.pry breakpoints in production Elixir source. */
 pub fn no_iex_pry(slice, _ctx, _repo_at_base) {
-  let findings = scan_files(
-    production_elixir_files(slice),
-    r"\bIEx\.pry\s*\(\s*\)|\brequire\s+IEx\b",
-    "s",
-  )
+  let findings = scan_files(production_elixir_files(slice), r"\bIEx\.pry\s*\(\s*\)|\brequire\s+IEx\b", "s")
   return block_on_findings(
     "no_iex_pry",
     "Remove IEx.pry breakpoints and the matching require IEx before merging; they only work in an attached IEx shell.",
@@ -209,11 +198,7 @@ pub fn unless_with_else(slice, _ctx, _repo_at_base) {
 @archivist(evidence: _EVIDENCE_PREDICATE_NAMING, confidence: 0.78, source_date: "2026-05-10")
 /** Warns when a function is named with both the is_ prefix and a trailing question mark. */
 pub fn predicate_function_naming(slice, _ctx, _repo_at_base) {
-  let findings = scan_files(
-    production_elixir_files(slice),
-    r"(?m)^\s*defp?\s+is_[A-Za-z0-9_]+\?",
-    "m",
-  )
+  let findings = scan_files(production_elixir_files(slice), r"(?m)^\s*defp?\s+is_[A-Za-z0-9_]+\?", "m")
   return warn_on_findings(
     "predicate_function_naming",
     "Pick one form: end the name with ? for runtime predicates, or use the is_ prefix for guard-safe macros, but not both.",
@@ -243,11 +228,7 @@ pub fn no_raise_inside_rescue(slice, _ctx, _repo_at_base) {
 @archivist(evidence: _EVIDENCE_PIPE_READABILITY, confidence: 0.66, source_date: "2026-05-10")
 /** Warns on pipe chains longer than five stages without an intermediate binding. */
 pub fn pipe_chain_readability(slice, _ctx, _repo_at_base) {
-  let findings = scan_files(
-    production_elixir_files(slice),
-    r"(?m)(?:^[ \t]*\|>[^\n]*\n){6,}",
-    "m",
-  )
+  let findings = scan_files(production_elixir_files(slice), r"(?m)(?:^[ \t]*\|>[^\n]*\n){6,}", "m")
   return warn_on_findings(
     "pipe_chain_readability",
     "Break long pipelines with a named intermediate or a small private function so the steps remain greppable and debuggable.",
@@ -256,9 +237,11 @@ pub fn pipe_chain_readability(slice, _ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_io_inspect)
 @archivist(evidence: _EVIDENCE_TAGGED_ERROR_TUPLES, confidence: 0.64, source_date: "2026-05-10")
-/** Blocks public functions that signal failure with bare atoms or strings instead of tagged error tuples. */
+/**
+ * Blocks public functions that signal failure with bare atoms or strings instead of tagged error tuples.
+ */
 pub fn tagged_error_tuples(slice, ctx, _repo_at_base) {
   let rubric = "Block only when a public Elixir function (def, not defp) added or changed in this slice signals fallible outcomes by returning :error, an arbitrary atom, a string, or nil where the rest of the module's public API uses {:ok, value} and {:error, reason} tuples or a bang variant. Allow boolean predicates ending in ?, functions whose contract is documented as returning :ok or an atom enum, callbacks that must conform to a behaviour, and bang functions that intentionally raise."
   let judgement = ctx.semantic_judge({rubric: rubric, files: production_elixir_files(slice)})
@@ -273,7 +256,7 @@ pub fn tagged_error_tuples(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_io_inspect)
 @archivist(evidence: _EVIDENCE_GENSERVER_BOUNDARY, confidence: 0.6, source_date: "2026-05-10")
 /** Blocks GenServer callbacks that leak fresh internal state types across the call boundary. */
 pub fn genserver_callback_boundary(slice, ctx, _repo_at_base) {
@@ -290,9 +273,11 @@ pub fn genserver_callback_boundary(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_io_inspect)
 @archivist(evidence: _EVIDENCE_PATTERN_MATCH, confidence: 0.62, source_date: "2026-05-10")
-/** Warns when a function body is a single case or cond that could be replaced by function-head pattern matching. */
+/**
+ * Warns when a function body is a single case or cond that could be replaced by function-head pattern matching.
+ */
 pub fn pattern_match_over_conditional(slice, ctx, _repo_at_base) {
   let rubric = "Warn only when an added or changed Elixir function body is a single case or cond expression that branches directly on the function's own arguments, where each branch could be expressed as a separate function clause with pattern matching or guards over the same arguments. Allow case or cond statements that branch on intermediate computations, that need shared setup before the branching, that share substantial code across branches, or that benefit from a default catch-all in one place."
   let judgement = ctx.semantic_judge({rubric: rubric, files: production_elixir_files(slice)})

--- a/go/invariants.harn
+++ b/go/invariants.harn
@@ -347,7 +347,7 @@ pub fn no_math_rand_for_keys(slice, _ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_ignored_errors)
 @archivist(evidence: _EVIDENCE_GOROUTINE_LEAKS, confidence: 0.62, source_date: "2026-05-08")
 /** Blocks long-lived goroutines that lack cancellation or shutdown evidence. */
 pub fn goroutine_leak_guard(slice, ctx, _repo_at_base) {
@@ -364,7 +364,7 @@ pub fn goroutine_leak_guard(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_ignored_errors)
 @archivist(evidence: _EVIDENCE_DEP_SECURITY, confidence: 0.64, source_date: "2026-05-08")
 /** Blocks Go dependency changes that omit vulnerability-check evidence. */
 pub fn go_dependency_vulns_checked(slice, ctx, _repo_at_base) {

--- a/graphql/invariants.harn
+++ b/graphql/invariants.harn
@@ -199,7 +199,7 @@ pub fn pagination_args_on_root_list_fields(slice, _ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: enum_values_upper_snake_case)
 @archivist(evidence: _EVIDENCE_BREAKING, confidence: 0.7, source_date: "2026-05-09")
 /** Blocks schema changes that break existing clients without an aliasing or migration path. */
 pub fn no_breaking_schema_change(slice, ctx, _repo_at_base) {
@@ -216,7 +216,7 @@ pub fn no_breaking_schema_change(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: enum_values_upper_snake_case)
 @archivist(evidence: _EVIDENCE_DEPRECATION, confidence: 0.7, source_date: "2026-05-09")
 /** Blocks removal of public schema elements that were not first marked @deprecated. */
 pub fn deprecation_over_removal(slice, ctx, _repo_at_base) {
@@ -233,7 +233,7 @@ pub fn deprecation_over_removal(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: enum_values_upper_snake_case)
 @archivist(evidence: _EVIDENCE_DEPTH_LIMIT, confidence: 0.6, source_date: "2026-05-09")
 /** Blocks new public GraphQL endpoints that lack a query depth or complexity limit. */
 pub fn query_depth_limit_enforced(slice, ctx, _repo_at_base) {

--- a/harn/invariants.harn
+++ b/harn/invariants.harn
@@ -307,7 +307,7 @@ pub fn oauth_redirect_uris_are_https_or_loopback(slice, _ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: llm_call_schema_sets_schema_retries)
 @archivist(evidence: _EVIDENCE_PROMPT_SECRETS, confidence: 0.67, source_date: "2026-04-26")
 /** Blocks prompts that embed secrets or sensitive customer data. */
 pub fn llm_prompts_do_not_embed_secrets(slice, ctx, _repo_at_base) {
@@ -324,7 +324,7 @@ pub fn llm_prompts_do_not_embed_secrets(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: llm_call_schema_sets_schema_retries)
 @archivist(evidence: _EVIDENCE_OAUTH_REDACTION, confidence: 0.68, source_date: "2026-05-19")
 /** Blocks OAuth client secrets and tokens from audit, transcript, log, or span payloads. */
 pub fn oauth_audit_payloads_redact_tokens(slice, ctx, _repo_at_base) {
@@ -341,7 +341,7 @@ pub fn oauth_audit_payloads_redact_tokens(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: llm_call_schema_sets_schema_retries)
 @archivist(evidence: _EVIDENCE_ACP_SIDE_EFFECTS, confidence: 0.64, source_date: "2026-04-26")
 /** Blocks ACP tool metadata that understates real side effects. */
 pub fn acp_tool_side_effects_are_honest(slice, ctx, _repo_at_base) {

--- a/haskell/invariants.harn
+++ b/haskell/invariants.harn
@@ -56,13 +56,20 @@ fn is_haskell_path(path) {
 
 fn is_test_path(path) {
   return path.starts_with("test/") || path.contains("/test/")
-    || path.starts_with("tests/") || path.contains("/tests/")
-    || path.starts_with("spec/") || path.contains("/spec/")
-    || path.starts_with("bench/") || path.contains("/bench/")
-    || path.starts_with("benches/") || path.contains("/benches/")
-    || path.starts_with("examples/") || path.contains("/examples/")
-    || path.ends_with("Spec.hs") || path.ends_with("Test.hs")
-    || path.ends_with("_spec.hs") || path.ends_with("_test.hs")
+    || path.starts_with("tests/")
+    || path.contains("/tests/")
+    || path.starts_with("spec/")
+    || path.contains("/spec/")
+    || path.starts_with("bench/")
+    || path.contains("/bench/")
+    || path.starts_with("benches/")
+    || path.contains("/benches/")
+    || path.starts_with("examples/")
+    || path.contains("/examples/")
+    || path.ends_with("Spec.hs")
+    || path.ends_with("Test.hs")
+    || path.ends_with("_spec.hs")
+    || path.ends_with("_test.hs")
 }
 
 fn is_internal_path(path) {
@@ -122,7 +129,9 @@ fn warn_on_findings(rule, remediation, findings) {
 @invariant
 @deterministic
 @archivist(evidence: _EVIDENCE_PARTIAL_FUNCTIONS, confidence: 0.78, source_date: "2026-05-10")
-/** Blocks Prelude partial functions (head, tail, init, last, fromJust, !!) in non-Internal production modules. */
+/**
+ * Blocks Prelude partial functions (head, tail, init, last, fromJust, !!) in non-Internal production modules.
+ */
 pub fn no_partial_functions_in_pub_api(slice, _ctx, _repo_at_base) {
   let findings = scan_files(
     pub_api_haskell_files(slice),
@@ -156,13 +165,11 @@ pub fn no_undefined_in_prod(slice, _ctx, _repo_at_base) {
 @invariant
 @deterministic
 @archivist(evidence: _EVIDENCE_ERROR_CALL, confidence: 0.7, source_date: "2026-05-10")
-/** Warns when production modules call `error` instead of returning Either or throwing a typed exception. */
+/**
+ * Warns when production modules call `error` instead of returning Either or throwing a typed exception.
+ */
 pub fn no_error_call_in_prod(slice, _ctx, _repo_at_base) {
-  let findings = scan_files(
-    production_haskell_files(slice),
-    r"(?:^|[^A-Za-z0-9_'.])error(?:[^A-Za-z0-9_']|$)",
-    "m",
-  )
+  let findings = scan_files(production_haskell_files(slice), r"(?:^|[^A-Za-z0-9_'.])error(?:[^A-Za-z0-9_']|$)", "m")
   return warn_on_findings(
     "no_error_call_in_prod",
     "Return Either/Maybe or throw a typed exception via Control.Exception (throwIO) instead of error.",
@@ -192,11 +199,7 @@ pub fn no_unsafe_perform_io(slice, _ctx, _repo_at_base) {
 @archivist(evidence: _EVIDENCE_EXPLICIT_IMPORTS, confidence: 0.7, source_date: "2026-05-10")
 /** Warns on open imports — imports without `qualified` and without an explicit import list. */
 pub fn explicit_imports(slice, _ctx, _repo_at_base) {
-  let findings = scan_files(
-    production_haskell_files(slice),
-    r"(?m)^import\s+[A-Z][\w\.]*(?:\s+as\s+\w+)?\s*$",
-    "m",
-  )
+  let findings = scan_files(production_haskell_files(slice), r"(?m)^import\s+[A-Z][\w\.]*(?:\s+as\s+\w+)?\s*$", "m")
   return warn_on_findings(
     "explicit_imports",
     "Add an explicit import list, e.g. `import Data.Map (Map, lookup)`, or qualify the import to keep the namespace stable.",
@@ -209,11 +212,7 @@ pub fn explicit_imports(slice, _ctx, _repo_at_base) {
 @archivist(evidence: _EVIDENCE_EXPLICIT_EXPORT, confidence: 0.74, source_date: "2026-05-10")
 /** Warns when modules omit an explicit export list before `where`. */
 pub fn explicit_export_list(slice, _ctx, _repo_at_base) {
-  let findings = scan_files(
-    production_haskell_files(slice),
-    r"(?m)^module\s+[A-Z][\w\.]*\s+where\b",
-    "m",
-  )
+  let findings = scan_files(production_haskell_files(slice), r"(?m)^module\s+[A-Z][\w\.]*\s+where\b", "m")
   return warn_on_findings(
     "explicit_export_list",
     "Add an explicit export list to the module header so the public surface is documented and reviewable.",
@@ -239,9 +238,11 @@ pub fn prefer_newtype_for_single_field(slice, _ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_partial_functions_in_pub_api)
 @archivist(evidence: _EVIDENCE_TOTAL_FUNCTIONS, confidence: 0.62, source_date: "2026-05-10")
-/** Blocks production functions that pattern-match non-exhaustively without a documented partial contract. */
+/**
+ * Blocks production functions that pattern-match non-exhaustively without a documented partial contract.
+ */
 pub fn total_function_semantic_check(slice, ctx, _repo_at_base) {
   let rubric = "Block only when changed Haskell production code introduces a function whose pattern matches are non-exhaustive — for example, list patterns missing the empty case, Maybe patterns missing Nothing, sum-type patterns missing constructors, lambda-case clauses missing variants, or `head`/`fromJust`-style partial helpers — and the function lacks a Haddock comment, MonadFail context, or other clear documentation that the partiality is intentional. Allow exhaustive matches, GADT/refinement-driven coverage, intentionally partial Internal helpers, and matches whose missing branches are statically impossible."
   let judgement = ctx.semantic_judge({rubric: rubric, files: production_haskell_files(slice)})
@@ -256,9 +257,11 @@ pub fn total_function_semantic_check(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_partial_functions_in_pub_api)
 @archivist(evidence: _EVIDENCE_ORPHAN_INSTANCES, confidence: 0.66, source_date: "2026-05-10")
-/** Blocks orphan typeclass instances — instances declared in a module that defines neither the class nor the type. */
+/**
+ * Blocks orphan typeclass instances — instances declared in a module that defines neither the class nor the type.
+ */
 pub fn no_orphan_instances(slice, ctx, _repo_at_base) {
   let rubric = "Block only when a changed Haskell module declares a typeclass instance and the slice shows that neither the class nor the head type constructor is defined in this module or its package. Allow newtype-wrapper instances declared alongside the wrapper, and instances that the module clearly owns. The judge may rely on imports and module headers as evidence."
   let judgement = ctx.semantic_judge({rubric: rubric, files: haskell_files(slice)})
@@ -273,7 +276,7 @@ pub fn no_orphan_instances(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_partial_functions_in_pub_api)
 @archivist(evidence: _EVIDENCE_SECRETS, confidence: 0.7, source_date: "2026-05-10")
 /** Blocks hardcoded credentials, tokens, and other long-lived secrets in Haskell source. */
 pub fn no_hardcoded_secrets(slice, ctx, _repo_at_base) {

--- a/html/invariants.harn
+++ b/html/invariants.harn
@@ -223,7 +223,7 @@ pub fn target_blank_uses_rel_noopener(slice, _ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: images_have_alt_text)
 @archivist(evidence: _EVIDENCE_FORM_LABELS, confidence: 0.66, source_date: "2026-05-09")
 /**
  * Blocks form controls that lack an accessible name from a label, aria-label, or aria-labelledby.
@@ -242,7 +242,7 @@ pub fn form_controls_have_accessible_names(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: images_have_alt_text)
 @archivist(evidence: _EVIDENCE_LINK_PURPOSE, confidence: 0.58, source_date: "2026-05-09")
 /**
  * Blocks generic anchor text such as "click here" or "read more" without disambiguating context.

--- a/java/invariants.harn
+++ b/java/invariants.harn
@@ -243,7 +243,7 @@ pub fn optional_returns_are_not_null(slice, _ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_raw_collection_types)
 @archivist(evidence: _EVIDENCE_SQL, confidence: 0.66, source_date: "2026-05-08")
 /** Blocks JDBC SQL built from untrusted string concatenation without bind parameters. */
 pub fn jdbc_queries_use_parameters(slice, ctx, _repo_at_base) {
@@ -260,7 +260,7 @@ pub fn jdbc_queries_use_parameters(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_raw_collection_types)
 @archivist(evidence: _EVIDENCE_SECRETS, confidence: 0.68, source_date: "2026-05-08")
 /** Blocks hardcoded credentials, tokens, and private keys in Java source. */
 pub fn no_hardcoded_secrets(slice, ctx, _repo_at_base) {

--- a/javascript/invariants.harn
+++ b/javascript/invariants.harn
@@ -238,7 +238,7 @@ pub fn no_implicit_globals(slice, _ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_floating_promises)
 @archivist(evidence: _EVIDENCE_RUNTIME_VALIDATION, confidence: 0.64, source_date: "2026-05-08")
 /** Blocks external data being trusted as domain data without runtime validation. */
 pub fn runtime_validate_external_data(slice, ctx, _repo_at_base) {
@@ -255,7 +255,7 @@ pub fn runtime_validate_external_data(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_floating_promises)
 @archivist(evidence: _EVIDENCE_SECRETS, confidence: 0.69, source_date: "2026-05-08")
 /** Blocks hardcoded credentials, tokens, and private keys in JavaScript source. */
 pub fn no_hardcoded_secrets(slice, ctx, _repo_at_base) {
@@ -272,7 +272,7 @@ pub fn no_hardcoded_secrets(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_floating_promises)
 @archivist(evidence: _EVIDENCE_SENSITIVE_LOGS, confidence: 0.64, source_date: "2026-05-08")
 /** Blocks logging of secrets, credentials, tokens, or sensitive user data. */
 pub fn no_sensitive_data_in_logs(slice, ctx, _repo_at_base) {

--- a/json/invariants.harn
+++ b/json/invariants.harn
@@ -1,17 +1,11 @@
-let _EVIDENCE_TRAILING_COMMAS = [
-  "https://www.rfc-editor.org/rfc/rfc8259#section-5",
-  "https://www.json.org/json-en.html",
-]
+let _EVIDENCE_TRAILING_COMMAS = ["https://www.rfc-editor.org/rfc/rfc8259#section-5", "https://www.json.org/json-en.html"]
 
 let _EVIDENCE_NO_COMMENTS = [
   "https://www.rfc-editor.org/rfc/rfc8259#section-12",
   "https://code.visualstudio.com/docs/languages/json#_json-with-comments",
 ]
 
-let _EVIDENCE_DOUBLE_QUOTED_STRINGS = [
-  "https://www.rfc-editor.org/rfc/rfc8259#section-7",
-  "https://www.json.org/json-en.html",
-]
+let _EVIDENCE_DOUBLE_QUOTED_STRINGS = ["https://www.rfc-editor.org/rfc/rfc8259#section-7", "https://www.json.org/json-en.html"]
 
 let _EVIDENCE_BOM = [
   "https://www.rfc-editor.org/rfc/rfc8259#section-8.1",
@@ -122,11 +116,7 @@ pub fn no_trailing_commas(slice, _ctx, _repo_at_base) {
 @archivist(evidence: _EVIDENCE_NO_COMMENTS, confidence: 0.78, source_date: "2026-05-09")
 /** Blocks JSONC-style comment markers in strict .json files; .jsonc and .json5 are exempt. */
 pub fn no_comments_in_json(slice, _ctx, _repo_at_base) {
-  let findings = scan_files(
-    strict_json_files(slice),
-    r"(?m)((^\s*)|([\}\],]\s*))(//|/\*)",
-    "m",
-  )
+  let findings = scan_files(strict_json_files(slice), r"(?m)((^\s*)|([\}\],]\s*))(//|/\*)", "m")
   return block_on_findings(
     "no_comments_in_json",
     "Remove the comment; rename the file to .jsonc or .json5 if comments are required.",
@@ -137,13 +127,11 @@ pub fn no_comments_in_json(slice, _ctx, _repo_at_base) {
 @invariant
 @deterministic
 @archivist(evidence: _EVIDENCE_DOUBLE_QUOTED_STRINGS, confidence: 0.84, source_date: "2026-05-15")
-/** Blocks single-quoted strings in strict .json files; JSON strings must use double quotation marks. */
+/**
+ * Blocks single-quoted strings in strict .json files; JSON strings must use double quotation marks.
+ */
 pub fn strings_use_double_quotes(slice, _ctx, _repo_at_base) {
-  let findings = scan_files(
-    strict_json_files(slice),
-    r"(?m)(?:^|[\{\[,:])\s*'[^'\n]*'",
-    "m",
-  )
+  let findings = scan_files(strict_json_files(slice), r"(?m)(?:^|[\{\[,:])\s*'[^'\n]*'", "m")
   return block_on_findings(
     "strings_use_double_quotes",
     "Use double quotes for JSON object keys and string values; single quotes are JSON5, not strict JSON.",
@@ -169,11 +157,7 @@ pub fn no_bom_prefix(slice, _ctx, _repo_at_base) {
 @archivist(evidence: _EVIDENCE_NAN_INFINITY, confidence: 0.78, source_date: "2026-05-09")
 /** Blocks NaN, Infinity, and -Infinity literals, which the JSON grammar does not define. */
 pub fn no_nan_or_infinity_literals(slice, _ctx, _repo_at_base) {
-  let findings = scan_files(
-    all_json_files(slice),
-    r"(?m)[:\[,]\s*-?\s*(NaN|Infinity)\b",
-    "m",
-  )
+  let findings = scan_files(all_json_files(slice), r"(?m)[:\[,]\s*-?\s*(NaN|Infinity)\b", "m")
   return block_on_findings(
     "no_nan_or_infinity_literals",
     "Replace NaN or Infinity with null, a sentinel string, or a documented numeric bound.",
@@ -182,7 +166,7 @@ pub fn no_nan_or_infinity_literals(slice, _ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_trailing_commas)
 @archivist(evidence: _EVIDENCE_SECRETS, confidence: 0.68, source_date: "2026-05-09")
 /** Blocks credentials, tokens, and private keys committed in JSON values. */
 pub fn no_hardcoded_secrets(slice, ctx, _repo_at_base) {
@@ -199,7 +183,7 @@ pub fn no_hardcoded_secrets(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_trailing_commas)
 @archivist(evidence: _EVIDENCE_SCHEMA, confidence: 0.66, source_date: "2026-05-09")
 /** Blocks JSON files that declare a $schema reference but introduce values that violate it. */
 pub fn respects_declared_schema(slice, ctx, _repo_at_base) {
@@ -216,7 +200,7 @@ pub fn respects_declared_schema(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_trailing_commas)
 @archivist(evidence: _EVIDENCE_KEY_ORDER, confidence: 0.6, source_date: "2026-05-09")
 /** Warns when config-shaped JSON edits gratuitously reorder unrelated keys. */
 pub fn stable_key_ordering(slice, ctx, _repo_at_base) {

--- a/kotlin/invariants.harn
+++ b/kotlin/invariants.harn
@@ -275,7 +275,7 @@ pub fn no_broad_detekt_suppressions(slice, _ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_bang_bang)
 @archivist(evidence: _EVIDENCE_NULL_SAFETY, confidence: 0.64, source_date: "2026-05-08")
 /** Blocks public Kotlin APIs that expose Java platform types without a nullability contract. */
 pub fn no_platform_types_in_public_api(slice, ctx, _repo_at_base) {
@@ -292,7 +292,7 @@ pub fn no_platform_types_in_public_api(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_bang_bang)
 @archivist(evidence: _EVIDENCE_ANDROID_COROUTINES, confidence: 0.62, source_date: "2026-05-08")
 /** Blocks new async APIs that should be suspend-first. */
 pub fn suspend_for_async(slice, ctx, _repo_at_base) {
@@ -309,7 +309,7 @@ pub fn suspend_for_async(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_bang_bang)
 @archivist(evidence: _EVIDENCE_ANDROID_COROUTINES, confidence: 0.6, source_date: "2026-05-08")
 /** Blocks main-thread blocking work in Android or UI-adjacent Kotlin code. */
 pub fn no_main_thread_blocking_work(slice, ctx, _repo_at_base) {

--- a/lua/invariants.harn
+++ b/lua/invariants.harn
@@ -41,10 +41,7 @@ let _EVIDENCE_REQUIRE_LOCAL = [
   "http://lua-users.org/wiki/ModulesTutorial",
 ]
 
-let _EVIDENCE_TAIL_CALLS = [
-  "https://www.lua.org/manual/5.4/manual.html#3.4.10",
-  "https://www.lua.org/pil/6.3.html",
-]
+let _EVIDENCE_TAIL_CALLS = ["https://www.lua.org/manual/5.4/manual.html#3.4.10", "https://www.lua.org/pil/6.3.html"]
 
 let _EVIDENCE_METATABLES = [
   "https://www.lua.org/manual/5.4/manual.html#2.4",
@@ -149,11 +146,7 @@ fn warn_on_findings(rule, remediation, findings) {
 @archivist(evidence: _EVIDENCE_GLOBAL_FUNCTION, confidence: 0.78, source_date: "2026-05-10")
 /** Blocks top-level `function name(...)` definitions that create implicit globals. */
 pub fn no_global_function_definition(slice, _ctx, _repo_at_base) {
-  let findings = scan_files(
-    production_lua_files(slice),
-    r"(?m)^[ \t]*function\s+[A-Za-z_][A-Za-z0-9_]*\s*\(",
-    "m",
-  )
+  let findings = scan_files(production_lua_files(slice), r"(?m)^[ \t]*function\s+[A-Za-z_][A-Za-z0-9_]*\s*\(", "m")
   return block_on_findings(
     "no_global_function_definition",
     "Use `local function name(...)` or attach the function to a module table (`function M.name(...)`).",
@@ -198,13 +191,11 @@ pub fn no_loadstring_or_loadfile(slice, _ctx, _repo_at_base) {
 @invariant
 @deterministic
 @archivist(evidence: _EVIDENCE_SETFENV_GETFENV, confidence: 0.88, source_date: "2026-05-10")
-/** Blocks setfenv/getfenv usage that was removed in Lua 5.2 and is unavailable on modern runtimes. */
+/**
+ * Blocks setfenv/getfenv usage that was removed in Lua 5.2 and is unavailable on modern runtimes.
+ */
 pub fn no_setfenv_or_getfenv(slice, _ctx, _repo_at_base) {
-  let findings = scan_files(
-    lua_files(slice),
-    r"(?m)(^|[^A-Za-z0-9_.:])(setfenv|getfenv)\s*\(",
-    "m",
-  )
+  let findings = scan_files(lua_files(slice), r"(?m)(^|[^A-Za-z0-9_.:])(setfenv|getfenv)\s*\(", "m")
   return block_on_findings(
     "no_setfenv_or_getfenv",
     "Use the Lua 5.2+ `_ENV` upvalue or an explicit environment table; setfenv/getfenv were removed.",
@@ -250,11 +241,7 @@ pub fn module_returns_value(slice, _ctx, _repo_at_base) {
 @archivist(evidence: _EVIDENCE_REQUIRE_LOCAL, confidence: 0.7, source_date: "2026-05-10")
 /** Warns on `require` calls at top-level that are not assigned to a local binding. */
 pub fn require_assigned_to_local(slice, _ctx, _repo_at_base) {
-  let findings = scan_files(
-    production_lua_files(slice),
-    "(?m)^[ \\t]*require\\s*[\\(\"'\\[]",
-    "m",
-  )
+  let findings = scan_files(production_lua_files(slice), "(?m)^[ \\t]*require\\s*[\\(\"'\\[]", "m")
   return warn_on_findings(
     "require_assigned_to_local",
     "Bind require results to a local: `local mod = require('mod')`; bare `require` calls leak through package.loaded only.",
@@ -263,7 +250,7 @@ pub fn require_assigned_to_local(slice, _ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_global_function_definition)
 @archivist(evidence: _EVIDENCE_TAIL_CALLS, confidence: 0.6, source_date: "2026-05-10")
 /** Warns on recursive Lua functions whose recursive call is not in tail position. */
 pub fn tail_call_recursion(slice, ctx, _repo_at_base) {
@@ -280,9 +267,11 @@ pub fn tail_call_recursion(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_global_function_definition)
 @archivist(evidence: _EVIDENCE_METATABLES, confidence: 0.62, source_date: "2026-05-10")
-/** Blocks metatable mutations that change reads, writes, or identity without an adjacent comment. */
+/**
+ * Blocks metatable mutations that change reads, writes, or identity without an adjacent comment.
+ */
 pub fn metatable_boundary_documented(slice, ctx, _repo_at_base) {
   let rubric = "Block only when changed Lua source assigns to a metatable field that crosses a behavior boundary — `__index`, `__newindex`, `__metatable`, `__call`, `__eq`, `__lt`, `__le`, `__add`, `__concat`, `__tostring`, or `__gc` — without an adjacent comment, docstring, or annotation that names the target type and explains the new behavior. Allow purely additive helper assignments inside a class-builder helper that already documents the pattern."
   let judgement = ctx.semantic_judge({rubric: rubric, files: lua_files(slice)})
@@ -297,7 +286,7 @@ pub fn metatable_boundary_documented(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_global_function_definition)
 @archivist(evidence: _EVIDENCE_SECRETS, confidence: 0.68, source_date: "2026-05-10")
 /** Blocks hardcoded credentials and high-risk secrets in Lua source. */
 pub fn no_hardcoded_secrets(slice, ctx, _repo_at_base) {

--- a/markdown/invariants.harn
+++ b/markdown/invariants.harn
@@ -203,7 +203,7 @@ pub fn no_dangerous_inline_html(slice, _ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: code_fence_language_specified)
 @archivist(evidence: _EVIDENCE_BROKEN_LINKS, confidence: 0.66, source_date: "2026-05-09")
 /** Blocks changed Markdown that introduces relative links or anchors with no resolvable target. */
 pub fn no_broken_internal_links(slice, ctx, _repo_at_base) {
@@ -220,7 +220,7 @@ pub fn no_broken_internal_links(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: code_fence_language_specified)
 @archivist(evidence: _EVIDENCE_LINK_STYLE, confidence: 0.6, source_date: "2026-05-09")
 /**
  * Warns when a single document mixes inline, reference, and bare-URL link styles in ways that hurt readability.

--- a/php/invariants.harn
+++ b/php/invariants.harn
@@ -289,7 +289,7 @@ pub fn no_debug_dump_in_prod(slice, _ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: declare_strict_types_enforced)
 @archivist(evidence: _EVIDENCE_PARAMETERIZED, confidence: 0.66, source_date: "2026-05-10")
 /** Blocks SQL built by interpolating user-controlled values into the query text. */
 pub fn prepared_statements_only(slice, ctx, _repo_at_base) {
@@ -306,7 +306,7 @@ pub fn prepared_statements_only(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: declare_strict_types_enforced)
 @archivist(evidence: _EVIDENCE_SECRETS, confidence: 0.66, source_date: "2026-05-10")
 /** Blocks hardcoded credentials and high-risk secrets in PHP source. */
 pub fn no_hardcoded_secrets(slice, ctx, _repo_at_base) {
@@ -323,7 +323,7 @@ pub fn no_hardcoded_secrets(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: declare_strict_types_enforced)
 @archivist(evidence: _EVIDENCE_UNSERIALIZE, confidence: 0.7, source_date: "2026-05-10")
 /** Blocks unserialize() calls on data that may originate from untrusted input. */
 pub fn unserialize_input_is_trusted(slice, ctx, _repo_at_base) {

--- a/protobuf/invariants.harn
+++ b/protobuf/invariants.harn
@@ -152,7 +152,11 @@ pub fn no_required_in_proto3(slice, _ctx, _repo_at_base) {
   let findings = scan_files_if(
     first_party_proto_files(slice),
     { file -> regex_match("(?m)^\\s*syntax\\s*=\\s*\"proto3\"\\s*;", file.text, "m") != nil
-      && regex_match(r"(?m)^\s*required\s+[A-Za-z_][A-Za-z0-9_.]*\s+[A-Za-z_][A-Za-z0-9_]*\s*=\s*\d+", file.text, "m")
+      && regex_match(
+      r"(?m)^\s*required\s+[A-Za-z_][A-Za-z0-9_.]*\s+[A-Za-z_][A-Za-z0-9_]*\s*=\s*\d+",
+      file.text,
+      "m",
+    )
       != nil },
   )
   return block_on_findings(
@@ -224,7 +228,7 @@ pub fn no_reserved_field_number_range(slice, _ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: explicit_syntax_version)
 @archivist(evidence: _EVIDENCE_FIELD_RENUMBER, confidence: 0.7, source_date: "2026-05-09")
 /** Blocks renumbered or repurposed field tags that would break wire compatibility. */
 pub fn no_field_number_renumbering(slice, ctx, _repo_at_base) {
@@ -241,9 +245,11 @@ pub fn no_field_number_renumbering(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: explicit_syntax_version)
 @archivist(evidence: _EVIDENCE_RESERVED_ON_DELETE, confidence: 0.72, source_date: "2026-05-09")
-/** Blocks field deletions that omit a matching reserved declaration for the freed number or name. */
+/**
+ * Blocks field deletions that omit a matching reserved declaration for the freed number or name.
+ */
 pub fn reserved_on_field_removal(slice, ctx, _repo_at_base) {
   let rubric = "Block only when changed .proto files remove a field from an existing message without adding a reserved entry that covers the removed field number and the removed field name. Allow removals that add the matching reserved declaration, removals from messages that have never been deployed, and additive changes."
   let judgement = ctx.semantic_judge({rubric: rubric, files: first_party_proto_files(slice)})

--- a/python/invariants.harn
+++ b/python/invariants.harn
@@ -236,7 +236,7 @@ pub fn no_assert_in_prod_path(slice, _ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_bare_except)
 @archivist(evidence: _EVIDENCE_SQL_PARAMETERS, confidence: 0.66, source_date: "2026-04-30")
 /** Blocks SQL assembled with user-controlled string interpolation. */
 pub fn sql_queries_use_parameters(slice, ctx, _repo_at_base) {
@@ -253,7 +253,7 @@ pub fn sql_queries_use_parameters(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_bare_except)
 @archivist(evidence: _EVIDENCE_SOURCE_SECRETS, confidence: 0.64, source_date: "2026-04-30")
 /** Blocks hardcoded credentials and high-risk secrets in Python source. */
 pub fn secrets_not_hardcoded_in_source(slice, ctx, _repo_at_base) {

--- a/r/invariants.harn
+++ b/r/invariants.harn
@@ -161,11 +161,7 @@ fn warn_on_findings(rule, remediation, findings) {
 @archivist(evidence: _EVIDENCE_ATTACH, confidence: 0.78, source_date: "2026-05-10")
 /** Blocks calls to attach() that splice a database into the search path. */
 pub fn no_attach(slice, _ctx, _repo_at_base) {
-  let findings = scan_files(
-    production_r_files(slice),
-    r"(?m)(^|[^A-Za-z0-9_.$@])attach\s*\(",
-    "m",
-  )
+  let findings = scan_files(production_r_files(slice), r"(?m)(^|[^A-Za-z0-9_.$@])attach\s*\(", "m")
   return block_on_findings(
     "no_attach",
     "Reference columns explicitly with df$col, with(df, ...), or dplyr verbs; attach() pollutes the search path and shadows variables.",
@@ -178,11 +174,7 @@ pub fn no_attach(slice, _ctx, _repo_at_base) {
 @archivist(evidence: _EVIDENCE_SETWD, confidence: 0.78, source_date: "2026-05-10")
 /** Blocks setwd() calls that hardcode the working directory in committed source. */
 pub fn no_setwd_in_scripts(slice, _ctx, _repo_at_base) {
-  let findings = scan_files(
-    production_r_files(slice),
-    r"(?m)(^|[^A-Za-z0-9_.$@])setwd\s*\(",
-    "m",
-  )
+  let findings = scan_files(production_r_files(slice), r"(?m)(^|[^A-Za-z0-9_.$@])setwd\s*\(", "m")
   return block_on_findings(
     "no_setwd_in_scripts",
     "Use here::here() or project-relative paths so the script runs from any working directory and on any contributor's machine.",
@@ -195,11 +187,7 @@ pub fn no_setwd_in_scripts(slice, _ctx, _repo_at_base) {
 @archivist(evidence: _EVIDENCE_RM_LIST_LS, confidence: 0.8, source_date: "2026-05-10")
 /** Blocks rm(list = ls()) idioms that wipe the calling environment. */
 pub fn no_rm_list_ls(slice, _ctx, _repo_at_base) {
-  let findings = scan_files(
-    production_r_files(slice),
-    r"\brm\s*\(\s*list\s*=\s*ls\s*\(",
-    "s",
-  )
+  let findings = scan_files(production_r_files(slice), r"\brm\s*\(\s*list\s*=\s*ls\s*\(", "s")
   return block_on_findings(
     "no_rm_list_ls",
     "Restart the R session for a clean slate instead of rm(list = ls()); the latter only clears user objects and gives a false sense of reproducibility.",
@@ -229,11 +217,7 @@ pub fn use_logical_constants(slice, _ctx, _repo_at_base) {
 @archivist(evidence: _EVIDENCE_RIGHT_ASSIGN, confidence: 0.66, source_date: "2026-05-10")
 /** Warns on right-assign operators -> and ->>; reading order obscures the assignment target. */
 pub fn no_right_assign(slice, _ctx, _repo_at_base) {
-  let findings = scan_files(
-    production_r_files(slice),
-    r"(?m)(^|[^<\-])->>?\s*[A-Za-z_.]",
-    "m",
-  )
+  let findings = scan_files(production_r_files(slice), r"(?m)(^|[^<\-])->>?\s*[A-Za-z_.]", "m")
   return warn_on_findings(
     "no_right_assign",
     "Use <- for assignment so the target name appears on the left; -> and ->> hide the binding and are easy to miss in review.",
@@ -244,13 +228,11 @@ pub fn no_right_assign(slice, _ctx, _repo_at_base) {
 @invariant
 @deterministic
 @archivist(evidence: _EVIDENCE_SEQ_ALONG, confidence: 0.74, source_date: "2026-05-10")
-/** Warns on 1:length(x), 1:nrow(x), 1:ncol(x) idioms that iterate c(1, 0) when the input is empty. */
+/**
+ * Warns on 1:length(x), 1:nrow(x), 1:ncol(x) idioms that iterate c(1, 0) when the input is empty.
+ */
 pub fn seq_along_over_one_to_length(slice, _ctx, _repo_at_base) {
-  let findings = scan_files(
-    production_r_files(slice),
-    r"\b1\s*:\s*(?:length|nrow|ncol|NROW|NCOL)\s*\(",
-    "s",
-  )
+  let findings = scan_files(production_r_files(slice), r"\b1\s*:\s*(?:length|nrow|ncol|NROW|NCOL)\s*\(", "s")
   return warn_on_findings(
     "seq_along_over_one_to_length",
     "Use seq_along(x) or seq_len(nrow(x)); 1:length(x) silently iterates twice when x has length zero, hitting both ends of the empty input bug.",
@@ -280,11 +262,7 @@ pub fn no_install_or_update_packages(slice, _ctx, _repo_at_base) {
 @archivist(evidence: _EVIDENCE_EVAL_PARSE, confidence: 0.74, source_date: "2026-05-10")
 /** Blocks eval(parse(text = ...)) which evaluates arbitrary text as R code. */
 pub fn no_eval_parse_text(slice, _ctx, _repo_at_base) {
-  let findings = scan_files(
-    production_r_files(slice),
-    r"\beval\s*\(\s*parse\s*\(\s*text\s*=",
-    "s",
-  )
+  let findings = scan_files(production_r_files(slice), r"\beval\s*\(\s*parse\s*\(\s*text\s*=", "s")
   return block_on_findings(
     "no_eval_parse_text",
     "Build expressions with rlang::expr / bquote / substitute and evaluate them with eval(); eval(parse(text = ...)) is an injection sink and skips static checks.",
@@ -293,9 +271,11 @@ pub fn no_eval_parse_text(slice, _ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_attach)
 @archivist(evidence: _EVIDENCE_VECTORIZE, confidence: 0.55, source_date: "2026-05-10")
-/** Warns on for loops over vectors or rows that perform a simple element-wise computation a vectorized op would express directly. */
+/**
+ * Warns on for loops over vectors or rows that perform a simple element-wise computation a vectorized op would express directly.
+ */
 pub fn vectorize_over_loops(slice, ctx, _repo_at_base) {
   let rubric = "Warn only when a changed R for loop iterates over a vector, list, or row indices and computes a result that maps cleanly onto a built-in vectorized operation (arithmetic on whole vectors, ifelse, pmin/pmax, rowSums/colSums, sweep, apply/lapply/vapply/sapply/map_*) without inter-iteration state. Allow loops that mutate external resources, accumulate dependent state across iterations, recurse, or break/next on a non-trivial condition."
   let judgement = ctx.semantic_judge({rubric: rubric, files: r_files(slice)})
@@ -310,7 +290,7 @@ pub fn vectorize_over_loops(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_attach)
 @archivist(evidence: _EVIDENCE_RANDOM_SEED, confidence: 0.62, source_date: "2026-05-10")
 /** Warns when an analysis script invokes randomness without an explicit set.seed() upstream. */
 pub fn reproducible_random_seed(slice, ctx, _repo_at_base) {
@@ -327,9 +307,11 @@ pub fn reproducible_random_seed(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_attach)
 @archivist(evidence: _EVIDENCE_NAMESPACE, confidence: 0.62, source_date: "2026-05-10")
-/** Warns when package R/ source loads dependencies via library()/require() or uses unqualified non-base symbols without an importFrom roxygen tag. */
+/**
+ * Warns when package R/ source loads dependencies via library()/require() or uses unqualified non-base symbols without an importFrom roxygen tag.
+ */
 pub fn package_namespace_discipline(slice, ctx, _repo_at_base) {
   let rubric = "Warn only when a changed file under a package's R/ directory either (a) calls library(), require(), requireNamespace() purely for side-effect attachment, or (b) uses a symbol from a non-base, non-recommended package without either a pkg:: prefix or an @importFrom roxygen tag elsewhere in the file. Allow conditional requireNamespace(..., quietly = TRUE) checks that gate optional behavior, allow base/recommended packages (base, stats, utils, graphics, grDevices, methods, tools), and allow files that only contain comments, roxygen, or data definitions."
   let judgement = ctx.semantic_judge({rubric: rubric, files: package_source_files(slice)})

--- a/ruby/invariants.harn
+++ b/ruby/invariants.harn
@@ -272,7 +272,7 @@ pub fn initialize_calls_super(slice, _ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: frozen_string_literal_magic_comment)
 @archivist(evidence: _EVIDENCE_RUBOCOP, confidence: 0.66, source_date: "2026-05-08")
 /** Blocks changes that bypass or weaken the repo's RuboCop policy without justification. */
 pub fn rubocop_style_compliance(slice, ctx, _repo_at_base) {
@@ -289,7 +289,7 @@ pub fn rubocop_style_compliance(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: frozen_string_literal_magic_comment)
 @archivist(evidence: _EVIDENCE_SECRETS, confidence: 0.68, source_date: "2026-05-08")
 /** Blocks hardcoded credentials and high-risk secrets in Ruby source. */
 pub fn no_hardcoded_secrets(slice, ctx, _repo_at_base) {
@@ -306,7 +306,7 @@ pub fn no_hardcoded_secrets(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: frozen_string_literal_magic_comment)
 @archivist(evidence: _EVIDENCE_SENSITIVE_LOGS, confidence: 0.63, source_date: "2026-05-08")
 /** Blocks logs and errors that expose secrets or sensitive user data. */
 pub fn no_sensitive_data_in_logs(slice, ctx, _repo_at_base) {

--- a/rust/invariants.harn
+++ b/rust/invariants.harn
@@ -105,7 +105,8 @@ fn scan_prod(slice, pattern) {
 fn scan_without_prod(slice, include_pattern, exclude_pattern) {
   var findings = []
   for file in prod_rust_files(slice) {
-    if regex_match(include_pattern, file.text, "s") != nil && regex_match(exclude_pattern, file.text, "s") == nil {
+    if regex_match(include_pattern, file.text, "s") != nil
+      && regex_match(exclude_pattern, file.text, "s") == nil {
       findings = findings
         .push({path: file.path, pattern: include_pattern})
     }
@@ -174,11 +175,7 @@ pub fn must_use_message_on_pub_result_option(slice, _ctx, _repo_at_base) {
 @archivist(evidence: _EVIDENCE_UNSAFE_COMMENT, confidence: 0.78, source_date: "2026-04-26")
 /** Blocks unsafe blocks or impls without a preceding SAFETY comment. */
 pub fn unsafe_requires_safety_comment(slice, _ctx, _repo_at_base) {
-  let findings = scan_without_prod(
-    slice,
-    r"\bunsafe\s*(\{|impl\b)",
-    r"//\s*SAFETY:[^\n]*\n\s*unsafe\s*(\{|impl\b)",
-  )
+  let findings = scan_without_prod(slice, r"\bunsafe\s*(\{|impl\b)", r"//\s*SAFETY:[^\n]*\n\s*unsafe\s*(\{|impl\b)")
   return block_on_findings(
     "unsafe_requires_safety_comment",
     "Precede each unsafe block or unsafe impl with a // SAFETY: comment explaining the invariant.",
@@ -258,7 +255,7 @@ pub fn no_panic_in_result_fn(slice, _ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_unwrap_in_prod)
 @archivist(evidence: _EVIDENCE_CARGO_ADVISORIES, confidence: 0.64, source_date: "2026-04-26")
 /** Blocks dependency changes that lack advisory or cargo-deny/audit evidence. */
 pub fn cargo_advisories_checked(slice, ctx, _repo_at_base) {
@@ -275,7 +272,7 @@ pub fn cargo_advisories_checked(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_unwrap_in_prod)
 @archivist(evidence: _EVIDENCE_FFI_SAFETY, confidence: 0.6, source_date: "2026-04-26")
 /** Blocks unsafe public FFI boundaries that omit safety contracts. */
 pub fn ffi_boundary_safety_contract(slice, ctx, _repo_at_base) {

--- a/scala/invariants.harn
+++ b/scala/invariants.harn
@@ -275,7 +275,7 @@ pub fn no_await_in_library_code(slice, _ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_any_in_public_api)
 @archivist(evidence: _EVIDENCE_EFFECTS, confidence: 0.62, source_date: "2026-05-10")
 /** Blocks unsafe boundaries between effect types and Future in production Scala. */
 pub fn effect_typed_boundaries(slice, ctx, _repo_at_base) {
@@ -292,7 +292,7 @@ pub fn effect_typed_boundaries(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_any_in_public_api)
 @archivist(evidence: _EVIDENCE_EFFECTS, confidence: 0.66, source_date: "2026-05-10")
 /** Blocks unsafe runtime escapes outside of process entry points. */
 pub fn no_unsafe_run_in_library_code(slice, ctx, _repo_at_base) {
@@ -309,7 +309,7 @@ pub fn no_unsafe_run_in_library_code(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_any_in_public_api)
 @archivist(evidence: _EVIDENCE_PATTERN_EXHAUSTIVE, confidence: 0.6, source_date: "2026-05-10")
 /** Warns when production match expressions are non-exhaustive without an explicit fallback. */
 pub fn pattern_matches_are_exhaustive(slice, ctx, _repo_at_base) {

--- a/scripts/execute_fixtures.py
+++ b/scripts/execute_fixtures.py
@@ -21,9 +21,18 @@ def load_fixture(pack_dir, predicate):
     return json.loads(fixture_path.read_text(encoding="utf-8"))
 
 
-def wrapper_source(pack, invariants_source, deterministic_entries):
+def wrapper_source(pack, deterministic_entries):
+    invariants_path = f"{pack}/invariants.harn"
     lines = [
-        invariants_source,
+        "fn flow_fixture_verdict(record) {",
+        '  let kind = to_string(record?.result?.verdict?.kind ?? record?.raw_result?.verdict ?? "")',
+        "  let normalized = kind.lower()",
+        '  if normalized == "allow" { return "Allow" }',
+        '  if normalized == "warn" { return "Warn" }',
+        '  if normalized == "block" { return "Block" }',
+        '  if normalized == "require_approval" { return "RequireApproval" }',
+        '  return kind == "" ? "Missing" : kind',
+        "}",
         "",
         "fn main(harness: Harness) {",
         "  var failures = []",
@@ -44,16 +53,27 @@ def wrapper_source(pack, invariants_source, deterministic_entries):
             lines.extend(
                 [
                     f"  let files_{counter} = json_parse(base64_decode({files_literal}))",
-                    f"  let result_{counter} = {predicate}({{files: files_{counter}}}, {{}}, nil)",
+                    f"  let eval_{counter} = flow_evaluate_invariants(",
+                    '    "",',
+                    f"    {{files: files_{counter}}},",
+                    "    {",
+                    f"      path: {harn_string_literal(invariants_path)},",
+                    f"      predicates: [{harn_string_literal(predicate)}],",
+                    "      budget_ms: 50,",
+                    "    },",
+                    "  )",
+                    f"  let records_{counter} = eval_{counter}.records ?? []",
+                    f"  let record_{counter} = if len(records_{counter}) > 0 {{ records_{counter}[0] }} else {{ nil }}",
+                    f"  let actual_{counter} = flow_fixture_verdict(record_{counter})",
                     "  executed = executed + 1",
-                    f'  if result_{counter}.verdict != "{expect}" {{',
+                    f"  if actual_{counter} != {harn_string_literal(expect)} {{",
                     "    failures = failures.push({",
                     f'      pack: "{pack}",',
                     f'      predicate: "{predicate}",',
-                    f'      case: "{case_name}",',
-                    f'      expect: "{expect}",',
-                    f"      actual: result_{counter}.verdict,",
-                    f"      result: result_{counter},",
+                    f"      case: {harn_string_literal(case_name)},",
+                    f"      expect: {harn_string_literal(expect)},",
+                    f"      actual: actual_{counter},",
+                    f"      result: record_{counter} ?? eval_{counter},",
                     "    })",
                     "  }",
                 ]
@@ -85,7 +105,7 @@ def run_pack(pack):
 
     deterministic = [entry for entry in entries if entry["mode"] == "deterministic"]
     skipped_semantic = sum(1 for entry in entries if entry["mode"] == "semantic")
-    source = wrapper_source(pack, invariants_path.read_text(encoding="utf-8"), deterministic)
+    source = wrapper_source(pack, deterministic)
 
     with tempfile.NamedTemporaryFile(
         "w",

--- a/scripts/validate_canon.py
+++ b/scripts/validate_canon.py
@@ -37,7 +37,7 @@ FILE_KEYS = {"path", "text"}
 
 INVARIANT_RE = re.compile(
     r"@invariant\s*"
-    r"@(?P<mode>deterministic|semantic)\s*"
+    r"@(?P<mode>deterministic|semantic)(?P<mode_args>\s*\([^)]*\))?\s*"
     r"@archivist\(\s*"
     r"evidence:\s*(?P<evidence>_EVIDENCE_[A-Za-z0-9_]+)\s*,\s*"
     r"confidence:\s*(?P<confidence>(?:0(?:\.\d+)?|1(?:\.0+)?))\s*,\s*"
@@ -48,6 +48,17 @@ INVARIANT_RE = re.compile(
 )
 EVIDENCE_RE = re.compile(r"let\s+(_EVIDENCE_[A-Za-z0-9_]+)\s*=\s*\[(.*?)\]", re.S)
 URL_RE = re.compile(r'"(https?://[^"]+)"')
+SEMANTIC_FALLBACK_RE = re.compile(
+    r"""
+    fallback\s*:\s*
+    (?:
+      "(?P<quoted>[A-Za-z_][A-Za-z0-9_]*)"
+      |
+      (?P<bare>[A-Za-z_][A-Za-z0-9_]*)
+    )
+    """,
+    re.X,
+)
 FIXTURE_CASE_NAME_RE = re.compile(r"[a-z][a-z0-9_]*\Z")
 
 
@@ -80,7 +91,18 @@ def is_normalized_relative_path(value):
 
 def parse_invariants(path, errors):
     text = path.read_text(encoding="utf-8")
-    entries = [match.groupdict() for match in INVARIANT_RE.finditer(text)]
+    entries = []
+    for match in INVARIANT_RE.finditer(text):
+        entry = match.groupdict()
+        mode_args = entry.get("mode_args") or ""
+        fallback_match = SEMANTIC_FALLBACK_RE.search(mode_args)
+        entry["fallback"] = (
+            fallback_match.group("quoted") or fallback_match.group("bare")
+            if fallback_match
+            else None
+        )
+        entries.append(entry)
+
     invariant_count = len(re.findall(r"@invariant\b", text))
     if invariant_count != len(entries):
         errors.append(
@@ -121,6 +143,30 @@ def validate_evidence(pack, entries, evidence_defs, errors):
             errors.append(f"{pack}: {predicate} source_date {source_date} is in the future")
         if source_date < cutoff:
             errors.append(f"{pack}: {predicate} source_date {source_date} is older than 18 months")
+
+
+def validate_semantic_fallbacks(pack, entries, errors):
+    deterministic_names = {entry["name"] for entry in entries if entry["mode"] == "deterministic"}
+    for entry in entries:
+        predicate = entry["name"]
+        fallback = entry.get("fallback")
+        if entry["mode"] == "deterministic":
+            if entry.get("mode_args"):
+                errors.append(
+                    f"{pack}: deterministic predicate {predicate} must not declare mode args"
+                )
+            continue
+
+        if fallback is None:
+            errors.append(
+                f"{pack}: semantic predicate {predicate} must declare "
+                "@semantic(fallback: deterministic_predicate)"
+            )
+        elif fallback not in deterministic_names:
+            errors.append(
+                f"{pack}: semantic predicate {predicate} fallback {fallback} is not a "
+                "deterministic predicate in the same pack"
+            )
 
 
 def validate_fixtures(pack_dir, predicate_names, errors):
@@ -308,6 +354,7 @@ def main():
                 f"{pack}: expected {MIN_SEMANTIC}-{MAX_SEMANTIC} semantic predicates, found {semantic}"
             )
 
+        validate_semantic_fallbacks(pack, entries, errors)
         validate_evidence(pack, entries, evidence_defs, errors)
         validate_pack_readme_coverage(pack_dir, set(names), errors)
         total_predicates += len(entries)

--- a/shell/invariants.harn
+++ b/shell/invariants.harn
@@ -22,10 +22,7 @@ let _EVIDENCE_TRAP_CLEANUP = [
   "https://mywiki.wooledge.org/SignalTrap",
 ]
 
-let _EVIDENCE_SHELLCHECK_DIRECTIVE = [
-  "https://www.shellcheck.net/wiki/Directive",
-  "https://www.shellcheck.net/wiki/Ignore",
-]
+let _EVIDENCE_SHELLCHECK_DIRECTIVE = ["https://www.shellcheck.net/wiki/Directive", "https://www.shellcheck.net/wiki/Ignore"]
 
 let _EVIDENCE_SHELLCHECK = [
   "https://www.shellcheck.net/wiki/Home",
@@ -117,8 +114,10 @@ fn warn_on_findings(rule, remediation, findings) {
 pub fn set_euo_pipefail(slice, _ctx, _repo_at_base) {
   let findings = scan_files_if(
     executable_shell_files(slice),
-    { file -> regex_match(r"(?m)^\s*set\b[^#\n]*(\s-[a-zA-Z]*e[a-zA-Z]*\b|\berrexit\b)", file.text, "m") == nil
-      || regex_match(r"(?m)^\s*set\b[^#\n]*(\s-[a-zA-Z]*u[a-zA-Z]*\b|\bnounset\b)", file.text, "m") == nil
+    { file -> regex_match(r"(?m)^\s*set\b[^#\n]*(\s-[a-zA-Z]*e[a-zA-Z]*\b|\berrexit\b)", file.text, "m")
+      == nil
+      || regex_match(r"(?m)^\s*set\b[^#\n]*(\s-[a-zA-Z]*u[a-zA-Z]*\b|\bnounset\b)", file.text, "m")
+      == nil
       || regex_match(r"(?m)^\s*set\b[^#\n]*\bpipefail\b", file.text, "m") == nil },
   )
   return block_on_findings(
@@ -133,11 +132,7 @@ pub fn set_euo_pipefail(slice, _ctx, _repo_at_base) {
 @archivist(evidence: _EVIDENCE_PARSING_LS, confidence: 0.82, source_date: "2026-05-09")
 /** Blocks parsing the output of ls in shell scripts. */
 pub fn no_parsing_ls(slice, _ctx, _repo_at_base) {
-  let findings = scan_files(
-    shell_files(slice),
-    r"(\$\(\s*ls\b|`\s*ls\b)",
-    "s",
-  )
+  let findings = scan_files(shell_files(slice), r"(\$\(\s*ls\b|`\s*ls\b)", "s")
   return block_on_findings(
     "no_parsing_ls",
     "Iterate with shell globs, arrays, or `find ... -print0 | xargs -0`; ls output is not safe to parse.",
@@ -150,11 +145,7 @@ pub fn no_parsing_ls(slice, _ctx, _repo_at_base) {
 @archivist(evidence: _EVIDENCE_EVAL, confidence: 0.74, source_date: "2026-05-09")
 /** Blocks eval calls whose argument contains a variable or command substitution. */
 pub fn no_eval_dynamic_input(slice, _ctx, _repo_at_base) {
-  let findings = scan_files(
-    shell_files(slice),
-    r"(?m)^[^#\n]*\beval\b\s+[^\n]*(\$|`)",
-    "m",
-  )
+  let findings = scan_files(shell_files(slice), r"(?m)^[^#\n]*\beval\b\s+[^\n]*(\$|`)", "m")
   return block_on_findings(
     "no_eval_dynamic_input",
     "Replace dynamic eval with explicit dispatch, arrays, or `printf -v`; eval on interpolated text is shell injection.",
@@ -184,11 +175,7 @@ pub fn trap_cleanup_on_tempfile(slice, _ctx, _repo_at_base) {
 @archivist(evidence: _EVIDENCE_SHELLCHECK_DIRECTIVE, confidence: 0.84, source_date: "2026-05-09")
 /** Warns on blanket ShellCheck disables that hide every diagnostic in a file. */
 pub fn no_blanket_shellcheck_disable(slice, _ctx, _repo_at_base) {
-  let findings = scan_files(
-    shell_files(slice),
-    r"(?m)^\s*#\s*shellcheck\s+disable\s*=\s*all\b",
-    "m",
-  )
+  let findings = scan_files(shell_files(slice), r"(?m)^\s*#\s*shellcheck\s+disable\s*=\s*all\b", "m")
   return warn_on_findings(
     "no_blanket_shellcheck_disable",
     "Disable specific SC codes with a comment explaining why, instead of `# shellcheck disable=all`.",
@@ -197,7 +184,7 @@ pub fn no_blanket_shellcheck_disable(slice, _ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: set_euo_pipefail)
 @archivist(evidence: _EVIDENCE_SHELLCHECK, confidence: 0.62, source_date: "2026-05-09")
 /** Blocks changed shell scripts that would fail ShellCheck under default configuration. */
 pub fn shellcheck_clean(slice, ctx, _repo_at_base) {
@@ -214,7 +201,7 @@ pub fn shellcheck_clean(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: set_euo_pipefail)
 @archivist(evidence: _EVIDENCE_SECRETS, confidence: 0.66, source_date: "2026-05-09")
 /** Blocks hardcoded credentials, tokens, and private keys in shell sources. */
 pub fn no_hardcoded_secrets(slice, ctx, _repo_at_base) {
@@ -231,7 +218,7 @@ pub fn no_hardcoded_secrets(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: set_euo_pipefail)
 @archivist(evidence: _EVIDENCE_SENSITIVE_LOGS, confidence: 0.6, source_date: "2026-05-09")
 /** Blocks shell scripts that echo or print secrets and sensitive request data. */
 pub fn no_sensitive_data_in_logs(slice, ctx, _repo_at_base) {

--- a/sql/invariants.harn
+++ b/sql/invariants.harn
@@ -226,7 +226,7 @@ pub fn destructive_drops_use_if_exists(slice, _ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_select_star)
 @archivist(evidence: _EVIDENCE_PARAMETERIZED, confidence: 0.66, source_date: "2026-05-09")
 /** Blocks dynamic SQL that interpolates untrusted input instead of binding parameters. */
 pub fn parameterized_queries_only(slice, ctx, _repo_at_base) {
@@ -243,7 +243,7 @@ pub fn parameterized_queries_only(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_select_star)
 @archivist(evidence: _EVIDENCE_FK_INDEX, confidence: 0.6, source_date: "2026-05-09")
 /** Blocks new foreign-key references that lack a covering index on the referencing column. */
 pub fn index_on_fk(slice, ctx, _repo_at_base) {

--- a/swift/invariants.harn
+++ b/swift/invariants.harn
@@ -55,10 +55,10 @@ fn production_swift_files(slice) {
   return swift_files(slice)
     .filter(
     { file -> !contains(file.path, "/Tests/")
-    && !contains(file.path, "/TestSupport/")
-    && !file.path.ends_with("Tests.swift")
-    && !file.path.ends_with("Preview.swift")
-    && !file.path.ends_with("Previews.swift") },
+      && !contains(file.path, "/TestSupport/")
+      && !file.path.ends_with("Tests.swift")
+      && !file.path.ends_with("Preview.swift")
+      && !file.path.ends_with("Previews.swift") },
   )
 }
 
@@ -181,10 +181,10 @@ pub fn main_actor_on_ui_observable_state(slice, _ctx, _repo_at_base) {
   let findings = scan_swift_if(
     slice,
     { text -> (contains(text, "import SwiftUI") || contains(text, "import UIKit")
-    || contains(text, "import AppKit"))
-    && (contains(text, "ObservableObject") || contains(text, "@Observable")
-    || regex_match(r"class\s+\w*(ViewModel|Controller)\b", text, "s") != nil)
-    && !contains(text, "@MainActor") },
+      || contains(text, "import AppKit"))
+      && (contains(text, "ObservableObject") || contains(text, "@Observable")
+      || regex_match(r"class\s+\w*(ViewModel|Controller)\b", text, "s") != nil)
+      && !contains(text, "@MainActor") },
   )
   return warn_on_findings(
     "main_actor_on_ui_observable_state",
@@ -239,7 +239,7 @@ pub fn no_print_in_production(slice, _ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_force_unwrap)
 @archivist(evidence: _EVIDENCE_ARC_CLOSURES, confidence: 0.66, source_date: "2026-04-26")
 /** Blocks likely retain cycles from escaping closures that capture self strongly. */
 pub fn no_retain_cycle_in_escaping_closure(slice, ctx, _repo_at_base) {
@@ -256,7 +256,7 @@ pub fn no_retain_cycle_in_escaping_closure(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_force_unwrap)
 @archivist(evidence: _EVIDENCE_UI_MAIN_ACTOR, confidence: 0.64, source_date: "2026-04-26")
 /** Blocks UI state mutation from non-main actor callbacks or tasks. */
 pub fn ui_state_mutations_stay_main_actor(slice, ctx, _repo_at_base) {
@@ -273,7 +273,7 @@ pub fn ui_state_mutations_stay_main_actor(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_force_unwrap)
 @archivist(evidence: _EVIDENCE_SENDABLE, confidence: 0.62, source_date: "2026-04-26")
 /** Blocks unsafe cross-concurrency sharing that Swift 6 sendability should protect. */
 pub fn sendable_cross_actor_boundaries_are_safe(slice, ctx, _repo_at_base) {

--- a/terraform/invariants.harn
+++ b/terraform/invariants.harn
@@ -114,7 +114,9 @@ fn warn_on_findings(rule, remediation, findings) {
 @invariant
 @deterministic
 @archivist(evidence: _EVIDENCE_TAGGING, confidence: 0.6, source_date: "2026-05-09")
-/** Warns when changed Terraform files declare cloud resources without Owner, Env, and CostCenter tags. */
+/**
+ * Warns when changed Terraform files declare cloud resources without Owner, Env, and CostCenter tags.
+ */
 pub fn required_tags_on_resources(slice, _ctx, _repo_at_base) {
   let findings = scan_files_if(
     production_tf_files(slice),
@@ -133,7 +135,9 @@ pub fn required_tags_on_resources(slice, _ctx, _repo_at_base) {
 @invariant
 @deterministic
 @archivist(evidence: _EVIDENCE_VAR_TYPES, confidence: 0.74, source_date: "2026-05-09")
-/** Warns when changed Terraform files declare variable blocks without an explicit type constraint. */
+/**
+ * Warns when changed Terraform files declare variable blocks without an explicit type constraint.
+ */
 pub fn variable_type_constraints_explicit(slice, _ctx, _repo_at_base) {
   let findings = scan_files_if(
     production_tf_files(slice),
@@ -150,7 +154,9 @@ pub fn variable_type_constraints_explicit(slice, _ctx, _repo_at_base) {
 @invariant
 @deterministic
 @archivist(evidence: _EVIDENCE_BACKEND, confidence: 0.6, source_date: "2026-05-09")
-/** Warns when a root-module file declares required_providers without configuring a remote state backend. */
+/**
+ * Warns when a root-module file declares required_providers without configuring a remote state backend.
+ */
 pub fn remote_state_backend_configured(slice, _ctx, _repo_at_base) {
   var findings = []
   for file in production_tf_files(slice) {
@@ -195,7 +201,9 @@ pub fn module_registry_version_pinned(slice, _ctx, _repo_at_base) {
 @invariant
 @deterministic
 @archivist(evidence: _EVIDENCE_PROVIDER_VERSION, confidence: 0.74, source_date: "2026-05-09")
-/** Blocks required_providers declarations that omit a version constraint for at least one provider. */
+/**
+ * Blocks required_providers declarations that omit a version constraint for at least one provider.
+ */
 pub fn provider_versions_pinned(slice, _ctx, _repo_at_base) {
   let findings = scan_files_if(
     production_tf_files(slice),
@@ -232,7 +240,7 @@ pub fn outputs_with_secret_names_marked_sensitive(slice, _ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: required_tags_on_resources)
 @archivist(evidence: _EVIDENCE_SECRETS, confidence: 0.66, source_date: "2026-05-09")
 /** Blocks hardcoded credentials, tokens, and private keys in Terraform source. */
 pub fn no_hardcoded_secrets(slice, ctx, _repo_at_base) {
@@ -249,9 +257,11 @@ pub fn no_hardcoded_secrets(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: required_tags_on_resources)
 @archivist(evidence: _EVIDENCE_IAM_LEAST_PRIV, confidence: 0.62, source_date: "2026-05-09")
-/** Blocks IAM policy documents that grant unscoped wildcard actions or resources without justification. */
+/**
+ * Blocks IAM policy documents that grant unscoped wildcard actions or resources without justification.
+ */
 pub fn iam_policies_avoid_wildcard_grants(slice, ctx, _repo_at_base) {
   let rubric = "Block only when changed Terraform IAM policy documents (aws_iam_policy_document, aws_iam_policy, aws_iam_role_policy, azurerm_role_definition, google_project_iam_*, google_organization_iam_*) allow Action = \"*\" or Resource = \"*\" or equivalent unrestricted wildcards in an Allow statement, with no narrowing Condition or service-scoped wildcard."
   let judgement = ctx.semantic_judge({rubric: rubric, files: tf_files(slice)})

--- a/toml/invariants.harn
+++ b/toml/invariants.harn
@@ -161,7 +161,7 @@ pub fn datetime_includes_offset(slice, _ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_duplicate_table_headers)
 @archivist(evidence: _EVIDENCE_SECRETS, confidence: 0.62, source_date: "2026-05-09")
 /** Blocks hardcoded credentials, tokens, or signing secrets in TOML configuration. */
 pub fn secrets_not_hardcoded_in_toml(slice, ctx, _repo_at_base) {
@@ -178,7 +178,7 @@ pub fn secrets_not_hardcoded_in_toml(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_duplicate_table_headers)
 @archivist(evidence: _EVIDENCE_PACKAGE_LICENSE, confidence: 0.6, source_date: "2026-05-15")
 /** Warns when publishable Cargo or Python package metadata omits license information. */
 pub fn package_metadata_declares_license(slice, ctx, _repo_at_base) {

--- a/typescript/invariants.harn
+++ b/typescript/invariants.harn
@@ -57,9 +57,9 @@ fn typescript_files(slice) {
   return slice.files
     .filter(
     { file -> file.path.ends_with(".ts")
-    || file.path.ends_with(".tsx")
-    || file.path.ends_with(".mts")
-    || file.path.ends_with(".cts") },
+      || file.path.ends_with(".tsx")
+      || file.path.ends_with(".mts")
+      || file.path.ends_with(".cts") },
   )
 }
 
@@ -262,7 +262,7 @@ pub fn no_inline_type_only_imports(slice, _ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_floating_promises)
 @archivist(evidence: _EVIDENCE_RUNTIME_VALIDATION, confidence: 0.66, source_date: "2026-04-26")
 /** Blocks external data being trusted as domain types without runtime validation. */
 pub fn runtime_validate_external_data(slice, ctx, _repo_at_base) {
@@ -279,7 +279,7 @@ pub fn runtime_validate_external_data(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_floating_promises)
 @archivist(evidence: _EVIDENCE_SECRETS, confidence: 0.69, source_date: "2026-04-26")
 /** Blocks hardcoded credentials, tokens, and private keys in TypeScript source. */
 pub fn no_hardcoded_secrets(slice, ctx, _repo_at_base) {
@@ -296,7 +296,7 @@ pub fn no_hardcoded_secrets(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_floating_promises)
 @archivist(evidence: _EVIDENCE_SENSITIVE_LOGS, confidence: 0.64, source_date: "2026-04-26")
 /** Blocks logging of secrets, credentials, tokens, or sensitive user data. */
 pub fn no_sensitive_data_in_logs(slice, ctx, _repo_at_base) {

--- a/xml/invariants.harn
+++ b/xml/invariants.harn
@@ -10,20 +10,11 @@ let _EVIDENCE_EXTERNAL_ENTITIES = [
   "https://www.w3.org/TR/xml/#sec-external-ent",
 ]
 
-let _EVIDENCE_UTF8 = [
-  "https://www.w3.org/TR/xml/#charencoding",
-  "https://datatracker.ietf.org/doc/html/rfc7303",
-]
+let _EVIDENCE_UTF8 = ["https://www.w3.org/TR/xml/#charencoding", "https://datatracker.ietf.org/doc/html/rfc7303"]
 
-let _EVIDENCE_NAMESPACES = [
-  "https://www.w3.org/TR/xml-names/",
-  "https://www.w3.org/TR/xml-names/#scoping",
-]
+let _EVIDENCE_NAMESPACES = ["https://www.w3.org/TR/xml-names/", "https://www.w3.org/TR/xml-names/#scoping"]
 
-let _EVIDENCE_XSD_TARGET_NAMESPACE = [
-  "https://www.w3.org/TR/xmlschema11-1/#sec-src-resolve",
-  "https://www.w3.org/TR/xmlschema-0/#NS",
-]
+let _EVIDENCE_XSD_TARGET_NAMESPACE = ["https://www.w3.org/TR/xmlschema11-1/#sec-src-resolve", "https://www.w3.org/TR/xmlschema-0/#NS"]
 
 let _EVIDENCE_XSLT_EXTERNAL = [
   "https://www.w3.org/TR/xslt-30/#dt-stable-uri-collection",
@@ -121,7 +112,9 @@ fn warn_on_findings(rule, remediation, findings) {
 @invariant
 @deterministic
 @archivist(evidence: _EVIDENCE_DOCTYPE_XXE, confidence: 0.92, source_date: "2026-05-09")
-/** Blocks inline DOCTYPE declarations in XML payload files; the entity subset is the primary XXE vector. */
+/**
+ * Blocks inline DOCTYPE declarations in XML payload files; the entity subset is the primary XXE vector.
+ */
 pub fn no_inline_doctype(slice, _ctx, _repo_at_base) {
   let findings = scan_files(xml_payload_files(slice), r"<!DOCTYPE\b", "is")
   return block_on_findings(
@@ -168,7 +161,9 @@ pub fn xml_declares_utf8(slice, _ctx, _repo_at_base) {
 @invariant
 @deterministic
 @archivist(evidence: _EVIDENCE_NAMESPACES, confidence: 0.66, source_date: "2026-05-09")
-/** Warns when XML uses prefixed element names but declares no xmlns:prefix bindings in the same file. */
+/**
+ * Warns when XML uses prefixed element names but declares no xmlns:prefix bindings in the same file.
+ */
 pub fn xml_namespace_prefixes_declared(slice, _ctx, _repo_at_base) {
   let findings = scan_files_if(
     xml_files(slice),
@@ -218,7 +213,7 @@ pub fn xslt_no_external_documents(slice, _ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_inline_doctype)
 @archivist(evidence: _EVIDENCE_SECRETS, confidence: 0.7, source_date: "2026-05-09")
 /** Blocks credentials, tokens, private keys, and production connection strings embedded in XML. */
 pub fn no_hardcoded_secrets(slice, ctx, _repo_at_base) {
@@ -235,9 +230,11 @@ pub fn no_hardcoded_secrets(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_inline_doctype)
 @archivist(evidence: _EVIDENCE_SCHEMA_DOS, confidence: 0.62, source_date: "2026-05-09")
-/** Blocks XSD shapes that disable validation or invite quadratic blowup of attacker-controlled input. */
+/**
+ * Blocks XSD shapes that disable validation or invite quadratic blowup of attacker-controlled input.
+ */
 pub fn xsd_constrains_user_input(slice, ctx, _repo_at_base) {
   let rubric = "Block only when changed XSD intentionally weakens input validation on attacker-reachable fields, for example using xs:any or xs:anyType in place of a real type, omitting maxLength on free-form strings nested under unbounded sequences, or removing pattern/enumeration facets that previously constrained an externally posted value."
   let judgement = ctx.semantic_judge({rubric: rubric, files: xsd_files(slice)})

--- a/yaml/invariants.harn
+++ b/yaml/invariants.harn
@@ -23,10 +23,7 @@ let _EVIDENCE_UNSAFE_TAGS = [
   "https://cheatsheetseries.owasp.org/cheatsheets/Deserialization_Cheat_Sheet.html",
 ]
 
-let _EVIDENCE_ANCHORS = [
-  "https://yaml.org/spec/1.2.2/#692-node-anchors",
-  "https://yaml.org/spec/1.2.2/#92-streams",
-]
+let _EVIDENCE_ANCHORS = ["https://yaml.org/spec/1.2.2/#692-node-anchors", "https://yaml.org/spec/1.2.2/#92-streams"]
 
 let _EVIDENCE_YAMLLINT = [
   "https://yamllint.readthedocs.io/en/stable/rules.html",
@@ -135,7 +132,9 @@ pub fn explicit_boolean_types(slice, _ctx, _repo_at_base) {
 @invariant
 @deterministic
 @archivist(evidence: _EVIDENCE_AMBIGUOUS_SCALARS, confidence: 0.7, source_date: "2026-05-09")
-/** Warns on bare scalars that parsers commonly mis-type: trailing-zero versions, leading-zero numbers, sexagesimal forms. */
+/**
+ * Warns on bare scalars that parsers commonly mis-type: trailing-zero versions, leading-zero numbers, sexagesimal forms.
+ */
 pub fn quoted_ambiguous_scalars(slice, _ctx, _repo_at_base) {
   let findings = scan_files(
     non_test_yaml_files(slice),
@@ -152,7 +151,9 @@ pub fn quoted_ambiguous_scalars(slice, _ctx, _repo_at_base) {
 @invariant
 @deterministic
 @archivist(evidence: _EVIDENCE_CONSISTENT_INDENT, confidence: 0.74, source_date: "2026-05-09")
-/** Warns on lines whose leading indentation is an odd number of spaces, which almost always signals an inconsistent indent step. */
+/**
+ * Warns on lines whose leading indentation is an odd number of spaces, which almost always signals an inconsistent indent step.
+ */
 pub fn consistent_indent(slice, _ctx, _repo_at_base) {
   let findings = scan_files(non_test_yaml_files(slice), r"(?m)^(?: |   |     |       )\S", "m")
   return warn_on_findings(
@@ -165,13 +166,11 @@ pub fn consistent_indent(slice, _ctx, _repo_at_base) {
 @invariant
 @deterministic
 @archivist(evidence: _EVIDENCE_UNSAFE_TAGS, confidence: 0.95, source_date: "2026-05-09")
-/** Blocks YAML language-specific object construction tags that map to remote-code-execution sinks. */
+/**
+ * Blocks YAML language-specific object construction tags that map to remote-code-execution sinks.
+ */
 pub fn no_unsafe_yaml_tags(slice, _ctx, _repo_at_base) {
-  let findings = scan_files(
-    yaml_files(slice),
-    r"(?m)!{1,2}(?:python|ruby|java|javax|perl|exec)\b",
-    "m",
-  )
+  let findings = scan_files(yaml_files(slice), r"(?m)!{1,2}(?:python|ruby|java|javax|perl|exec)\b", "m")
   return block_on_findings(
     "no_unsafe_yaml_tags",
     "Remove language-specific !!python/!ruby/!!java tags; load this YAML with a safe loader instead.",
@@ -182,7 +181,9 @@ pub fn no_unsafe_yaml_tags(slice, _ctx, _repo_at_base) {
 @invariant
 @deterministic
 @archivist(evidence: _EVIDENCE_ANCHORS, confidence: 0.66, source_date: "2026-05-09")
-/** Warns when a multi-document YAML file uses aliases that may reference anchors in a different document. */
+/**
+ * Warns when a multi-document YAML file uses aliases that may reference anchors in a different document.
+ */
 pub fn no_anchors_across_docs(slice, _ctx, _repo_at_base) {
   let findings = scan_files_if(
     non_test_yaml_files(slice),
@@ -197,9 +198,11 @@ pub fn no_anchors_across_docs(slice, _ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_tabs_for_indent)
 @archivist(evidence: _EVIDENCE_YAMLLINT, confidence: 0.66, source_date: "2026-05-09")
-/** Blocks changed YAML that yamllint would flag as an error under a sensible default configuration. */
+/**
+ * Blocks changed YAML that yamllint would flag as an error under a sensible default configuration.
+ */
 pub fn yamllint_compliance(slice, ctx, _repo_at_base) {
   let rubric = "Block only when changed YAML clearly violates a yamllint default rule that yamllint reports as an error: duplicate keys, empty mapping values where a value is required, line-length runaway, missing document start when policy requires it, octal value misuse, or syntax that fails to parse. Do not block on style preferences when yamllint defaults treat them as warnings."
   let judgement = ctx.semantic_judge({rubric: rubric, files: yaml_files(slice)})
@@ -214,7 +217,7 @@ pub fn yamllint_compliance(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_tabs_for_indent)
 @archivist(evidence: _EVIDENCE_SECRETS, confidence: 0.7, source_date: "2026-05-09")
 /** Blocks credentials, tokens, and private keys committed in YAML configuration. */
 pub fn no_hardcoded_secrets(slice, ctx, _repo_at_base) {

--- a/zig/invariants.harn
+++ b/zig/invariants.harn
@@ -419,7 +419,7 @@ pub fn doc_comments_attach_to_declarations(slice, _ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_silent_error_swallow)
 @archivist(evidence: _EVIDENCE_ALLOCATOR_LIFETIME, confidence: 0.62, source_date: "2026-05-10")
 /** Blocks heap allocations whose result is not freed, transferred, or guarded by defer/errdefer. */
 pub fn allocator_lifetime_hygiene(slice, ctx, _repo_at_base) {
@@ -436,7 +436,7 @@ pub fn allocator_lifetime_hygiene(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_silent_error_swallow)
 @archivist(evidence: _EVIDENCE_SECRETS, confidence: 0.66, source_date: "2026-05-10")
 /** Blocks hardcoded credentials, tokens, and private keys in Zig sources. */
 pub fn no_hardcoded_secrets(slice, ctx, _repo_at_base) {
@@ -453,7 +453,7 @@ pub fn no_hardcoded_secrets(slice, ctx, _repo_at_base) {
 }
 
 @invariant
-@semantic
+@semantic(fallback: no_silent_error_swallow)
 @archivist(evidence: _EVIDENCE_ENDIANNESS, confidence: 0.6, source_date: "2026-05-10")
 /**
  * Warns when multi-byte integer I/O across a serialization boundary does not name an endianness.


### PR DESCRIPTION
## Summary
- add explicit Flow semantic fallback annotations to every seed pack so `flow_evaluate_invariants` can discover full `invariants.harn` files
- teach `validate_canon.py` to require semantic fallbacks and verify they reference a same-pack deterministic predicate
- route deterministic fixture execution through Harn's `flow_evaluate_invariants` runtime instead of direct predicate calls

## Verification
- `python3 -m py_compile scripts/validate_canon.py scripts/execute_fixtures.py`
- `python3 scripts/validate_canon.py`
- `git diff --check`
- `PATH=/private/tmp/harn-0.8.168-bin:$PATH harn fmt --check <changed harn files>`
- `PATH=/private/tmp/harn-0.8.168-bin:$PATH harn check` on every `invariants.harn`
- `PATH=/private/tmp/harn-0.8.168-bin:$PATH harn lint` on every `invariants.harn` (existing unused-evidence warnings only; exit 0)
- `PATH=/private/tmp/harn-0.8.168-bin:$PATH python3 scripts/execute_fixtures.py`
