### PR TITLE
Expose canon packs as a Harn package contribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ manifest instead of carrying their own language-routing tables. The validator
 treats eval-critical language routes as a contract so convergence packs cannot
 silently disappear from Harn/Burin discovery.
 
+When this repo is installed as a Harn package, `harn.toml` exposes the same
+`canon-packs.json` file as a `harn.canon` contribution. Package consumers should
+read that contribution and still treat `canon-packs.json` as the single source
+of pack routing truth.
+
 Predicate files use Harn attributes to carry evidence:
 
 ```harn

--- a/harn.toml
+++ b/harn.toml
@@ -1,0 +1,14 @@
+[package]
+name = "harn-canon"
+version = "0.1.0"
+description = "Seed Harn Flow invariant packs for language and stack review."
+license = "Apache-2.0 OR MIT"
+repository = "https://github.com/burin-labs/harn-canon"
+harn = ">=0.9,<0.10"
+docs_url = "README.md"
+
+[[contributes]]
+kind = "harn.canon"
+id = "harn-canon"
+title = "Harn Canon"
+manifest = "canon-packs.json"


### PR DESCRIPTION
## Summary
- add harn.toml package metadata for harn-canon
- expose canon-packs.json as a harn.canon package contribution
- document that canon-packs.json remains the single source of pack routing truth

## Validation
- HARN_CANON_TODAY=$(date -u +%F) harn run scripts/validate-canon.harn
- harn check scripts/canon-lib.harn scripts/validate-canon.harn scripts/execute-fixtures.harn
- git diff --check
- /private/tmp/harn-canon-package-discovery/target/codex1-package-check-target/debug/harn package check .

## Notes
Depends on Harn package contribution support merged in burin-labs/harn#4078.