### PR TITLE
Use sentence case in language pack headings

### DIFF
--- a/c/README.md
+++ b/c/README.md
@@ -2,7 +2,7 @@
 
 This pack covers plain C source and header files for hosted application and library code. It targets the high-signal review issues an Archivist can catch cheaply on changed slices: classic memory and string-handling footguns (`gets`, unbounded copies, format-string vulns), unsafe entry points (`void main`, `tmpnam`/`mktemp`), parsing helpers that swallow errors (`atoi`/`atol`/`atof`), header hygiene, and stack-allocation hazards. Three semantic predicates carry the load that regex cannot: NULL-return checks on heap allocations, evidence of a static-analyzer or sanitizer pipeline, and vulnerability-check evidence for native dependency changes.
 
-## Stack Assumptions
+## Stack assumptions
 
 - C source files use `.c`; C headers use `.h`. Files containing only C++ (`.cc`, `.cpp`, `.cxx`, `.hpp`) are out of scope for this pack; use the C++ pack for those.
 - Production paths exclude any path under `test/`, `tests/`, `unittest/`, `unittests/`, and any file matching `*_test.c`, `*_tests.c`, or `test_main.c`.
@@ -11,7 +11,7 @@ This pack covers plain C source and header files for hosted application and libr
 - Semantic predicates make a single judge call over changed C and project files using only evidence captured at authoring time.
 - Hosted environment is assumed (i.e., `int main` is required). Freestanding builds (kernel, embedded firmware, microcontrollers) should suppress `no_void_main` locally once the predicate runtime supports suppressions.
 
-## Predicate Coverage
+## Predicate coverage
 
 | Predicate | Mode | Verdict | Purpose |
 |---|---|---|---|
@@ -41,7 +41,7 @@ Evidence scanned on 2026-05-10.
 - **Style guides**: Google C++ Style Guide on `#define` header guards (applies cleanly to C).
 - **Dependency security**: OSV.dev, Microsoft `vcpkg` docs, Conan 2.x requirements docs, GitHub Dependabot configuration docs.
 
