### PR TITLE
Harden canon manifest validation

### DIFF
--- a/scripts/canon-lib.harn
+++ b/scripts/canon-lib.harn
@@ -15,12 +15,20 @@ pub fn repo_root() -> string {
 }
 
 pub fn load_pack_manifest() -> list {
-  const manifest = json_parse(harness.fs.read_text(PACK_MANIFEST_PATH))
+  const manifest = load_pack_manifest_document()
   const packs = manifest?.packs ?? []
   if manifest?.schema_version != 1 || type_of(packs) != "list" {
     throw "canon-packs.json must use schema_version 1 with a packs list"
   }
   return packs
+}
+
+pub fn load_pack_manifest_document() -> dict {
+  const manifest = json_parse(harness.fs.read_text(PACK_MANIFEST_PATH))
+  if type_of(manifest) != "dict" {
+    throw "canon-packs.json must be a JSON object"
+  }
+  return manifest
 }
 
 pub fn expected_packs() -> list<string> {

--- a/scripts/validate-canon.harn
+++ b/scripts/validate-canon.harn
@@ -4,6 +4,7 @@ import {
   expected_packs,
   is_normalized_relative_path,
   load_pack_manifest,
+  load_pack_manifest_document,
   parse_invariants,
   parse_ymd,
   repo_root,
@@ -43,6 +44,8 @@ const FIXTURE_KEYS = ["predicate", "cases"]
 const CASE_KEYS = ["name", "expect", "files", "ctx"]
 
 const FILE_KEYS = ["path", "text"]
+
+const PACK_MANIFEST_ROOT_KEYS = ["schema_version", "packs"]
 
 const PACK_MANIFEST_KEYS = ["id", "title", "invariants", "fixtures", "extensions", "file_names"]
 
@@ -130,7 +133,10 @@ fn validate_manifest(errors: list<string>) -> list<string> {
   let out = errors
   let seen = {}
   let packs_by_id = {}
+  const manifest = load_pack_manifest_document()
+  out = validate_allowed_keys("canon-packs.json", "manifest root", manifest, PACK_MANIFEST_ROOT_KEYS, out)
   const packs = load_pack_manifest()
+  let pack_ids: list<string> = []
   for index in range(0, len(packs)) {
     const pack = packs[index]
     if type_of(pack) != "dict" {
@@ -148,6 +154,7 @@ fn validate_manifest(errors: list<string>) -> list<string> {
     }
     seen[pack_id] = true
     packs_by_id[pack_id] = pack
+    pack_ids = pack_ids + [pack_id]
     const expected_invariants = pack_id + "/invariants.harn"
     const expected_fixtures = pack_id + "/fixtures"
     if pack?.invariants != expected_invariants {
@@ -166,6 +173,9 @@ fn validate_manifest(errors: list<string>) -> list<string> {
       out = out + ["canon-packs.json: " + expected_fixtures + " does not exist"]
     }
     out = validate_routing_selectors(pack_id, pack, out)
+  }
+  if pack_ids != pack_ids.sort() {
+    out = out + ["canon-packs.json: packs must be sorted by id"]
   }
   return validate_eval_critical_routes(packs_by_id, out)
 }


### PR DESCRIPTION
## Summary

- add a shared `load_pack_manifest_document()` helper so validators can inspect the canonical manifest root
- reject unknown root keys in `canon-packs.json`
- require manifest pack rows to stay sorted by `id`, preserving stable routing diffs for hosts that consume the manifest as the SSOT

## Validation

- `harn fmt --check scripts/canon-lib.harn scripts/validate-canon.harn`
- `harn check scripts/canon-lib.harn scripts/validate-canon.harn scripts/execute-fixtures.harn`
- `HARN_CANON_TODAY=2026-07-08 harn run scripts/validate-canon.harn`
- `harn run scripts/execute-fixtures.harn`
- `git diff --check`
- `git verify-commit HEAD`