### PR TITLE
Tighten Zig ArrayList allocator migration canon

### DIFF
--- a/zig/README.md
+++ b/zig/README.md
@@ -41,7 +41,7 @@ Evidence scanned on 2026-05-10, 2026-06-23, 2026-07-01, and 2026-07-02.
 - Zig source `doc/build.zig.zon.md` for the manifest schema, including `.minimum_zig_version` (advisory) and the `.hash` requirement on URL-based dependencies.
 - Zig Build System tutorial (`ziglang.org/learn/build-system`) for package-manager workflow guidance.
 - The Zig Guide community handbook (`zig.guide`) for error-handling and allocator idioms.
-- Zig 0.16.0 release notes for the migration to unmanaged containers.
+- Zig 0.16.0 release notes for the migration to unmanaged containers and allocator-taking ArrayList methods.
 - Zig standard library JSON source and current zig.guide JSON examples for `std.json.parseFromSlice`.
 - Zig standard library JSON parser, JSON hashmap, array-hash-map sources, and memory docs for `std.json.ArrayHashMap` ownership and cleanup.
 - Zig standard library hash map and array hash map sources, plus current zig.guide hash map examples, for the public `.count()` API on map values.
@@ -63,7 +63,11 @@ Evidence scanned on 2026-05-10, 2026-06-23, 2026-07-01, and 2026-07-02.
 - `parsed_json_arrayhashmap_has_single_owner` has two file-local checks. The parsed-value check requires `std.json.ArrayHashMap`, `std.json.parseFromSlice`, and a manual `.value...map.deinit(...)` in the same changed file. The manual-key check looks for `allocator.dupe` or `dupeZ`, insertion through common `.map` insert APIs, and `.map.deinit(...)` without an entry loop that frees `entry.key_ptr.*` or `entry.key`. It can miss helper-based cleanup in another file and can block unusual code that intentionally copies a parsed value into a new owner or uses a custom key-cleanup helper.
 - `hashmap_count_uses_count_method` requires a recognized Zig hash map type in the file and then scans for likely map-shaped `.size` reads such as `map.size`, `user_map.size`, or `.items.map.size`. It can miss unusually named map variables and can false-positive on a non-map field named `size` in the same changed file.
 - `enum_tags_use_tag_name_builtin` is an exact token scan. A comment or string literal that mentions `std.meta.tagToString(` will be blocked until the pack can use AST facts.
-- `arraylist_uses_unmanaged_api` blocks `std.ArrayList(T).init(allocator)` in current Zig code. Projects pinned to older Zig releases may need to suppress or opt out of this predicate.
+- `arraylist_uses_unmanaged_api` blocks `std.ArrayList(T).init(allocator)` in current Zig code and recognizes
+  direct `const` or `var` declarations of `std.ArrayList(T) = .empty` whose mutating or ownership calls still
+  omit allocator arguments. Projects pinned to older Zig releases may need to suppress or opt out of this predicate.
+  The method-call arm can miss aliases and helper-returned lists, and can block unrelated allocator-less method
+  calls in the same file as a direct `.empty` declaration.
 - `defer_block_closes_without_semicolon` scans from a `defer {` opener to a line containing only `};`. A multiline struct literal inside a defer body that also has a standalone `};` line can false-positive.
 - `doc_comments_attach_to_declarations` is intentionally narrow. It blocks `///` immediately before statement-shaped lines such as `return`, `try`, `defer`, and `if`, but can miss misplaced doc comments before local `const` or `var` declarations to avoid false-positives on documented top-level declarations.
 - Semantic predicates depend on a cheap judge. They should stay high-threshold and cite concrete changed spans before blocking.

--- a/zig/fixtures/arraylist_uses_unmanaged_api.json
+++ b/zig/fixtures/arraylist_uses_unmanaged_api.json
@@ -12,6 +12,16 @@
       ]
     },
     {
+      "name": "blocks_empty_arraylist_methods_without_allocator",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/schema.zig",
+          "text": "const std = @import(\"std\");\n\npub fn collect(allocator: std.mem.Allocator) ![]u8 {\n    _ = allocator;\n    var out: std.ArrayList(u8) = .empty;\n    defer out.deinit();\n    try out.append('x');\n    return out.toOwnedSlice();\n}\n"
+        }
+      ]
+    },
+    {
       "name": "allows_unmanaged_arraylist_empty",
       "expect": "Allow",
       "files": [

--- a/zig/invariants.harn
+++ b/zig/invariants.harn
@@ -385,10 +385,26 @@ pub fn enum_tags_use_tag_name_builtin(slice, _ctx, _repo_at_base) {
 @archivist(evidence: _EVIDENCE_ARRAYLIST_UNMANAGED, confidence: 0.78, source_date: "2026-06-23")
 /** Blocks the old managed std.ArrayList(T).init(allocator) spelling in current Zig code. */
 pub fn arraylist_uses_unmanaged_api(slice, _ctx, _repo_at_base) {
-  let findings = scan_files(zig_files(slice), r"\bstd\.ArrayList\s*\([^\n]+?\)\.init\s*\(")
+  let findings = scan_files_if(
+    zig_files(slice),
+    { file -> regex_match(r"\bstd\.ArrayList\s*\([^\n]+?\)\.init\s*\(", file.text, "s") != nil
+      || (regex_match(
+      r"\b(?:const|var)\s+[A-Za-z_][A-Za-z0-9_]*\s*:\s*std\.ArrayList\s*\([^)\n]+\)\s*=\s*\.empty\b",
+      file.text,
+      "s",
+    )
+      != nil
+      && (regex_match(
+      r"\.(?:append|appendSlice|insert|insertSlice|resize|ensureTotalCapacity|ensureUnusedCapacity)\s*\(\s*[^,\n)]*\s*\)",
+      file.text,
+      "s",
+    )
+      != nil
+      || regex_match(r"\.(?:deinit|toOwnedSlice)\s*\(\s*\)", file.text, "s") != nil)) },
+  )
   return block_on_findings(
     "arraylist_uses_unmanaged_api",
-    "Initialize current `std.ArrayList(T)` values with `.empty`; pass the allocator to methods such as `append`, `toOwnedSlice`, and `deinit`.",
+    "Initialize current `std.ArrayList(T)` values with `.empty`, then pass the allocator to mutating and ownership methods such as `append`, `toOwnedSlice`, and `deinit`.",
     findings,
   )
 }


### PR DESCRIPTION
## Summary
- extend the existing `arraylist_uses_unmanaged_api` Zig predicate to catch half-migrated `std.ArrayList(T) = .empty` code that still calls allocator-taking methods without an allocator
- add a fixture case for `deinit()`, `append(value)`, and `toOwnedSlice()` on current ArrayList values
- update the Zig pack README with the method-call scope and false-positive boundary

## Notes
I folded this into the existing ArrayList migration predicate instead of adding a new predicate, because the Zig pack is already at its deterministic predicate cap and the existing rule already owns this API migration surface.

## Verification
- `python3 scripts/validate_canon.py`
- `python3 -m py_compile scripts/validate_canon.py`
- `harn fmt --check zig/invariants.harn`
- `python3 scripts/execute_fixtures.py --pack zig`
- `git diff --check`