### PR TITLE
Tighten Zig getOrPut key ownership invariant

### DIFF
--- a/zig/README.md
+++ b/zig/README.md
@@ -22,7 +22,7 @@ This pack covers Zig source (`.zig`) and the `build.zig.zon` package manifest. Z
 | `build_zon_min_zig_version_set` | deterministic | Warn | `build.zig.zon` should set `.minimum_zig_version` so toolchain assumptions stay machine-readable. |
 | `build_zon_dependency_hash_pinned` | deterministic | Block | URL-based dependency entries in `build.zig.zon` must declare a `.hash` so package fetches are content-verified. |
 | `no_std_json_parser_api` | deterministic | Block | Current Zig code should use `std.json.parseFromSlice` or `std.json.Scanner`, not the removed `std.json.Parser` type. |
-| `parsed_json_arrayhashmap_has_single_owner` | deterministic | Block | `std.json.ArrayHashMap` ownership stays single-owner: parsed values deinit through `parsed.deinit()`, and duplicated manual keys need explicit key frees. |
+| `parsed_json_arrayhashmap_has_single_owner` | deterministic | Block | `std.json.ArrayHashMap` ownership stays single-owner: parsed values deinit through `parsed.deinit()`, duplicated stored keys are freed, and unused duplicated `getOrPut` keys are freed on `found_existing`. |
 | `hashmap_count_uses_count_method` | deterministic | Block | Zig hash maps expose their element count through `.count()`; stale `.size` reads should not ship. |
 | `enum_tags_use_tag_name_builtin` | deterministic | Block | Enum and tagged-union values use the `@tagName(value)` builtin for names, not stale `std.meta.tagToString(...)` calls. |
 | `arraylist_uses_unmanaged_api` | deterministic | Block | Current `std.ArrayList(T)` values initialize with `.empty`; allocator-bearing calls happen on methods. |
@@ -43,7 +43,7 @@ Evidence scanned on 2026-05-10, 2026-06-23, 2026-07-01, and 2026-07-02.
 - The Zig Guide community handbook (`zig.guide`) for error-handling and allocator idioms.
 - Zig 0.16.0 release notes for the migration to unmanaged containers and allocator-taking ArrayList methods.
 - Zig standard library JSON source and current zig.guide JSON examples for `std.json.parseFromSlice`.
-- Zig standard library JSON parser, JSON hashmap, array-hash-map sources, and memory docs for `std.json.ArrayHashMap` ownership and cleanup.
+- Zig standard library JSON parser, JSON hashmap, array-hash-map sources, and memory docs for `std.json.ArrayHashMap` ownership, cleanup, and `getOrPut` key lifetime.
 - Zig standard library hash map and array hash map sources, plus current zig.guide hash map examples, for the public `.count()` API on map values.
 - Zig language reference, Zig standard library `std.meta` source, and current zig.guide enum examples for `@tagName(value)` and `std.meta.stringToEnum`.
 - Zig language reference and zig.guide examples for `defer` semantics and block-form usage.
@@ -60,7 +60,7 @@ Evidence scanned on 2026-05-10, 2026-06-23, 2026-07-01, and 2026-07-02.
 - `tests_use_testing_allocator` keys on the literal identifiers `page_allocator` and `c_allocator`. Aliased re-exports (`const A = std.heap.page_allocator;` re-exported under another name) will be missed.
 - `build_zon_dependency_hash_pinned` only flags URL-based entries that lack a hash; entries using `.path = ...` are skipped, matching the manifest schema.
 - `no_std_json_parser_api` is a token scan. A prose comment or string literal mentioning `std.json.Parser` will be blocked until the pack can use AST facts.
-- `parsed_json_arrayhashmap_has_single_owner` has two file-local checks. The parsed-value check requires `std.json.ArrayHashMap`, `std.json.parseFromSlice`, and a manual `.value...map.deinit(...)` in the same changed file. The manual-key check looks for `allocator.dupe` or `dupeZ`, insertion through common `.map` insert APIs, and `.map.deinit(...)` without an entry loop that frees `entry.key_ptr.*` or `entry.key`. It can miss helper-based cleanup in another file and can block unusual code that intentionally copies a parsed value into a new owner or uses a custom key-cleanup helper.
+- `parsed_json_arrayhashmap_has_single_owner` has file-local checks. The parsed-value check requires `std.json.ArrayHashMap`, `std.json.parseFromSlice`, and a manual `.value...map.deinit(...)` in the same changed file. The manual-key check looks for `allocator.dupe` or `dupeZ`, insertion through common `.map` insert APIs, and `.map.deinit(...)` without an entry loop that frees `entry.key_ptr.*` or `entry.key`. The `getOrPut` collision check requires a duplicated `u8` key, `getOrPut`, and a `found_existing` branch, then expects a direct `free(key)`-shaped cleanup for the unused duplicate. It can miss helper-based cleanup in another file and can block unusual code that intentionally copies a parsed value into a new owner or uses a custom key-cleanup helper.
 - `hashmap_count_uses_count_method` requires a recognized Zig hash map type in the file and then scans for likely map-shaped `.size` reads such as `map.size`, `user_map.size`, or `.items.map.size`. It can miss unusually named map variables and can false-positive on a non-map field named `size` in the same changed file.
 - `enum_tags_use_tag_name_builtin` is an exact token scan. A comment or string literal that mentions `std.meta.tagToString(` will be blocked until the pack can use AST facts.
 - `arraylist_uses_unmanaged_api` blocks `std.ArrayList(T).init(allocator)` in current Zig code and recognizes