-## Known False Positives
+## Known false positives
 
 - Regex predicates do not parse C. Macro-expanded names, comments containing the function names, string-literal arguments quoting the names, and unusual whitespace can confuse deterministic checks.
 - `no_format_string_from_variable` matches conservative patterns: a bare identifier as the format argument for `printf`/`vprintf`/`sprintf`/`vsprintf`, the second argument for `fprintf`/`dprintf`/`vfprintf`/`syslog`, and the third argument for `snprintf`/`vsnprintf`. Helper wrappers that take a `va_list` and call-expression format arguments such as `printf(get_msg())` are false negatives this predicate intentionally does not cover; rely on `static_analyzer_clean` (clang-analyzer's `-Wformat-nonliteral`) for those. Calls that build the format via `strcat` and then pass the buffer are likewise covered by `static_analyzer_clean` or `bounded_string_ops`.

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -2,7 +2,7 @@
 
 This pack covers plain C++ application and library code with an emphasis on memory safety, modern initialization, header hygiene, and special-member discipline. The v0 rules deliberately use simple source-text predicates where a failure mode is concrete (raw `new`/`delete`, `malloc`/`free`, `NULL`, missing include guards, `using namespace` in headers, C-style casts, `typedef`) and lean on semantic predicates where C++ class context is too rich for regex alone (Rule of Five, member initialization, const correctness).
 
-## Stack Assumptions
+## Stack assumptions
 
 - C++ source files use `.cpp`, `.cxx`, `.cc`, or `.c++`. Headers use `.h`, `.hpp`, `.hh`, `.hxx`, `.h++`, `.ipp`, `.tpp`, or `.inl`.
 - The pack targets C++17 and later. `nullptr`, `=default`/`=delete`, in-class member initializers, `using` aliases, and named casts are all assumed available.
@@ -11,7 +11,7 @@ This pack covers plain C++ application and library code with an emphasis on memo
 - Deterministic predicates run over changed source text until Flow exposes a stable Clang/`libclang` AST query API; semantic predicates make a single judge call over the changed slice.
 - The pack is a seed canon, not a replacement for clang-tidy, the C++ compiler, AddressSanitizer/UBSan, or runtime profiling.
 
-## Predicate Coverage
+## Predicate coverage
 
 | Predicate | Mode | Verdict | Purpose |
 |---|---|---|---|
@@ -35,7 +35,7 @@ Evidence scanned on 2026-05-10.
 - cppreference: `nullptr`, `unique_ptr`, the rule of three/five, and the `#include` and `#pragma once` preprocessor reference pages.
 - Google C++ Style Guide: namespaces section on `using namespace` discipline.
 
-## Known False Positives
+## Known false positives
 
 - All deterministic predicates scan raw file text. Source comments, raw string literals, and `#define` bodies that contain `new`, `delete`, `malloc`, `NULL`, `typedef`, or `using namespace` token sequences will be flagged until the pack runs against an AST query layer.
 - `no_raw_new_delete` matches `new T` and `delete ptr` in any context. Placement `new` (`new (mem) T`) deliberately bypasses the regex (`new` is followed by `(`, not an identifier); flag-and-grep is the recommended audit until placement new gets first-class detection.

--- a/csharp/README.md
+++ b/csharp/README.md
@@ -2,14 +2,14 @@
 
 This pack covers plain C# and .NET library or application code before framework-specific packs such as ASP.NET Core, MAUI, Unity, or Orleans add tighter local rules. It focuses on high-signal defaults for nullable safety, async correctness, analyzer hygiene, exception diagnostics, and security-sensitive data handling.
 
-## Stack Assumptions
+## Stack assumptions
 
 - Files use `.cs`; project checks target `.csproj`, `Directory.Build.props`, and `Directory.Build.targets`.
 - Projects use SDK-style .NET builds with nullable reference types enabled centrally or in each changed project file.
 - Deterministic predicates operate over changed source text until Flow exposes stable Roslyn symbols, analyzer configuration, and effective MSBuild property queries.
 - Semantic predicates may block only when the judge can cite a concrete changed span and the issue is not reliably expressible with simple syntax checks.
 
-## Predicate Coverage
+## Predicate coverage
 
 | Predicate | Mode | Verdict | Purpose |
 |---|---|---|---|
@@ -35,7 +35,7 @@ Evidence scanned on 2026-05-08.
 - OWASP cheat sheets for SQL injection prevention, logging, and secrets management.
 - GitHub secret scanning docs for hardcoded credential risk and remediation context.
 
-## Known False Positives
+## Known false positives
 
 - Regex predicates are intentionally conservative and file-scoped. A file containing both an offending pattern and an allowed pattern may be allowed until Roslyn-level matching lands.
 - `nullable_reference_types_enabled` only inspects changed project/default files. The intended runtime form should resolve the effective nullable context for each touched C# file.

--- a/css/README.md
+++ b/css/README.md
@@ -2,7 +2,7 @@
 
 This pack covers vanilla CSS plus the common preprocessor dialects (Sass `.scss`/`.sass`, Less `.less`). It targets review issues that changed stylesheet slices can catch cheaply: cascade hygiene (`!important`, id selectors), internationalization (logical properties), unit hygiene (zero values, absolute font sizes), and accessibility (focus indicators, reduced-motion respect).
 
-## Stack Assumptions
+## Stack assumptions
 
 - Source files end in `.css`, `.scss`, `.sass`, or `.less`. CSS-in-JS, styled-components, and tagged-template stylesheets are out of scope until Harn Flow exposes a stable embedded-CSS extractor.
 - Vendor and build artifacts under `node_modules/`, `vendor/`, `dist/`, `build/`, or matching `*.min.css`/`*.min.scss`/`*.min.less` are skipped.
@@ -11,7 +11,7 @@ This pack covers vanilla CSS plus the common preprocessor dialects (Sass `.scss`
 - Semantic predicates make one cheap judge call over changed stylesheets and use only evidence captured at authoring time.
 - Advisory rules return `Warn` when stylistic exceptions are common (vendor-driven id usage, intentionally physical layouts, decorative micro-transitions). Blocking rules are reserved for `!important` without justification, suppressed focus indicators, and motion that ignores `prefers-reduced-motion`.
 
-## Predicate Coverage
+## Predicate coverage
 
 | Predicate | Mode | Verdict | Purpose |
 |---|---|---|---|
@@ -33,7 +33,7 @@ Evidence scanned on 2026-05-09.
 - web.dev: logical-properties learn module, font-size guidance, reduced-motion article.
 - Stylelint docs: `declaration-no-important`, `selector-max-id`, `length-zero-no-unit` rule references for cross-tool calibration of common style issues.
 
-## Known False Positives
+## Known false positives
 
 - Regex predicates do not parse CSS. Comments, multi-line declarations, Sass interpolation, nested rules, and `@supports` blocks can confuse deterministic checks.
 - `no_important_without_comment` accepts the file as soon as one `!important` is paired with a nearby comment; multiple unjustified overrides in the same file will not all be flagged independently. It also cannot tell whether a comment actually explains the override versus being unrelated.

--- a/dart/README.md
+++ b/dart/README.md
@@ -2,7 +2,7 @@
 
 This pack covers Dart application, package, and Flutter source with an emphasis on null safety, public-API hygiene, async correctness, and Flutter widget immutability. The v0 rules favor simple source-text predicates for concrete failure modes and semantic predicates where Dart and Flutter framework contracts require code context the regex layer cannot infer.
 
-## Stack Assumptions
+## Stack assumptions
 
 - Files use the `.dart` extension and target Dart 3.x (sound null safety required) and current Flutter stable.
 - Projects may use the standard `pub` package layout (`lib/`, `bin/`, `test/`, `integration_test/`, `example/`) and code generation tools that emit `*.g.dart`, `*.freezed.dart`, `*.gr.dart`, `*.config.dart`, `*.mocks.dart`, `*.chopper.dart`, and protobuf `*.pb.dart` files.
@@ -11,7 +11,7 @@ This pack covers Dart application, package, and Flutter source with an emphasis 
 - Semantic predicates use `ctx.semantic_judge(...)` and must cite concrete changed spans before blocking.
 - The pack is a seed canon, not a replacement for `dart analyze`, `flutter analyze`, the official lint rule sets in `package:lints` or `package:flutter_lints`, or `dart format`.
 
-## Predicate Coverage
+## Predicate coverage
 
 | Predicate | Mode | Verdict | Purpose |
 |---|---|---|---|
@@ -38,7 +38,7 @@ Evidence scanned on 2026-05-10.
 - api.flutter.dev: `StatelessWidget` class docs and the `@immutable` annotation as the framework contract behind widget immutability.
 - dart.dev tooling: pub package layout and the analyzer overview that govern import-path expectations and `// ignore_for_file` directives.
 
-## Known False Positives
+## Known false positives
 
 - `no_force_null_assertion` is source-text based. It can flag legitimate `expr!` uses where the type system genuinely cannot prove non-null (for example, a generated `late` field accessed after a documented init step). Until predicate-level suppressions exist, prefer narrowing the regex with a wrapper or refactoring the call site.
 - `no_dynamic_in_signatures` warns on any function whose return or parameter type is the keyword `dynamic`. It does not currently detect `dynamic` inside generic positions like `List<dynamic>`, and it may catch generated adapters that legitimately return `dynamic`; route those files through `is_generated_path` or rename them to a generated suffix.

--- a/dockerfile/README.md
+++ b/dockerfile/README.md
@@ -2,7 +2,7 @@
 
 This pack covers `Dockerfile` and `Containerfile` build recipes. It targets high-signal review issues that changed Dockerfile slices can catch cheaply: floating base-image tags, noisy or leaky `apt-get` invocations, `ADD` misuse, supply-chain-unsafe `curl | sh` installs, missing non-root user, secret-shaped values baked into image layers, shell-form `CMD`/`ENTRYPOINT`, single-stage builds that ship build toolchains, and unnecessary layer fragmentation.
 
-## Stack Assumptions
+## Stack assumptions
 
 - Build recipes are named `Dockerfile`, `Dockerfile.<variant>`, `<name>.Dockerfile`, or `Containerfile` (Podman/Buildah convention).
 - Dockerfiles are linted as build-system source, so every changed file flows through this pack regardless of subdirectory.
@@ -10,7 +10,7 @@ This pack covers `Dockerfile` and `Containerfile` build recipes. It targets high
 - Semantic predicates make one cheap judge call over changed Dockerfiles and use only evidence captured at authoring time.
 - Advisory rules return `Warn` when idiomatic exceptions are common (slim base images that already drop privileges, `apt-get`-free distros, single-stage debug images). Blocking rules are reserved for floating base-image tags, `curl | sh` installs, and secrets baked into `ENV`/`ARG`.
 
-## Predicate Coverage
+## Predicate coverage
 
 | Predicate | Mode | Verdict | Purpose |
 |---|---|---|---|
@@ -36,7 +36,7 @@ Evidence scanned on 2026-05-09.
 - OWASP Secrets Management Cheat Sheet for hardcoded credential risk.
 - Debian `apt-get` manpage for `--no-install-recommends` semantics.
 
-## Known False Positives
+## Known false positives
 
 - Regex predicates do not parse Dockerfiles. Inline comments, `\` line continuations across many lines, heredocs, and multi-stage `FROM ... AS build` aliases can confuse deterministic checks.
 - `no_latest_or_unpinned_base_image` allows digest pins (`@sha256:...`) and any explicit non-`latest` tag, and exempts `FROM scratch`. It handles common `FROM --flag=value image` forms, but full reference parsing still belongs in a Dockerfile parser. Pin freshness stays in dependency management.

--- a/elixir/README.md
+++ b/elixir/README.md
@@ -2,7 +2,7 @@
 
 This pack covers general-purpose Elixir application and library code on top of the BEAM. It targets review-slice issues with clear correctness, debuggability, or convention impact: stray debug helpers committed by accident, unbounded atom creation that can exhaust the BEAM atom table, idiomatic flow-control choices, predicate naming, exception handling that drops stacktraces, pipeline readability, error contract drift, GenServer state-shape leakage, and case/cond bodies that should be function clauses.
 
-## Stack Assumptions
+## Stack assumptions
 
 - Source files use the `.ex` and `.exs` extensions.
 - Production paths exclude any path under `test/`, `tests/`, `_build/`, `deps/`, `cover/`, or `.elixir_ls/`, and any file ending in `_test.exs`.
@@ -10,7 +10,7 @@ This pack covers general-purpose Elixir application and library code on top of t
 - Deterministic predicates run over changed source text until Flow exposes a stable Elixir AST query API. Rules with meaningful false-positive risk warn rather than block.
 - Semantic predicates make a single judge call over changed Elixir files and stay conservative — they should only fire when they can cite concrete changed spans.
 
-## Predicate Coverage
+## Predicate coverage
 
 | Predicate | Mode | Verdict | Purpose |
 |---|---|---|---|
@@ -33,7 +33,7 @@ Evidence scanned on 2026-05-10.
 - Elixir official documentation (HexDocs `main`): code anti-patterns, process anti-patterns, naming conventions, library guidelines, the `IO`, `Kernel`, `String`, `IEx`, `Process`, and `GenServer` modules, and the case/cond/if guide.
 - Credo static analysis checks: `Warning.IoInspect`, `Warning.Dbg`, `Warning.IExPry`, `Warning.UnsafeToAtom`, `Warning.RaiseInsideRescue`, `Refactor.UnlessWithElse`, `Refactor.PipeChainStart`, `Refactor.Nesting`, `Readability.PredicateFunctionNames`.
 
-## Known False Positives
+## Known false positives
 
 - Regex predicates are source-text checks. Comments, heredocs, string literals, and metaprogramming can fool them until AST-backed matching lands.
 - `no_io_inspect`, `no_dbg_macro`, and `no_iex_pry` may flag intentional production diagnostics. Prefer `Logger` with explicit levels; suppress narrowly once the runtime supports it.

--- a/go/README.md
+++ b/go/README.md
@@ -2,7 +2,7 @@
 
 This pack covers Go modules, command packages, and reusable libraries. It targets high-signal review issues that changed source slices can catch cheaply: ignored errors, context propagation mistakes, library panics, overly broad exported APIs, lossy error wrapping, duplicate declarations, HTTP response leaks, weak randomness, goroutine lifetime leaks, and dependency vulnerability review.
 
-## Stack Assumptions
+## Stack assumptions
 
 - Go source files use `.go`; module metadata uses `go.mod` and `go.sum`.
 - Production paths exclude `_test.go`, `test/`, `tests/`, and `testdata/` files.
@@ -11,7 +11,7 @@ This pack covers Go modules, command packages, and reusable libraries. It target
 - Semantic predicates make one cheap judge call over changed Go/module files and use only evidence captured at authoring time.
 - Advisory rules return `Warn` when idiomatic exceptions are common. Blocking rules are reserved for ignored errors, library panics, duplicate declarations, likely response-body leaks, security-sensitive randomness, goroutine leaks, and missing dependency-vulnerability evidence.
 
-## Predicate Coverage
+## Predicate coverage
 
 | Predicate | Mode | Verdict | Purpose |
 |---|---|---|---|
@@ -39,7 +39,7 @@ Most evidence was scanned on 2026-05-08. The Go language spec declaration and me
 - Go vulnerability tooling and dependency docs: module dependency management and `govulncheck`.
 - GitHub Dependabot docs: dependency update and security automation paths.
 
-## Known False Positives
+## Known false positives
 
 - Regex predicates do not parse Go. Comments, raw strings, nested function literals, unusual formatting, and aliases can confuse deterministic checks.
 - `no_ignored_errors` intentionally catches obvious `_ = call()` and `value, _ := call()` shapes, but it cannot prove the discarded result has type `error`.

--- a/graphql/README.md
+++ b/graphql/README.md
@@ -2,7 +2,7 @@
 
 This pack covers GraphQL schema files (`.graphql`, `.graphqls`, `.gql`) and the server wiring that hosts them. The surface area is small relative to a full language pack, so v0 prioritizes high-signal naming, documentation, evolution, and resource-bound rules drawn from the GraphQL spec, the Apollo schema-design tech notes, the Relay connection spec, and the OWASP GraphQL cheat sheet.
 
-## Stack Assumptions
+## Stack assumptions
 
 - Schema checks target `.graphql`, `.graphqls`, and `.gql` files. Generated paths (`/generated/`, `/__generated__/`, `*.generated.*`) are excluded.
 - Schemas are written in GraphQL SDL, not introspected JSON; client document linting belongs in a separate pack.
@@ -10,7 +10,7 @@ This pack covers GraphQL schema files (`.graphql`, `.graphqls`, `.gql`) and the 
 - Deterministic predicates run over changed schema source text. AST queries will replace the regexes once Flow exposes a stable GraphQL query API.
 - Semantic predicates use `ctx.semantic_judge(...)` and must cite concrete changed spans before blocking; schema-evolution checks rely on the judge to reason about the diff until the runtime exposes paired base-and-head schema snapshots.
 
-## Predicate Coverage
+## Predicate coverage
 
 | Predicate | Mode | Verdict | Purpose |
 |---|---|---|---|
@@ -36,7 +36,7 @@ Evidence scanned on 2026-05-09.
 - The Guild graphql-inspector docs for diff-based breaking-change detection.
 - OWASP GraphQL Security Cheat Sheet for query-cost and depth-limit guidance.
 
-## Known False Positives
+## Known false positives
 
 - `enum_values_upper_snake_case` is line-anchored: an enum value that starts with an uppercase letter but contains lowercase mid-identifier (`MixedCase`) is not flagged until AST checks land.
 - `no_double_underscore_names` matches type and field declaration sites only; it does not inspect references to introspection types in queries.

--- a/harn/README.md
+++ b/harn/README.md
@@ -2,14 +2,14 @@
 
 This pack covers Harn scripts, Flow workflows, and agent-facing Harn modules. It is intentionally focused on the mistakes most likely to create nondeterminism, runaway cost, schema drift, or unsafe agent behavior.
 
-## Stack Assumptions
+## Stack assumptions
 
 - Files use the `.harn` extension and current Harn syntax.
 - The Flow predicate runtime provides `Slice`, `Context`, `Repo`, and `ctx.semantic_judge(...)` through Harn.
 - Deterministic predicates run over changed Harn source text. They prefer conservative warnings when regex matching can produce false positives.
 - Semantic predicates are strict-gate candidates only when the judge can cite a concrete changed span.
 
-## Predicate Coverage
+## Predicate coverage
 
 | Predicate | Mode | Verdict | Purpose |
 |---|---|---|---|
@@ -41,7 +41,7 @@ Evidence scanned on 2026-04-26 and refreshed for Harn channel/OAuth surfaces on 
 - RFC 7591 and RFC 8252: OAuth dynamic client registration validation and native-app loopback redirect exceptions.
 - OWASP Logging Cheat Sheet: data that should be excluded from application logs.
 
-## Known False Positives
+## Known false positives
 
 - Regex predicates are syntax-aware only at the source-text level until Flow exposes a stable Harn AST query API.
 - `parallel_io_sets_max_concurrent` warns on helper calls whose names look like external IO, even when a wrapper has its own limiter.

--- a/haskell/README.md
+++ b/haskell/README.md
@@ -2,7 +2,7 @@
 
 This pack covers general-purpose Haskell application and library code. It targets the well-known footguns that an Archivist can catch cheaply on a changed slice: Prelude partial functions in the public API, `undefined` and `error` stubs, unsafe IO escapes, open imports, missing export lists, single-field records that should be `newtype`s, non-exhaustive pattern matches, orphan typeclass instances, and hardcoded secrets.
 
-## Stack Assumptions
+## Stack assumptions
 
 - Source files use the `.hs` (Haskell) or `.lhs` (literate Haskell) extension.
 - Production paths exclude any path under `test/`, `tests/`, `spec/`, `bench/`, `benches/`, or `examples/`, and any file whose name ends in `Spec.hs`, `Test.hs`, `_spec.hs`, or `_test.hs`.
@@ -10,7 +10,7 @@ This pack covers general-purpose Haskell application and library code. It target
 - Deterministic predicates use file-text regex scans because Harn Flow does not yet expose a stable Haskell AST query API; rules with meaningful false-positive risk warn rather than block. Semantic predicates make a single judge call over changed Haskell files.
 - Predicates are GHC2024-aware: `total_function_semantic_check` and `prefer_newtype_for_single_field` reflect modern GHC defaults (`-Wincomplete-patterns`, `-Wmissing-export-lists`, `-Wmissing-import-lists`).
 
-## Predicate Coverage
+## Predicate coverage
 
 | Predicate | Mode | Verdict | Purpose |
 |---|---|---|---|
@@ -36,7 +36,7 @@ Evidence scanned on 2026-05-10.
 - Haskell 2010 Report §5: module export lists and visibility semantics.
 - OWASP Cheat Sheet Series and GitHub secret-scanning documentation: hardcoded-credential risk and remediation patterns.
 
-## Known False Positives
+## Known false positives
 
 - Regex predicates do not parse Haskell. Comments, string literals, Template Haskell quasi-quotes, and identifier ticks (`head'`) can fool the deterministic checks until AST-backed matching lands.
 - `no_partial_functions_in_pub_api` flags bare uses of `head`/`tail`/`init`/`last`/`fromJust` and the `(!!)` operator. Fully qualified references (`Data.List.head`) are not caught because the leading `.` confuses the boundary heuristic; qualified `Prelude` partials are rare in practice because `Prelude` is auto-imported. Move legitimate partial helpers into an `Internal` module to suppress the rule.

--- a/html/README.md
+++ b/html/README.md
@@ -2,7 +2,7 @@
 
 This pack covers plain HTML markup before framework-specific packs (React, Vue, Astro, server-side templating engines) layer tighter rules on top. It targets high-signal accessibility and security defaults that survive direct inspection of changed HTML files: image alternative text, document language, inline event handlers, inline styles, semantic landmarks, safe new-window anchors, accessible form controls, and accessible link purpose.
 
-## Stack Assumptions
+## Stack assumptions
 
 - Source checks target files ending in `.html` or `.htm`. Templating dialects with non-HTML syntax (`.hbs`, `.ejs`, `.liquid`, `.pug`, framework-specific single-file components) are out of scope until per-framework packs land.
 - Build, dependency, and report directories are excluded: `node_modules/`, `dist/`, `build/`, `out/`, `coverage/`, `vendor/`, `.next/`, `.nuxt/`, `.svelte-kit/`, `.cache/`, `target/`, and `test-results/`.
@@ -10,7 +10,7 @@ This pack covers plain HTML markup before framework-specific packs (React, Vue, 
 - Deterministic predicates are regex-driven scans of changed source text. They are intentionally tolerant of whitespace and case, but they do not parse HTML, so attribute order and quoting style matter.
 - Semantic predicates make one cheap judge call over changed HTML files and use only evidence captured at authoring time. They block only when the judge can cite a concrete changed span.
 
-## Predicate Coverage
+## Predicate coverage
 
 | Predicate | Mode | Verdict | Purpose |
 |---|---|---|---|
@@ -33,7 +33,7 @@ Evidence scanned on 2026-05-09.
 - W3C WCAG 2.2 Understanding documents: Language of Page (3.1.1), Labels or Instructions (3.3.2), and Link Purpose (In Context) (2.4.4).
 - web.dev guides: strict CSP and external-anchors-use-rel-noopener.
 
-## Known False Positives
+## Known false positives
 
 - Regex predicates do not parse HTML. Comments, embedded `<script>` or `<style>` blocks, conditional comments, and unusually formatted multi-line tags can confuse deterministic checks.
 - `images_have_alt_text` ignores `<img>` tags that *contain* an `alt` attribute regardless of value. It does not detect placeholder alt text such as the file name; the semantic judge can still flag those when `link_purpose_is_clear` and follow-up accessibility predicates land.

--- a/java/README.md
+++ b/java/README.md
@@ -2,7 +2,7 @@
 
 This pack covers plain Java application and library code before framework-specific packs such as Spring, Android, or Maven/Gradle policy packs add tighter rules. It focuses on high-signal defaults for generic type safety, nullness contracts, exception handling, logging, immutable data modeling, and untrusted input boundaries.
 
-## Stack Assumptions
+## Stack assumptions
 
 - Source checks target `.java` files; production checks exclude common test paths and `*Test.java`, `*Tests.java`, and `*IT.java`.
 - Projects are assumed to target Java 17 or newer, so records are available for simple immutable data carriers.
@@ -10,7 +10,7 @@ This pack covers plain Java application and library code before framework-specif
 - Deterministic predicates operate over changed source text until Flow exposes stable Java AST and build-tool queries.
 - Semantic predicates may block only when the judge can cite a concrete changed span and the issue is not reliably expressible with simple syntax checks.
 
-## Predicate Coverage
+## Predicate coverage
 
 | Predicate | Mode | Verdict | Purpose |
 |---|---|---|---|
@@ -37,7 +37,7 @@ Evidence scanned on 2026-05-08.
 - OWASP cheat sheets for logging, secrets management, and SQL injection prevention.
 - GitHub secret scanning documentation for hardcoded credential risk and remediation context.
 
-## Known False Positives
+## Known false positives
 
 - Regex predicates are intentionally conservative and file-scoped. A file containing both an offending pattern and a separate allowed pattern may be allowed or warned imprecisely until AST-level matching lands.
 - `no_raw_collection_types` focuses on common collection-like APIs and does not attempt full generic type parsing.

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -2,14 +2,14 @@
 
 This pack covers plain JavaScript before framework-specific packs such as React, Node services, browser extensions, or build tooling add narrower rules. It focuses on high-signal defaults for async correctness, dynamic-code hazards, production logging, global scope hygiene, and untrusted data handling.
 
-## Stack Assumptions
+## Stack assumptions
 
 - Files use `.js`, `.jsx`, `.mjs`, or `.cjs`.
 - Projects use modern JavaScript, strict mode or modules where practical, and linting compatible with current ESLint rule guidance.
 - Deterministic predicates operate over changed source text until Flow exposes stable JavaScript AST and module-resolution queries.
 - Semantic predicates may block only when the judge can cite a concrete changed span and the issue is not reliably expressible with simple syntax checks.
 
-## Predicate Coverage
+## Predicate coverage
 
 | Predicate | Mode | Verdict | Purpose |
 |---|---|---|---|
@@ -34,7 +34,7 @@ Evidence scanned on 2026-05-08.
 - OWASP cheat sheets for input validation, logging, and secrets management.
 - GitHub secret scanning docs for hardcoded credential risk and remediation context.
 
-## Known False Positives
+## Known false positives
 
 - Regex predicates are intentionally conservative and line-oriented until AST-level matching lands.
 - `no_floating_promises` only blocks obvious async surfaces such as `fetch`, `Promise.*`, `new Promise`, or `*Async` calls until promise-aware JavaScript analysis is available.

--- a/json/README.md
+++ b/json/README.md
@@ -2,14 +2,14 @@
 
 This pack covers strict JSON content quality before format-specific packs (npm `package.json` rules, JSON Schema authoring, OpenAPI documents, etc.) layer narrower checks on top. It focuses on RFC 8259 conformance, encoding hygiene, and untrusted-data hazards that show up across most JSON files a repo ships.
 
-## Stack Assumptions
+## Stack assumptions
 
 - Files use `.json`, `.jsonc`, or `.json5`. Strict-conformance predicates apply only to `.json`; `.jsonc` and `.json5` are exempt because their parsers accept comments and trailing commas by design.
 - Files matching `tsconfig*.json`, `jsconfig*.json`, or paths under `.vscode/` and `.devcontainer/` are treated as JSONC-by-convention and exempt from the strict checks; the toolchains that read them allow comments and trailing commas.
 - Deterministic predicates work on changed source text until Flow exposes a stable JSON AST and value-tree query API.
 - Semantic predicates may block only when the judge can cite a concrete changed value or property and the issue is not reliably expressible with simple syntax checks.
 
-## Predicate Coverage
+## Predicate coverage
 
 | Predicate | Mode | Verdict | Purpose |
 |---|---|---|---|
@@ -34,7 +34,7 @@ Evidence scanned on 2026-05-09 and refreshed on 2026-05-15 for new predicates.
 - JSON Schema specification and the JSON Schema "getting started" guide.
 - npm `package.json` configuration reference describing the conventional ordering authors expect tooling to preserve.
 
-## Known False Positives
+## Known false positives
 
 - Regex predicates are intentionally conservative and file-scoped. A literal `,]`, `//`, `/*`, `NaN`, or `Infinity` substring inside a JSON string value can trip the corresponding predicate until value-aware matching lands.
 - `strings_use_double_quotes` may flag a string value that itself contains a JSON-looking snippet with single quotes, because v0 scans raw file text rather than parsed string boundaries.

--- a/kotlin/README.md
+++ b/kotlin/README.md
@@ -2,7 +2,7 @@
 
 This pack covers Kotlin JVM, Android, and Kotlin Multiplatform source with an emphasis on null-safety, coroutine structure, API clarity, and value-object idioms. The v0 rules favor simple source-text predicates for concrete failure modes and semantic predicates where platform types or async API design require code context.
 
-## Stack Assumptions
+## Stack assumptions
 
 - Files use `.kt` or `.kts` and target Kotlin 2.x-era language and coroutine practices.
 - JVM and Android projects may use Gradle, kotlinx.coroutines, Jetpack lifecycle scopes, Compose, Java interop, detekt, and ktlint-style formatting.
@@ -10,7 +10,7 @@ This pack covers Kotlin JVM, Android, and Kotlin Multiplatform source with an em
 - Semantic predicates use `ctx.semantic_judge(...)` and must cite concrete changed spans before blocking.
 - The pack is a seed canon, not a replacement for the Kotlin compiler, explicit API mode, detekt, Android Lint, ktlint, or coroutine debug tooling.
 
-## Predicate Coverage
+## Predicate coverage
 
 | Predicate | Mode | Verdict | Purpose |
 |---|---|---|---|
@@ -37,7 +37,7 @@ Evidence scanned on 2026-05-08.
 - Android Open Source Project API guidelines: asynchronous and non-blocking Kotlin API design.
 - detekt documentation: style rules and suppression behavior used as ecosystem lint precedent.
 
-## Known False Positives
+## Known false positives
 
 - `no_bang_bang` is source-text based and can flag rare intentional assertions. Test paths are excluded, but production assertions should usually be replaced or localized with `requireNotNull`.
 - `immutable_by_default` warns on any `var`, including stateful UI and persistence models where mutation is intentional.

--- a/lua/README.md
+++ b/lua/README.md
@@ -2,7 +2,7 @@
 
 This pack covers general-purpose Lua application and library code targeting modern Lua (5.2+, including LuaJIT). It focuses on review-slice checks with clear correctness, maintenance, or security impact: implicit globals, dynamic source loading, removed-API usage (`setfenv`/`getfenv`), shell-execution hygiene, module-return convention, `require` binding style, tail-call recursion, metatable-boundary documentation, and hardcoded secrets.
 
-## Stack Assumptions
+## Stack assumptions
 
 - Files use the `.lua` extension. LuaRocks `.rockspec` files are intentionally excluded — they are written as bare-name globals (a Lua-as-DSL pattern) and would trip the implicit-globals heuristic.
 - Projects target Lua 5.2 or newer (or LuaJIT) — `setfenv` and `getfenv` were removed in Lua 5.2 and `loadstring` was folded into `load`. Code that needs Lua 5.1 compatibility should suppress the affected predicates locally.
@@ -11,7 +11,7 @@ This pack covers general-purpose Lua application and library code targeting mode
 - Deterministic predicates run over changed source text until Flow exposes a stable Lua AST query API. Rules with meaningful false-positive risk (`no_implicit_globals`, `module_returns_value`, `require_assigned_to_local`) warn rather than block.
 - Semantic predicates use one cheap judge call and should block only when they can cite concrete changed spans.
 
-## Predicate Coverage
+## Predicate coverage
 
 | Predicate | Mode | Verdict | Purpose |
 |---|---|---|---|
@@ -37,7 +37,7 @@ Evidence scanned on 2026-05-10.
 - Lua-users wiki tutorials: `ScopeTutorial`, `ModulesTutorial`, `MetatablesTutorial`, and the Lua 5.2 migration page.
 - OWASP cheat sheets and GitHub secret scanning documentation: code injection, OS command injection, secrets management, and hardcoded credential risk.
 
-## Known False Positives
+## Known false positives
 
 - Regex predicates are source-text checks. Comments, string literals, multiline strings (`[[ ... ]]`), and metaprogramming can fool them until AST-backed matching lands.
 - `no_global_function_definition` flags any `function name(` at the start of a line; the column-zero heuristic misses functions defined inside a `do ... end` block (false negative) and may flag `function name(` lines inside long-strings (false positive).

--- a/markdown/README.md
+++ b/markdown/README.md
@@ -2,7 +2,7 @@
 
 This pack covers prose Markdown files used for documentation, READMEs, and design notes. Markdown has a smaller surface area than full programming languages, so the pack stays narrow and focuses on review-slice checks with clear correctness, accessibility, or safety impact: untagged code fences, heading-level discipline, single document title, image alt text, dangerous raw HTML, broken internal links, and link-style consistency.
 
-## Stack Assumptions
+## Stack assumptions
 
 - Files use `.md` or `.markdown`. MDX (`.mdx`) is intentionally excluded for v0 because its JSX layer needs separate parsing rules.
 - Documents target CommonMark with GitHub Flavored Markdown extensions; predicates do not assume Pandoc-only or Liquid-templated dialects.
@@ -10,7 +10,7 @@ This pack covers prose Markdown files used for documentation, READMEs, and desig
 - Deterministic predicates run regex scans on changed source text until Harn Flow exposes a Markdown AST query API. Rules with meaningful false-positive risk warn rather than block.
 - Semantic predicates make one cheap judge call and only act when they can cite concrete changed spans.
 
-## Predicate Coverage
+## Predicate coverage
 
 | Predicate | Mode | Verdict | Purpose |
 |---|---|---|---|
@@ -33,7 +33,7 @@ Evidence scanned on 2026-05-09.
 - OWASP Cross-Site Scripting Prevention Cheat Sheet: HTML and URL contexts that motivate the dangerous-HTML predicate.
 - GitHub docs: basic writing and formatting syntax, used as the de-facto rendering reference for repository-hosted docs.
 
-## Known False Positives
+## Known false positives
 
 - Regex predicates do not parse Markdown. Code samples that demonstrate Markdown syntax can be misread; HTML inside fenced code blocks is treated as regular content.
 - `code_fence_language_specified` flags only when a complete bare opener / bare closer pair is detected; a file with all tagged blocks is allowed even if their closers are bare. It does not yet recognize tilde (`~~~`) fences.

--- a/php/README.md
+++ b/php/README.md
@@ -2,7 +2,7 @@
 
 This pack covers general-purpose PHP application and library code targeting modern PHP (8.1+) before framework-specific packs (Laravel, Symfony, WordPress) layer in tighter defaults. It targets review-slice issues with clear correctness, maintenance, or security impact: missing strict-types declarations, legacy syntax that depends on ini settings, removed extensions, code-injection sinks, register-globals revivals via `extract()`, untyped class state, debug leakage, SQL injection, hardcoded secrets, and PHP object injection through `unserialize()`.
 
-## Stack Assumptions
+## Stack assumptions
 
 - Source files use the `.php` extension; templates additionally use `.phtml`. Strict-types and typed-property checks scope to `.php` only because templates frequently open with HTML.
 - Production paths exclude any path under `/tests/`, `/Tests/`, `/test/`, `/spec/`, `/bin/`, `/scripts/`, `/script/`, and any file ending in `Test.php`, `TestCase.php`, or `_test.php`. Vendored paths under `/vendor/`, `/node_modules/`, `/build/`, and `/dist/` are excluded everywhere.
@@ -10,7 +10,7 @@ This pack covers general-purpose PHP application and library code targeting mode
 - Deterministic predicates run regex over changed source text until Flow exposes a stable PHP AST query API. Rules with meaningful false-positive risk warn rather than block.
 - Semantic predicates make a single judge call over changed PHP files; they should only block when they can cite concrete changed spans.
 
-## Predicate Coverage
+## Predicate coverage
 
 | Predicate | Mode | Verdict | Purpose |
 |---|---|---|---|
@@ -37,7 +37,7 @@ Evidence scanned on 2026-05-10.
 - OWASP cheat sheets and project pages: SQL Injection Prevention, Secrets Management, Deserialization, Code Injection, PHP Object Injection, PHP File Inclusion, CICD-SEC-06 Insufficient Credential Hygiene.
 - CWE: CWE-95 (eval injection).
 
-## Known False Positives
+## Known false positives
 
 - Regex predicates do not parse PHP. String literals, heredocs, and comments containing keywords can fool deterministic checks until AST-backed matching lands.
 - `declare_strict_types_enforced` only inspects `.php` files that begin with `<?php` (after an optional UTF-8 BOM). Files that open with HTML or other content are intentionally skipped because strict-types must be the first statement of the file. Expect false negatives on files with leading whitespace beyond a BOM.

--- a/protobuf/README.md
+++ b/protobuf/README.md
@@ -2,7 +2,7 @@
 
 This pack covers `.proto` schemas — proto2, proto3, and the newer Editions syntax. Protobuf has a small surface area but a brutal failure mode: a renumbered field or a deleted-then-reused tag silently corrupts data on the wire across every consumer that has not yet redeployed. The predicates here target the handful of authoring mistakes that are cheap to catch on a slice and expensive to recover from in production.
 
-## Stack Assumptions
+## Stack assumptions
 
 - Schema sources end in `.proto`; generated stubs (`*.pb.go`, `*.pb.cc`, `*_pb2.py`, etc.) are out of scope for this pack — those should be reviewed by the consuming language's pack.
 - Vendored or generated proto trees under `/vendor/`, `/third_party/`, `/node_modules/`, `/generated/`, or `/.proto-cache/` are excluded from first-party scans.
@@ -10,7 +10,7 @@ This pack covers `.proto` schemas — proto2, proto3, and the newer Editions syn
 - Semantic predicates make one cheap judge call over changed `.proto` files and rely on the diff context to compare against the prior schema.
 - Advisory rules return `Warn` when official guidance is style-level. Blocking rules are reserved for declarations the protobuf compiler or wire format outright rejects, and for changes that break wire compatibility for already-deployed consumers.
 
-## Predicate Coverage
+## Predicate coverage
 
 | Predicate | Mode | Verdict | Purpose |
 |---|---|---|---|
@@ -32,7 +32,7 @@ Evidence scanned on 2026-05-09.
 - Editions [overview](https://protobuf.dev/editions/overview/) for the post-syntax declaration form.
 - Updating-a-message and deleting-a-field sections of the proto3 and proto2 guides for wire-compat rules.
 
-## Known False Positives
+## Known false positives
 
 - Regex predicates do not parse protobuf. Block comments, unusual whitespace, and macros (when proto files are templated) can confuse deterministic checks.
 - `field_names_lower_snake_case` looks at simple `optional/repeated/required type field = N` shapes; map fields and `oneof` members with type parameters may not match the same regex and can slip through.

--- a/python/README.md
+++ b/python/README.md
@@ -2,7 +2,7 @@
 
 This pack covers general-purpose Python application and library code. It is intentionally focused on mistakes that are cheap to detect in review slices and have a clear operational or security cost: swallowed exceptions, shared mutable defaults, leaked debug output, unsafe dynamic execution, unclosed files, shell injection, production asserts, SQL injection, and hardcoded secrets.
 
-## Stack Assumptions
+## Stack assumptions
 
 - Files use the `.py` extension and target modern Python 3.
 - Deterministic predicates run over changed Python source text. They are regex-backed until Flow exposes a stable Python AST query API, so lower-confidence checks warn instead of block.
@@ -10,7 +10,7 @@ This pack covers general-purpose Python application and library code. It is inte
 - Semantic predicates use one cheap judge call and should block only when they can cite a concrete changed span.
 - Existing project linters such as Ruff, mypy, pyright, Bandit, pytest, and framework-specific checks remain the primary local enforcement tools; this pack seeds portable defaults for Flow.
 
-## Predicate Coverage
+## Predicate coverage
 
 | Predicate | Mode | Verdict | Purpose |
 |---|---|---|---|
@@ -33,7 +33,7 @@ Evidence scanned on 2026-04-30.
 - Ruff rule documentation: E722 bare except, ANN201 public function annotations, T201 print, B006 mutable argument defaults, S307 eval, S102 exec, S101 assert, S602 subprocess shell, and hardcoded password rules.
 - OWASP, CWE-78, and CWE-798 guidance: SQL injection, OS command injection, credential hygiene, and hardcoded credentials.
 
-## Known False Positives
+## Known false positives
 
 - Regex predicates are syntax-aware only at the source-text level; comments, string literals, aliases, and multiline formatting can fool them.
 - `type_hints_on_pub_fn` only catches unannotated top-level functions on a single signature span. It does not fully validate every parameter annotation.

--- a/r/README.md
+++ b/r/README.md
@@ -2,7 +2,7 @@
 
 This pack covers the R-specific footguns that an Archivist can catch cheaply on a changed slice: search-path pollution, non-reproducible session state, brittle logical literals, ambiguous assignment direction, off-by-one iteration over empty inputs, code injection through `eval(parse(...))`, mutating package-install side effects, and the classic "loop where a vectorized op would do." Two of the three semantic predicates target reproducibility and namespace discipline — both judgement-heavy enough that a single judge call earns its keep over regex.
 
-## Stack Assumptions
+## Stack assumptions
 
 - R source files use `.R`, `.r`, `.Rmd`, `.rmd`, `.qmd`, or `.Rnw` extensions. R Markdown and Quarto files mix prose with code chunks, but the regex predicates fire on full-text matches, so a hit inside a code chunk is treated the same as a hit in a `.R` script.
 - Production paths exclude any path under `tests/`, `testthat/`, `test/`, `inst/extdata/`, `man-roxygen/`, `data-raw/`, or `dev/`.
@@ -10,7 +10,7 @@ This pack covers the R-specific footguns that an Archivist can catch cheaply on 
 - Analysis scripts are R files outside `R/` and outside test directories. The `reproducible_random_seed` predicate scopes there because `set.seed()` inside package source would clobber the caller's RNG state.
 - Deterministic predicates use file-text regex scans because Harn Flow does not yet expose a stable R AST query API; semantic predicates make a single judge call over changed R files.
 
-## Predicate Coverage
+## Predicate coverage
 
 | Predicate | Mode | Verdict | Purpose |
 |---|---|---|---|
@@ -39,7 +39,7 @@ Evidence scanned on 2026-05-10.
 - *Google R style guide* (google.github.io/styleguide/Rguide.html): assignment operator and logical-constant guidance.
 - *here* (here.r-lib.org), *renv* (rstudio.github.io/renv), and *rlang* (rlang.r-lib.org): canonical alternatives to `setwd()`, `install.packages()`, and `eval(parse(text = ...))`.
 
-## Known False Positives
+## Known false positives
 
 - Regex predicates do not parse R. Strings, comments, and roxygen blocks containing the matched tokens (e.g. an `attach(` literal in a docstring) will trip the deterministic checks. Suppress locally once the predicate runtime supports it.
 - `use_logical_constants` matches `T` and `F` only when they appear in a logical-literal context (after `=`, `,`, `(`, `<-`, `==`, `&&`, `||`, etc.). It still flags `T`/`F` used as user-defined symbols in those contexts; the canon's stance is that single-letter `T`/`F` as a variable name is itself worth flagging. Conversely, `T` inside a string or comment slips through, which is fine.

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -2,7 +2,7 @@
 
 This pack covers general-purpose Ruby application and library code before framework-specific packs such as Rails add tighter defaults. It focuses on review-slice checks with clear correctness, maintenance, or security impact: explicit string literal mutability, global mutation, risky core-class changes, legacy options hashes, dynamic evaluation, unsafe deserialization, superclass initialization, RuboCop policy drift, hardcoded secrets, and sensitive logging.
 
-## Stack Assumptions
+## Stack assumptions
 
 - Files use `.rb`, `.rake`, `.gemspec`, `Gemfile`, or `Rakefile` Ruby source conventions.
 - Projects target modern Ruby with keyword arguments, Psych safe-loading APIs, and RuboCop available as the local style authority.
@@ -10,7 +10,7 @@ This pack covers general-purpose Ruby application and library code before framew
 - Production-path checks exclude obvious `spec/`, `test/`, `tests/`, `bin/`, `script/`, `scripts/`, `Rakefile`, and `.rake` paths.
 - Semantic predicates use one cheap judge call and should block only when they can cite concrete changed spans.
 
-## Predicate Coverage
+## Predicate coverage
 
 | Predicate | Mode | Verdict | Purpose |
 |---|---|---|---|
@@ -34,7 +34,7 @@ Evidence scanned on 2026-05-08.
 - RuboCop documentation: `Style/FrozenStringLiteralComment`, `Style/GlobalVars`, `Style/ClassVars`, `Style/OptionHash`, `Security/Eval`, `Security/YAMLLoad`, `Lint/MissingSuper`, configuration, and the RuboCop project overview.
 - OWASP cheat sheets and GitHub secret scanning documentation: deserialization, secrets management, logging, and hardcoded credential risk.
 
-## Known False Positives
+## Known false positives
 
 - Regex predicates are source-text checks. Comments, string literals, metaprogramming, and multiline formatting can fool them until AST-backed matching lands.
 - `frozen_string_literal_magic_comment` warns on production Ruby files that intentionally rely on mutable string literals.

--- a/rust/README.md
+++ b/rust/README.md
@@ -2,7 +2,7 @@
 
 This pack covers Rust crates and workspaces. It targets high-signal issues that are cheap to catch from changed source slices: accidental panics, undocumented unsafe code, blocking work in async functions, dependency-advisory drift, and public API contracts that callers can otherwise misuse.
 
-## Stack Assumptions
+## Stack assumptions
 
 - Rust source files use `.rs`; Cargo metadata uses `Cargo.toml` and `Cargo.lock`.
 - Production paths exclude `tests/`, `benches/`, and `examples/` fixtures or sample programs.
@@ -10,7 +10,7 @@ This pack covers Rust crates and workspaces. It targets high-signal issues that 
 - Semantic predicates make one cheap judge call over changed Rust/Cargo files and use only evidence captured at authoring time.
 - The pack is advisory-first where regex matching has likely false positives. Blocking rules are reserved for unfinished code, bare production unwraps, undocumented unsafe blocks, obvious blocking calls inside `async fn`, and missing semantic dependency/FFI safety evidence.
 
-## Predicate Coverage
+## Predicate coverage
 
 | Predicate | Mode | Verdict | Purpose |
 |---|---|---|---|
@@ -35,7 +35,7 @@ Evidence scanned on 2026-04-26.
 - Tokio and Async Book docs: blocking work in async contexts, `spawn_blocking`, and async `sleep`.
 - RustSec, cargo-deny, and Cargo docs: advisory databases, dependency checks, and `Cargo.lock` reproducibility.
 
-## Known False Positives
+## Known false positives
 
 - Regex predicates do not parse Rust. Macro-generated functions, nested blocks, raw strings, comments, and multi-line signatures can confuse the deterministic checks.
 - `no_unwrap_in_prod` ignores test, bench, and example paths, but it can still catch intentional invariant unwraps in production code. Prefer `expect("why this is impossible")` or a local allow once the predicate runtime supports suppressions.

--- a/scala/README.md
+++ b/scala/README.md
@@ -2,7 +2,7 @@
 
 This pack covers Scala 2.13 and Scala 3 source on the JVM, with an emphasis on null safety, immutability, total function shape, effect-system hygiene, and pattern-match exhaustiveness. The v0 rules favor simple source-text predicates for concrete failure modes and semantic predicates where effect-system boundaries or exhaustiveness require code context.
 
-## Stack Assumptions
+## Stack assumptions
 
 - Files use `.scala`. Worksheets (`.sc`) and sbt build files (`.sbt`) are out of scope; the v0 pack reads only compiled-source `.scala` files.
 - Projects may use sbt, Mill, Bloop, Metals, ScalaTest, MUnit, ZIO, cats-effect, Akka, Pekko, or Spark; predicates target idioms that are common across these stacks rather than framework-specific patterns.
@@ -11,7 +11,7 @@ This pack covers Scala 2.13 and Scala 3 source on the JVM, with an emphasis on n
 - Semantic predicates use `ctx.semantic_judge(...)` and must cite concrete changed spans before blocking.
 - The pack is a seed canon, not a replacement for the Scala compiler, scalac `-Xfatal-warnings`, scalafix, scalafmt, or WartRemover.
 
-## Predicate Coverage
+## Predicate coverage
 
 | Predicate | Mode | Verdict | Purpose |
 |---|---|---|---|
@@ -40,7 +40,7 @@ Evidence scanned on 2026-05-10.
 - ZIO documentation: the `ZIO[R, E, A]` effect type and runtime entry points.
 - WartRemover wart catalogue: `Any`, `Null`, `Var`, `Return`, `OptionPartial`, `TryPartial`, `AsInstanceOf`, `IsInstanceOf` as ecosystem precedent.
 
-## Known False Positives
+## Known false positives
 
 - `no_any_in_public_api` matches return-type position only; `Any` in parameter types or as a generic upper bound (`[T <: Any]`) is not flagged. Method overloading on `Any` is occasionally intentional and the rule is Warn-level.
 - `no_null` is source-text based and may flag the literal token inside string content (`"value is null"`). Test paths and Java-interop suppressions are out of scope; scope `null` to a local interop helper if you genuinely need it.

--- a/shell/README.md
+++ b/shell/README.md
@@ -2,14 +2,14 @@
 
 This pack covers POSIX shell, Bash, and other Bourne-family scripts that ship inside repositories: build helpers, deploy scripts, CI glue, and one-off operational tools. It targets the small set of high-signal mistakes that turn shell scripts into latent reliability and security incidents — missing strict-mode flags, parsing `ls`, dynamic `eval`, missing tempfile cleanup, blanket `shellcheck` disables, hardcoded secrets, and leaking sensitive data into logs.
 
-## Stack Assumptions
+## Stack assumptions
 
 - Files are detected by extension (`.sh`, `.bash`, `.zsh`, `.ksh`, `.dash`) or by a Bourne-family shebang on line 1 (`sh`, `bash`, `zsh`, `ksh`, `dash`, `ash`).
 - Strict-mode enforcement targets *executable* scripts (those with a shebang). Files without a shebang are assumed to be sourced libraries where `set -e`/`set -u` semantics may be inappropriate.
 - Deterministic predicates run over changed source text until Flow exposes a stable shell AST query API; rules with meaningful false-positive risk warn rather than block.
 - Semantic predicates make one cheap judge call over the changed shell files and rely on the rubric to cite concrete spans before blocking.
 
-## Predicate Coverage
+## Predicate coverage
 
 | Predicate | Mode | Verdict | Purpose |
 |---|---|---|---|
@@ -32,7 +32,7 @@ Evidence scanned on 2026-05-09.
 - Greg's Wiki (`mywiki.wooledge.org`): `ParsingLs`, `BashFAQ/048` (eval pitfalls), and `SignalTrap`.
 - OWASP cheat sheets: Secrets Management and Logging guidance; GitHub secret-scanning documentation for the hardcoded-credential surface area.
 
-## Known False Positives
+## Known false positives
 
 - Regex predicates do not parse shell. Heredocs, single-quoted literals, and string interpolation can fool them until a real shell AST is wired in.
 - `set_euo_pipefail` only inspects files with a Bourne-family shebang. Sourced libraries (no shebang) are skipped because they typically inherit the caller's options.

--- a/sql/README.md
+++ b/sql/README.md
@@ -2,7 +2,7 @@
 
 This pack covers schema, migration, and query safety for raw SQL files. It targets review issues that an Archivist can catch cheaply on changed slices: implicit column lists, comma joins, table-wide DELETE/UPDATE statements, non-idempotent migration DDL, dynamic SQL that concatenates untrusted input, and foreign keys without supporting indexes.
 
-## Stack Assumptions
+## Stack assumptions
 
 - SQL source files use the `.sql` extension.
 - Production paths exclude any path under `test/`, `tests/`, `testdata/`, `fixtures/`, `seed/`, or `seeds/`, and any file ending in `_test.sql`, `_seed.sql`, or `_fixture.sql`.
@@ -10,7 +10,7 @@ This pack covers schema, migration, and query safety for raw SQL files. It targe
 - Deterministic predicates use file-text regex scans because Harn Flow does not yet expose a stable SQL AST query API; semantic predicates make a single judge call over changed SQL files.
 - Predicates are dialect-aware where it matters: `migrations_use_if_not_exists`, `destructive_drops_use_if_exists`, and `index_on_fk` cover PostgreSQL and MySQL syntax variants and tolerate `CONCURRENTLY` for PostgreSQL index DDL.
 
-## Predicate Coverage
+## Predicate coverage
 
 | Predicate | Mode | Verdict | Purpose |
 |---|---|---|---|
@@ -33,7 +33,7 @@ Evidence scanned on 2026-05-09.
 - GitLab development docs: SQL guidelines (explicit columns over `SELECT *`).
 - Holywell SQL Style Guide (`sqlstyle.guide`): explicit `JOIN` keyword preferred over comma-separated `FROM`.
 
-## Known False Positives
+## Known false positives
 
 - Regex predicates do not parse SQL. Comments containing keywords, dollar-quoted bodies, and CTE-heavy statements can fool the deterministic checks.
 - `no_select_star` flags any `SELECT * FROM ...`, including `INSERT INTO target SELECT * FROM staging` patterns that are intentional in copy migrations. Suppress locally once the predicate runtime supports it.

--- a/swift/README.md
+++ b/swift/README.md
@@ -2,7 +2,7 @@
 
 This pack covers Swift application and package code with an emphasis on crash prevention, UI responsiveness, ARC memory safety, and Swift 6 data-race safety. The v0 rules deliberately prefer simple source-text predicates where a failure mode is concrete, and semantic predicates where Swift syntax and framework lifetime rules are too contextual for regex alone.
 
-## Stack Assumptions
+## Stack assumptions
 
 - Files use the `.swift` extension and target Swift 5.10 through Swift 6.x.
 - Apple-platform code may use SwiftUI, UIKit, AppKit, Combine, Swift Testing, XCTest, Dispatch, and OSLog.
@@ -10,7 +10,7 @@ This pack covers Swift application and package code with an emphasis on crash pr
 - Semantic predicates use `ctx.semantic_judge(...)` and must cite concrete changed spans before blocking.
 - The pack is a seed canon, not a replacement for SwiftSyntax, SwiftLint, the Swift compiler, Xcode diagnostics, or runtime profiling.
 
-## Predicate Coverage
+## Predicate coverage
 
 | Predicate | Mode | Verdict | Purpose |
 |---|---|---|---|
@@ -37,7 +37,7 @@ Evidence scanned on 2026-04-26.
 - SwiftLint rule docs: `force_unwrapping`, `force_try`, `force_cast`, and `implicitly_unwrapped_optional` behavior as widely adopted ecosystem lint precedent.
 - Swift Forums: current discussion on accidental retain cycles from strong closure captures.
 
-## Known False Positives
+## Known false positives
 
 - `no_force_unwrap` is source-text based and can flag rare intentional force unwraps or implicitly unwrapped optional declarations outside recognized test/preview paths; it may miss unwraps at the end of a line until SwiftSyntax-backed matching exists.
 - `prefer_structured_concurrency` warns on any new Dispatch, OperationQueue, Thread, or pthread usage, including legitimate low-level adapters.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -2,7 +2,7 @@
 
 This pack covers Terraform configurations (`.tf` files) for AWS, Azure, GCP, and other providers. Terraform's surface area is small enough that a v0 pack can target the highest-signal review issues directly: tagging hygiene, variable typing, remote state, version pinning, sensitive output handling, hardcoded secrets, and over-broad IAM grants.
 
-## Stack Assumptions
+## Stack assumptions
 
 - Source checks target HCL `.tf` files; `.tf.json`, `.tfvars`, override files, and `.terraform.lock.hcl` are out of scope for v0.
 - Production paths exclude `examples/`, `test/`, `tests/`, `testdata/`, and `.terraform/` working directories.
@@ -11,7 +11,7 @@ This pack covers Terraform configurations (`.tf` files) for AWS, Azure, GCP, and
 - Deterministic predicates operate over changed source text until Flow exposes a stable HCL AST query API. Regex-based matching is intentionally conservative.
 - Semantic predicates may block only when the judge can cite a concrete changed span and the issue is not reliably expressible as a syntactic check.
 
-## Predicate Coverage
+## Predicate coverage
 
 | Predicate | Mode | Verdict | Purpose |
 |---|---|---|---|
@@ -36,7 +36,7 @@ Evidence scanned on 2026-05-09.
 - OWASP Secrets Management Cheat Sheet and GitHub secret scanning documentation for hardcoded-credential risk.
 - AWS IAM, Microsoft Entra, and Google Cloud IAM least-privilege guidance for wildcard-grant avoidance.
 
-## Known False Positives
+## Known false positives
 
 - Regex predicates do not parse HCL. Multi-block files where some blocks satisfy a check and others do not may slip past file-scoped predicates until AST-level matching lands.
 - `required_tags_on_resources` is a Warn-level word-boundary check. Files that mention "owner", "env", or "costcenter" outside of tags (variable names, comments, locals) will silence the warning. Orgs with different tag standards should override this predicate locally.

--- a/toml/README.md
+++ b/toml/README.md
@@ -2,13 +2,13 @@
 
 This pack covers TOML configuration documents — Cargo manifests, `pyproject.toml`, tool configs, and any other `.toml` file. TOML has a small surface area, so this v0 focuses on rules drawn directly from the TOML 1.0 specification plus the dominant package-metadata conventions used by the largest TOML ecosystems.
 
-## Stack Assumptions
+## Stack assumptions
 
 - TOML files use the `.toml` extension (covers `Cargo.toml`, `pyproject.toml`, `taplo.toml`, `deny.toml`, and the long tail of tool configs).
 - Predicates run on changed slices and use file-text scans — no separate TOML parser is invoked, so syntactic edge cases that a parser would catch (e.g. unterminated strings) are out of scope here and remain the parser's job.
 - Advisory rules return `Warn` when a project's existing convention may legitimately diverge. Blocking rules are reserved for spec violations and security-sensitive issues.
 
-## Predicate Coverage
+## Predicate coverage
 
 | Predicate | Mode | Verdict | Purpose |
 |---|---|---|---|
@@ -30,7 +30,7 @@ Evidence scanned on 2026-05-09 and refreshed on 2026-05-15 for new predicates.
 - RFC 3339 (datetime grammar that TOML inherits, including the meaning of an absent offset).
 - OWASP Secrets Management Cheat Sheet, GitHub secret-scanning docs, and CWE-798 (hardcoded credentials).
 
-## Known False Positives
+## Known false positives
 
 - Regex predicates do not parse TOML. Unusual whitespace, comments inside complex values, or inline tables split across (technically invalid) lines may confuse the deterministic checks.
 - `no_duplicate_table_headers` relies on a regex backreference and is intentionally narrow: it catches `[a.b]` repeated verbatim but does not catch the harder case of a dotted key (e.g. `a.b.c = 1`) implicitly redefining a table established with `[a.b]`. Implicit-redefinition detection needs a real parser and is left for a future revision.
@@ -41,7 +41,7 @@ Evidence scanned on 2026-05-09 and refreshed on 2026-05-15 for new predicates.
 - `secrets_not_hardcoded_in_toml` depends on the judge recognizing concrete credential-shaped strings. It should remain high-threshold and cite exact lines before blocking; placeholders, env-var references, and clearly fake fixtures must allow.
 - `package_metadata_declares_license` is intentionally Warn-level because private workspaces, unpublished examples, and inherited workspace metadata can be legitimate.
 
-## Future Predicates
+## Future predicates
 
 These were considered for v0 and deferred until the Harn Flow runtime exposes the needed primitives:
 

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -2,14 +2,14 @@
 
 This pack covers plain TypeScript and TSX code before framework-specific packs such as React, Next.js, or Node services add tighter local rules. It focuses on high-signal defaults for type safety, async correctness, production logging, and untrusted boundary handling.
 
-## Stack Assumptions
+## Stack assumptions
 
 - Files use `.ts`, `.tsx`, `.mts`, or `.cts`; config checks target `tsconfig.json`.
 - Projects use TypeScript strict mode and type-aware linting where practical.
 - Deterministic predicates operate over changed source text until Flow exposes stable TypeScript AST and tsconfig-resolution queries.
 - Semantic predicates may block only when the judge can cite a concrete changed span and the issue is not reliably expressible with simple syntax checks.
 
-## Predicate Coverage
+## Predicate coverage
 
 | Predicate | Mode | Verdict | Purpose |
 |---|---|---|---|
@@ -35,7 +35,7 @@ Evidence scanned on 2026-04-26.
 - OWASP cheat sheets for input validation, logging, and secrets management.
 - GitHub secret scanning docs for hardcoded credential risk and remediation context.
 
-## Known False Positives
+## Known false positives
 
 - Regex predicates are intentionally conservative. A few remain file-scoped where structured matching needs AST-level support.
 - `no_floating_promises` only blocks obvious async surfaces such as `fetch`, `Promise.*`, `new Promise`, or `*Async` calls until TypeScript type information is available.

--- a/xml/README.md
+++ b/xml/README.md
@@ -2,14 +2,14 @@
 
 This pack covers raw XML payloads, schemas (XSD), stylesheets (XSLT), and related XML-shaped formats (WSDL, SVG, RSS, Atom). XML has a smaller surface area than a full programming language, so the pack focuses on the few defaults that consistently catch real shipping incidents: external entity injection, encoding ambiguity, namespace discipline, schema hygiene, stylesheet resource loading, and credential leaks in config files.
 
-## Stack Assumptions
+## Stack assumptions
 
 - Source checks target `.xml`, `.xsd`, `.xsl`, `.xslt`, `.wsdl`, `.svg`, `.rss`, and `.atom` files.
 - Payload-only checks (DOCTYPE block) exclude `.xsd`, `.xsl`, and `.xslt` because schemas and stylesheets routinely declare types the parser never needs to expand.
 - Deterministic predicates operate on changed source text. Until Flow exposes an XML AST and parser-configuration query, parser-side defenses (`FEATURE_SECURE_PROCESSING`, `XMLConstants.ACCESS_EXTERNAL_DTD`, `defusedxml`, etc.) live in language packs rather than this format pack.
 - Semantic predicates may block only when the judge can cite a concrete changed span and the issue is not reliably expressible with simple syntax checks.
 
-## Predicate Coverage
+## Predicate coverage
 
 | Predicate | Mode | Verdict | Purpose |
 |---|---|---|---|
@@ -35,7 +35,7 @@ Evidence scanned on 2026-05-09.
 - MITRE CWE-611 (Improper Restriction of XML External Entity Reference) and CWE-776 (Recursive Entity Expansion).
 - GitHub secret scanning documentation for hardcoded credential risk and remediation context.
 
-## Known False Positives
+## Known false positives
 
 - Regex predicates are intentionally conservative and file-scoped. Files containing both an offending pattern and an allowed one may be allowed or warned imprecisely until AST-level matching lands.
 - `no_inline_doctype` blocks every DOCTYPE in payload files, including legitimate uses such as XHTML documents that intentionally reference a public DTD. Move to an external schema or a XHTML-specific override pack if needed.

--- a/yaml/README.md
+++ b/yaml/README.md
@@ -2,14 +2,14 @@
 
 This pack covers plain YAML configuration before stack-specific packs (Kubernetes, GitHub Actions, Ansible, Helm) layer tighter rules on top. YAML's surface area is small but its parser quirks are loud, so the v0 set focuses on long-known footguns: tab indentation, the YAML 1.1 vs 1.2 boolean drift (the "Norway problem"), bare scalars that parsers re-type, the cross-document anchor scope rule, and language-specific object tags that are remote-code-execution sinks.
 
-## Stack Assumptions
+## Stack assumptions
 
 - Source checks target `.yaml` and `.yml` files.
 - Syntactic predicates skip YAML living under `fixtures/`, `__fixtures__/`, `testdata/`, `test-data/`, `test/`, `tests/`, and `spec/` paths because parser fixtures intentionally include malformed input. Security predicates (`no_unsafe_yaml_tags`, `no_hardcoded_secrets`) and `yamllint_compliance` still check those paths.
 - Deterministic predicates run over changed source text until Flow exposes a stable YAML AST query API. Rules with meaningful false-positive risk warn rather than block.
 - Semantic predicates use one cheap judge call and should block only when they can cite a concrete changed span.
 
-## Predicate Coverage
+## Predicate coverage
 
 | Predicate | Mode | Verdict | Purpose |
 |---|---|---|---|
@@ -31,7 +31,7 @@ Evidence scanned on 2026-05-09.
 - PyYAML documentation on safe vs full loaders, and the OWASP Deserialization Cheat Sheet for unsafe-tag risk and remediation.
 - OWASP Secrets Management Cheat Sheet and GitHub secret-scanning documentation for hardcoded credential risk and remediation context.
 
-## Known False Positives
+## Known false positives
 
 - All deterministic predicates run on raw source text. Comments, block scalars, multi-line quoted strings, and flow-style mappings can fool simple regexes until AST-level matching lands.
 - `no_tabs_for_indent` does not distinguish a tab inside a quoted string from a tab used as indentation; tabs inside string content are rare in practice but will trigger the block.

--- a/zig/README.md
+++ b/zig/README.md
@@ -2,7 +2,7 @@
 
 This pack covers Zig source (`.zig`) and the `build.zig.zon` package manifest. Zig is a young, rapidly evolving language; v0 focuses on the highest-signal review issues that survive across the recent stable releases and current 0.16 toolchains: silent error-handling shortcuts, stale standard-library API shapes, unjustified unsafe casts, `@panic` in library paths, test-time leak detection, and supply-chain hygiene in the package manifest.
 
-## Stack Assumptions
+## Stack assumptions
 
 - Source predicates target Zig 0.15.x and 0.16.x. Older releases predate `build.zig.zon` and the modern cast/error/container APIs; the predicates here are not expected to be useful below 0.12.
 - Production paths exclude `_test.zig` and `test_*.zig` files plus `tests/`, `test/`, `testdata/`, `examples/`, and `example/` directories. Test-block heuristics rely on the convention that test declarations appear at the top level of a file.
@@ -10,7 +10,7 @@ This pack covers Zig source (`.zig`) and the `build.zig.zon` package manifest. Z
 - Deterministic predicates operate on changed source text. Zig has no published stable AST query API yet, so regex-based matching is intentionally conservative — the pack errs toward false negatives rather than false positives.
 - Semantic predicates are reserved for issues that cannot be reliably expressed as syntactic checks. They block only when the judge can cite a concrete changed span.
 
-## Predicate Coverage
+## Predicate coverage
 
 | Predicate | Mode | Verdict | Purpose |
 |---|---|---|---|
@@ -52,7 +52,7 @@ Evidence scanned on 2026-05-10, 2026-06-23, 2026-07-01, 2026-07-02, and 2026-07-
 - OWASP Secrets Management and Software Supply Chain Security cheat sheets, plus GitHub secret-scanning documentation, for the secret-handling and dependency-hash predicates.
 - Zig testing docs (`Zig-Test`, `std.testing.expectEqualStrings`) and the zig.guide test chapter for the assertion node kinds the observe-before-assert detector reasons over.
 
-## Known False Positives and Negatives
+## Known false positives and negatives
 
 - Regex predicates do not parse Zig. Casts, `catch unreachable`, and `@panic` calls inside string literals or comments will trigger the deterministic predicates. Adding the comment-based escape valve documented in each predicate (or moving the literal out of the changed region) silences these.
 - `no_silent_error_swallow` only flags syntactically empty bodies. `catch {} // intentional` is treated as the author having opted into the swallow with a documented reason and is not blocked.
@@ -75,7 +75,7 @@ Evidence scanned on 2026-05-10, 2026-06-23, 2026-07-01, 2026-07-02, and 2026-07-
 - `assertion_on_ungrounded_output` is the observe-before-assert grounding detector. It parses the changed test file with the bundled Zig tree-sitter grammar (`std/ast`), maps `const x = <producer(...)>` bindings whose callee role is in the producing family (serialize/format/encode/parse/write/etc.), then blocks an assertion callee (`expect`/`expectEqual*`/`expectStringStartsWith`/…) that carries an author string literal and references a producer-bound variable **when the producing callee is absent from `ctx.observed_symbols`**. The discriminator is provenance, not shape: the identical assertion is allowed once an `observe_output` probe has recorded the producing symbol in `ctx.observed_symbols`, so a run that already grounded is never fought. It keys on the same-file `output = producer(...)` binding, so an assertion on a producer output flowing through a helper in another file is missed. It runs on files the shared `is_test_zig_path` helper recognizes as tests: `_test.zig`, `test_*.zig`, and `tests/`, `test/`, `testdata/`, `examples/`, or `example/` directory segments at any depth. `ctx.observed_symbols` is host-injected (Burin threads it from the agent event stream in follow-on work); with no host it defaults to empty, so the detector treats every producer as unobserved.
 - Semantic predicates depend on a cheap judge. They should stay high-threshold and cite concrete changed spans before blocking.
 
-## Design Notes
+## Design notes
 
 - `const_by_default` is omitted: the Zig compiler already emits a hard error on `var` declarations that are never reassigned. A predicate would be redundant with the toolchain.
 - `error_union_propagation` is partly handled by the compiler, which rejects discarded fallible results outside an explicit `_ = ...` slot. The remaining hand-rolled escapes, `catch {}` and `catch unreachable`, are covered by `no_silent_error_swallow` and `no_catch_unreachable_in_prod`.


### PR DESCRIPTION
Applies the repository-wide documentation style consistently across all 34 language packs.\n\nValidation: canonical pack validator passes for 34 packs, 340 predicates, and 340 fixtures.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-canon/pr/120"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786428304&installation_id=145974243&pr_number=120&repository=burin-labs%2Fharn-canon&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-canon%2Fpull%2F120&signature=0c59155bc1336175a6927f4ce255b1ca58e31844389d15cb24dcf86e46ba77a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->