--- a/zig/fixtures/parsed_json_arrayhashmap_has_single_owner.json
+++ b/zig/fixtures/parsed_json_arrayhashmap_has_single_owner.json
@@ -72,6 +72,26 @@
       ]
     },
     {
+      "name": "blocks_get_or_put_existing_entry_leaks_duped_key",
+      "expect": "Block",
+      "files": [
+        {
+          "path": "src/schema.zig",
+          "text": "const std = @import(\"std\");\n\nconst Item = struct { value: u32 };\n\npub fn build(allocator: std.mem.Allocator, raw: []const u8) !std.json.ArrayHashMap(Item) {\n    var items: std.json.ArrayHashMap(Item) = .{ .map = .empty };\n    errdefer items.map.deinit(allocator);\n\n    const key = try allocator.dupe(u8, raw);\n    const entry = try items.map.getOrPut(allocator, key);\n    if (entry.found_existing) {\n        return items;\n    }\n    entry.value_ptr.* = .{ .value = 1 };\n    return items;\n}\n\npub fn release(allocator: std.mem.Allocator, items: *std.json.ArrayHashMap(Item)) void {\n    var iter = items.map.iterator();\n    while (iter.next()) |entry| {\n        allocator.free(entry.key_ptr.*);\n    }\n    items.map.deinit(allocator);\n}\n"
+        }
+      ]
+    },
+    {
+      "name": "allows_get_or_put_existing_entry_frees_unused_key",
+      "expect": "Allow",
+      "files": [
+        {
+          "path": "src/schema.zig",
+          "text": "const std = @import(\"std\");\n\nconst Item = struct { value: u32 };\n\npub fn build(allocator: std.mem.Allocator, raw: []const u8) !std.json.ArrayHashMap(Item) {\n    var items: std.json.ArrayHashMap(Item) = .{ .map = .empty };\n    errdefer items.map.deinit(allocator);\n\n    const key = try allocator.dupe(u8, raw);\n    const entry = try items.map.getOrPut(allocator, key);\n    if (entry.found_existing) {\n        allocator.free(key);\n        return items;\n    }\n    entry.value_ptr.* = .{ .value = 1 };\n    return items;\n}\n\npub fn release(allocator: std.mem.Allocator, items: *std.json.ArrayHashMap(Item)) void {\n    var iter = items.map.iterator();\n    while (iter.next()) |entry| {\n        allocator.free(entry.key_ptr.*);\n    }\n    items.map.deinit(allocator);\n}\n"
+        }
+      ]
+    },
+    {
       "name": "allows_borrowed_static_key",
       "expect": "Allow",
       "files": [

--- a/zig/invariants.harn
+++ b/zig/invariants.harn
@@ -331,11 +331,20 @@ pub fn parsed_json_arrayhashmap_has_single_owner(slice, _ctx, _repo_at_base) {
     )
       != nil
       && regex_match(r"\.map\.deinit\s*\(", file.text, "s") != nil
-      && regex_match(r"\bfree\s*\([^)]*(?:\.key_ptr\.\*|\.key)\s*\)", file.text, "s") == nil)) },
+      && regex_match(r"\bfree\s*\([^)]*(?:\.key_ptr\.\*|\.key)\s*\)", file.text, "s") == nil)
+      || (regex_match(r"\b[A-Za-z_][A-Za-z0-9_]*\.dupeZ?\s*\(\s*u8\b", file.text, "s") != nil
+      && regex_match(r"\.map\.getOrPut(?:AssumeCapacity)?\s*\(", file.text, "s") != nil
+      && regex_match(r"\.found_existing\b", file.text, "s") != nil
+      && regex_match(
+      r"\bfree\s*\(\s*(?:key|[A-Za-z_][A-Za-z0-9_]*_key|key_[A-Za-z0-9_]*)\s*\)",
+      file.text,
+      "s",
+    )
+      == nil)) },
   )
   return block_on_findings(
     "parsed_json_arrayhashmap_has_single_owner",
-    "Keep `std.json.ArrayHashMap` ownership single-owner: use `parsed.deinit()` for parsed values, and free every duplicated manual key before `map.deinit(allocator)`.",
+    "Use `parsed.deinit()` for parsed values; free duplicated stored keys before map deinit; free unused duplicated getOrPut keys when `found_existing` is true.",
     findings,
   )
 }


### PR DESCRIPTION
## Summary
- Tighten the Zig `parsed_json_arrayhashmap_has_single_owner` predicate for duplicated `getOrPut` keys
- Block `found_existing` paths that leak an unused duplicated key even when stored keys are freed at map teardown
- Add paired block/allow fixtures and update the Zig pack README limitations

## Verification
- `python3 scripts/validate_canon.py`
- `python3 scripts/execute_fixtures.py --pack zig`
- `python3 scripts/execute_fixtures.py`
- `python3 -m py_compile scripts/validate_canon.py scripts/execute_fixtures.py`
- `harn check zig/invariants.harn`
- `harn lint zig/invariants.harn` (exits zero; existing evidence-variable warnings are unchanged)
- `harn fmt --check zig/invariants.harn`
- `git diff --check`