### PR TITLE
Harden Canon JSON boundaries with closed types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,11 +52,20 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          harn fmt --check scripts/canon-lib.harn scripts/validate-canon.harn scripts/execute-fixtures.harn
-          for script in scripts/canon-lib.harn scripts/validate-canon.harn scripts/execute-fixtures.harn; do
+          scripts=(
+            scripts/canon-lib.harn
+            scripts/validate-canon.harn
+            scripts/execute-fixtures.harn
+            scripts/canon-boundary-test.harn
+          )
+          harn fmt --check "${scripts[@]}"
+          for script in "${scripts[@]}"; do
             harn check "${script}"
             harn lint --strict "${script}"
           done
+
+      - name: Test typed JSON boundaries
+        run: harn test scripts/canon-boundary-test.harn --timeout 30000
 
       - name: Validate canon packs
         shell: bash

--- a/scripts/canon-boundary-test.harn
+++ b/scripts/canon-boundary-test.harn
@@ -1,0 +1,245 @@
+import { with_temp_dir } from "std/testing"
+import { read_fixture_document_result, read_pack_manifest_path_result } from "./canon-lib"
+import { __run_pack_at } from "./execute-fixtures"
+import { validate_fixture_value } from "./validate-canon"
+
+fn write_json(path: string, value: unknown) -> nil {
+  harness.fs.write_text(path, json_stringify(value))
+  return nil
+}
+
+fn canonical_manifest() -> dict {
+  return {
+    schema_version: 1,
+    packs: [
+      {
+        id: "rust",
+        title: "Rust",
+        invariants: "rust/invariants.harn",
+        fixtures: "rust/fixtures",
+        extensions: ["rs"],
+        file_names: ["cargo.toml"],
+      },
+    ],
+  }
+}
+
+fn canonical_fixture() -> dict {
+  return {
+    predicate: "safe_rule",
+    cases: [
+      {
+        name: "allows_safe_input",
+        expect: "Allow",
+        files: [{path: "src/main.rs", text: "fn main() {}"}],
+        ctx: {mode: "test"},
+      },
+      {name: "blocks_unsafe_input", expect: "Block", files: [{path: "src/lib.rs", text: "unsafe {}"}]},
+    ],
+  }
+}
+
+@test
+pipeline test_canonical_manifest_and_fixture_decode(task) {
+  with_temp_dir(
+    { root ->
+      const manifest_path = path_join(root, "manifest.json")
+      const fixture_path = path_join(root, "fixture.json")
+      write_json(manifest_path, canonical_manifest())
+      write_json(fixture_path, canonical_fixture())
+      const manifest = read_pack_manifest_path_result(manifest_path)
+      const fixture = read_fixture_document_result(fixture_path)
+      assert(is_ok(manifest), "canonical manifest decodes")
+      assert(is_ok(fixture), "canonical fixture decodes")
+      assert_eq(unwrap(manifest).packs[0]?.id, "rust")
+      assert_eq(unwrap(fixture).cases.count, 2)
+      assert_eq(validate_fixture_value("rust/fixtures/safe_rule.json", "safe_rule", unwrap(fixture)), [])
+    },
+    "canon-boundary-canonical",
+  )
+}
+
+@test
+pipeline test_manifest_rejects_unknown_root_and_nested_keys(task) {
+  with_temp_dir(
+    { root ->
+      const root_unknown = canonical_manifest() + {extra: true}
+      let pack_unknown = canonical_manifest()
+      pack_unknown.packs[0].extra = true
+      const root_path = path_join(root, "root-unknown.json")
+      const pack_path = path_join(root, "pack-unknown.json")
+      write_json(root_path, root_unknown)
+      write_json(pack_path, pack_unknown)
+      assert_eq(unwrap_err(read_pack_manifest_path_result(root_path)).kind, "schema_invalid")
+      assert_eq(unwrap_err(read_pack_manifest_path_result(pack_path)).kind, "schema_invalid")
+    },
+    "canon-boundary-unknown",
+  )
+}
+
+@test
+pipeline test_manifest_rejects_wrong_nested_types(task) {
+  with_temp_dir(
+    { root ->
+      let manifest = canonical_manifest()
+      manifest.packs[0].extensions = ["rs", 7]
+      const path = path_join(root, "wrong-type.json")
+      write_json(path, manifest)
+      assert_eq(unwrap_err(read_pack_manifest_path_result(path)).kind, "schema_invalid")
+    },
+    "canon-boundary-type",
+  )
+}
+
+@test
+pipeline test_manifest_accepts_file_name_only_pack(task) {
+  with_temp_dir(
+    { root ->
+      const manifest = {
+        schema_version: 1,
+        packs: [
+          {
+            id: "metadata",
+            title: "Metadata",
+            invariants: "metadata/invariants.harn",
+            fixtures: "metadata/fixtures",
+            file_names: ["cargo.toml"],
+          },
+        ],
+      }
+      const path = path_join(root, "file-name-only.json")
+      write_json(path, manifest)
+      const decoded = read_pack_manifest_path_result(path)
+      assert(is_ok(decoded), "file_names is a complete routing selector without extensions")
+      assert_eq(unwrap(decoded).packs[0]?.file_names, ["cargo.toml"])
+    },
+    "canon-boundary-file-name-only",
+  )
+}
+
+@test
+pipeline test_fixture_rejects_invalid_expected_verdict(task) {
+  with_temp_dir(
+    { root ->
+      let fixture = canonical_fixture()
+      fixture.cases[0].expect = "Maybe"
+      const path = path_join(root, "invalid-expect.json")
+      write_json(path, fixture)
+      assert_eq(unwrap_err(read_fixture_document_result(path)).kind, "schema_invalid")
+    },
+    "canon-boundary-expect",
+  )
+}
+
+@test
+pipeline test_fixture_rejects_unknown_keys_at_owned_boundaries(task) {
+  with_temp_dir(
+    { root ->
+      let root_unknown = canonical_fixture()
+      root_unknown.extra = true
+      let case_unknown = canonical_fixture()
+      case_unknown.cases[0].extra = true
+      let file_unknown = canonical_fixture()
+      file_unknown.cases[0].files[0].extra = true
+      const root_path = path_join(root, "root-unknown.json")
+      const case_path = path_join(root, "case-unknown.json")
+      const file_path = path_join(root, "file-unknown.json")
+      write_json(root_path, root_unknown)
+      write_json(case_path, case_unknown)
+      write_json(file_path, file_unknown)
+      assert_eq(unwrap_err(read_fixture_document_result(root_path)).kind, "schema_invalid")
+      assert_eq(unwrap_err(read_fixture_document_result(case_path)).kind, "schema_invalid")
+      assert_eq(unwrap_err(read_fixture_document_result(file_path)).kind, "schema_invalid")
+    },
+    "canon-boundary-fixture-unknown",
+  )
+}
+
+@test
+pipeline test_fixture_rejects_wrong_file_field_type(task) {
+  with_temp_dir(
+    { root ->
+      let fixture = canonical_fixture()
+      fixture.cases[0].files[0].text = 7
+      const path = path_join(root, "wrong-file-type.json")
+      write_json(path, fixture)
+      assert_eq(unwrap_err(read_fixture_document_result(path)).kind, "schema_invalid")
+    },
+    "canon-boundary-fixture-type",
+  )
+}
+
+@test
+pipeline test_executor_reports_malformed_fixture_as_setup_failure(task) {
+  with_temp_dir(
+    { root ->
+      const pack_root = path_join(root, "test-pack")
+      const fixtures_root = path_join(pack_root, "fixtures")
+      harness.fs.mkdir(fixtures_root)
+      harness.fs
+        .write_text(
+        path_join(pack_root, "invariants.harn"),
+        join(
+          [
+            "const _EVIDENCE_TEST = [\"https://example.com/canon-test\"]",
+            "",
+            "@invariant",
+            "@deterministic",
+            "@archivist(evidence: _EVIDENCE_TEST, confidence: 1.0, source_date: \"2026-07-13\")",
+            "pub fn malformed_rule(slice, ctx, repo_at_base) {",
+            "  return {verdict: \"Allow\"}",
+            "}",
+          ],
+          "\n",
+        ),
+      )
+      write_json(
+        path_join(fixtures_root, "malformed_rule.json"),
+        {predicate: "malformed_rule", cases: [], extra: true},
+      )
+      const report = __run_pack_at(root, "test-pack")
+      assert_eq(report.executed, 0)
+      assert_eq(report.failures.count, 1)
+      assert_eq(report.failures[0]?.kind, "setup")
+      assert(
+        report.failures[0]?.error?.contains("malformed_rule.json") ?? false,
+        "typed decoder failure is reported",
+      )
+    },
+    "canon-boundary-executor-setup",
+  )
+}
+
+@test
+pipeline test_fixture_semantics_reject_non_normalized_paths(task) {
+  const fixture = {
+    predicate: "safe_rule",
+    cases: [
+      {
+        name: "allows_safe_input",
+        expect: "Allow",
+        files: [{path: "../src/main.rs", text: "fn main() {}"}],
+      },
+      {name: "blocks_unsafe_input", expect: "Block", files: [{path: "src/lib.rs", text: "unsafe {}"}]},
+    ],
+  }
+  const errors = validate_fixture_value("rust/fixtures/safe_rule.json", "safe_rule", fixture)
+  assert_eq(errors.count, 1)
+  assert_eq(
+    errors[0],
+    "rust/fixtures/safe_rule.json: case 0 file 0 path must be normalized and relative",
+  )
+}
+
+@test
+pipeline test_fixture_semantics_reject_duplicate_cases(task) {
+  const fixture = {
+    predicate: "safe_rule",
+    cases: [
+      {name: "same_case", expect: "Allow", files: [{path: "src/main.rs", text: "fn main() {}"}]},
+      {name: "same_case", expect: "Warn", files: [{path: "src/lib.rs", text: "unsafe {}"}]},
+    ],
+  }
+  const errors = validate_fixture_value("rust/fixtures/safe_rule.json", "safe_rule", fixture)
+  assert_eq(errors, ["rust/fixtures/safe_rule.json: duplicate case names: same_case"])
+}

--- a/scripts/canon-lib.harn
+++ b/scripts/canon-lib.harn
@@ -1,3 +1,14 @@
+import { JsonReadFailure, SchemaValidationFailure, read_json_typed_result } from "std/fs"
+import {
+  schema_closed_object,
+  schema_dict,
+  schema_enum,
+  schema_field,
+  schema_list,
+  schema_literal,
+  schema_string,
+} from "std/schema"
+
 const ROOT_DIR = path_normalize(path_join(source_dir(), ".."))
 
 const PACK_MANIFEST_PATH = path_join(ROOT_DIR, "canon-packs.json")
@@ -10,36 +21,146 @@ const URL_RE = "\"(https?://[^\"]+)\""
 
 const SEMANTIC_FALLBACK_RE = "fallback\\s*:\\s*(?:\"([A-Za-z_][A-Za-z0-9_]*)\"|([A-Za-z_][A-Za-z0-9_]*))"
 
+pub type CanonPack = {
+  id: string,
+  title: string,
+  invariants: string,
+  fixtures: string,
+  extensions?: list<string>,
+  file_names?: list<string>,
+}
+
+pub type CanonPackManifest = {schema_version: 1, packs: list<CanonPack>}
+
+pub type InvariantMode = "deterministic" | "semantic"
+
+pub type InvariantEntry = {
+  mode: InvariantMode,
+  mode_args: string,
+  fallback?: string,
+  evidence: string,
+  confidence: string,
+  source_date: string,
+  name: string,
+}
+
+pub type ParsedInvariants = {
+  entries: list<InvariantEntry>,
+  evidence_defs: dict<string, list<string>>,
+  errors: list<string>,
+}
+
+pub type CanonDate = {year: int, month: int, day: int, serial: int}
+
+pub type FixtureExpectedVerdict = "Allow" | "Warn" | "Block"
+
+pub type CanonFixtureFile = {path: string, text: string}
+
+pub type CanonFixtureCase = {
+  name: string,
+  expect: FixtureExpectedVerdict,
+  files: list<CanonFixtureFile>,
+  ctx?: dict,
+}
+
+pub type CanonFixtureDocument = {predicate: string, cases: list<CanonFixtureCase>}
+
+pub type CanonJsonReadFailure = JsonReadFailure | SchemaValidationFailure
+
+pub type FixtureCaseFailure = {
+  kind: "case",
+  pack: string,
+  predicate: string,
+  case: string,
+  expect: FixtureExpectedVerdict,
+  actual: string,
+  result: unknown,
+}
+
+pub type FixtureSetupFailure = {kind: "setup", error: string}
+
+pub type FixtureRunFailure = FixtureCaseFailure | FixtureSetupFailure
+
+pub type FixtureCasePass = {kind: "pass"}
+
+pub type FixtureCaseFail = {kind: "fail", failure: FixtureCaseFailure}
+
+pub type FixtureCaseResult = FixtureCasePass | FixtureCaseFail
+
+pub type FixturePackReport = {
+  pack: string,
+  executed: int,
+  skipped_semantic: int,
+  failures: list<FixtureRunFailure>,
+}
+
+/**
+ * Build the closed manifest schema owned by this JSON boundary.
+ *
+ * `schema_of` currently leaves nested record schemas open, so the owner schema
+ * is explicit to reject unknown keys at every manifest record level.
+ */
+pub fn pack_manifest_schema() -> Schema<CanonPackManifest> {
+  const pack_schema = schema_closed_object(
+    {
+      id: schema_string(),
+      title: schema_string(),
+      invariants: schema_string(),
+      fixtures: schema_string(),
+      extensions: schema_field(schema_list(schema_string()), false),
+      file_names: schema_field(schema_list(schema_string()), false),
+    },
+  )
+  return schema_closed_object({schema_version: schema_literal(1), packs: schema_list(pack_schema)})
+}
+
+/**
+ * Build the fixture document schema, closed at every owned record boundary.
+ *
+ * `ctx` remains an intentionally open dictionary because predicate-specific
+ * context keys are owned by each canon pack, not by the fixture envelope.
+ */
+pub fn fixture_document_schema() -> Schema<CanonFixtureDocument> {
+  const file_schema = schema_closed_object({path: schema_string(), text: schema_string()})
+  const case_schema = schema_closed_object(
+    {
+      name: schema_string(),
+      expect: schema_enum(["Allow", "Warn", "Block"]),
+      files: schema_list(file_schema),
+      ctx: schema_field(schema_dict(), false),
+    },
+  )
+  return schema_closed_object({predicate: schema_string(), cases: schema_list(case_schema)})
+}
+
 pub fn repo_root() -> string {
   return ROOT_DIR
 }
 
-pub fn load_pack_manifest() -> list {
-  const manifest = load_pack_manifest_document()
-  const packs = manifest?.packs ?? []
-  if manifest?.schema_version != 1 || type_of(packs) != "list" {
-    throw "canon-packs.json must use schema_version 1 with a packs list"
-  }
-  return packs
+pub fn read_pack_manifest_result() -> Result<CanonPackManifest, CanonJsonReadFailure> {
+  return read_pack_manifest_path_result(PACK_MANIFEST_PATH)
 }
 
-pub fn load_pack_manifest_document() -> dict {
-  const manifest = json_parse(harness.fs.read_text(PACK_MANIFEST_PATH))
-  if type_of(manifest) != "dict" {
-    throw "canon-packs.json must be a JSON object"
-  }
-  return manifest
+pub fn read_pack_manifest_path_result(path: string) -> Result<CanonPackManifest, CanonJsonReadFailure> {
+  return read_json_typed_result<CanonPackManifest>(path, pack_manifest_schema())
 }
 
-pub fn expected_packs() -> list<string> {
-  return load_pack_manifest().map({ pack -> to_string(pack?.id ?? "") }).filter({ id -> id != "" }).to_list()
+pub fn read_fixture_document_result(path: string) -> Result<CanonFixtureDocument, CanonJsonReadFailure> {
+  return read_json_typed_result<CanonFixtureDocument>(path, fixture_document_schema())
 }
 
-pub fn duplicate_values(values: list) -> list<string> {
+pub fn json_read_failure_message(failure: CanonJsonReadFailure) -> string {
+  return failure.path + ": " + failure.detail
+}
+
+pub fn expected_packs(manifest: CanonPackManifest) -> list<string> {
+  return manifest.packs.map({ pack -> pack.id }).to_list()
+}
+
+pub fn duplicate_values(values: list<string>) -> list<string> {
   let counts = {}
   for value in values {
-    const key = to_string(value)
-    counts[key] = (counts[key] ?? 0) + 1
+    counts[value] = (counts[value] ?? 0) + 1
   }
   let out: list<string> = []
   for key in keys(counts).sort() {
@@ -77,20 +198,6 @@ pub fn set_intersects(left: list<string>, right: list<string>) -> bool {
   return false
 }
 
-pub fn validate_allowed_keys(
-  rel_path: string,
-  location: string,
-  value,
-  allowed: list<string>,
-  errors: list<string>,
-) -> list<string> {
-  const unknown = set_difference(keys(value ?? {}).sort(), allowed)
-  if len(unknown) > 0 {
-    return errors + [rel_path + ": " + location + " has unknown keys: " + join(unknown, ", ")]
-  }
-  return errors
-}
-
 pub fn is_normalized_relative_path(value: string) -> bool {
   if value.starts_with("/") || value.contains("\\") {
     return false
@@ -103,7 +210,7 @@ pub fn is_normalized_relative_path(value: string) -> bool {
   return true
 }
 
-fn first_group(pattern: string, text: string) {
+fn first_group(pattern: string, text: string) -> string? {
   const captures = regex_captures(pattern, text ?? "") ?? []
   if len(captures) == 0 {
     return nil
@@ -117,16 +224,20 @@ fn first_group(pattern: string, text: string) {
   return nil
 }
 
-fn fallback_name(mode_args: string) {
+fn fallback_name(mode_args: string) -> string? {
   return first_group(SEMANTIC_FALLBACK_RE, mode_args)
 }
 
-pub fn parse_invariants(path: string, errors: list<string> = []) -> dict {
+pub fn parse_invariants(path: string, errors: list<string> = []) -> ParsedInvariants {
   const text = harness.fs.read_text(path)
-  let entries: list<dict> = []
+  let entries: list<InvariantEntry> = []
   for capture in regex_captures(INVARIANT_RE, text) ?? [] {
     const groups = capture?.groups ?? []
-    const mode = to_string(groups[0] ?? "")
+    const mode: InvariantMode = if to_string(groups[0] ?? "") == "deterministic" {
+      "deterministic"
+    } else {
+      "semantic"
+    }
     const mode_args = to_string(groups[1] ?? "")
     entries = entries
       + [
@@ -154,7 +265,7 @@ pub fn parse_invariants(path: string, errors: list<string> = []) -> dict {
         + " @invariant markers",
     ]
   }
-  let evidence_defs = {}
+  let evidence_defs: dict<string, list<string>> = {}
   for capture in regex_captures(EVIDENCE_RE, text) ?? [] {
     const groups = capture?.groups ?? []
     const name = to_string(groups[0] ?? "")
@@ -171,7 +282,7 @@ pub fn parse_invariants(path: string, errors: list<string> = []) -> dict {
   return {entries: entries, evidence_defs: evidence_defs, errors: out_errors}
 }
 
-pub fn parse_ymd(value: string) {
+pub fn parse_ymd(value: string) -> CanonDate? {
   const captures = regex_captures("^(\\d{4})-(\\d{2})-(\\d{2})$", value) ?? []
   if len(captures) == 0 {
     return nil
@@ -206,7 +317,7 @@ fn days_in_month(year: int, month: int) -> int {
   return 28
 }
 
-pub fn shifted_months(day: dict, months: int) -> dict {
+pub fn shifted_months(day: CanonDate, months: int) -> CanonDate {
   const zero_based = day.year * 12 + (day.month - 1) + months
   const year = floor(to_float(zero_based) / 12.0)
   const month = zero_based - to_int(year) * 12 + 1
@@ -219,7 +330,7 @@ pub fn shifted_months(day: dict, months: int) -> dict {
   }
 }
 
-pub fn today_from_env_or_args(today_arg = nil) {
+pub fn today_from_env_or_args(today_arg: unknown = nil) -> CanonDate {
   const raw = trim(to_string(today_arg ?? harness.env.get("HARN_CANON_TODAY") ?? ""))
   if raw == "" {
     throw "set HARN_CANON_TODAY=YYYY-MM-DD or pass --today YYYY-MM-DD"
@@ -231,7 +342,7 @@ pub fn today_from_env_or_args(today_arg = nil) {
   return parsed
 }
 
-pub fn fixture_verdict(record) -> string {
+pub fn fixture_verdict(record: dict) -> string {
   const kind = to_string(record?.result?.verdict?.kind ?? record?.raw_result?.verdict ?? "")
   const normalized = kind.lower()
   if normalized == "allow" {

--- a/scripts/execute-fixtures.harn
+++ b/scripts/execute-fixtures.harn
@@ -1,13 +1,21 @@
 import { parse_args } from "std/cli"
-import { expected_packs, fixture_verdict, parse_invariants, repo_root } from "./canon-lib"
+import {
+  CanonFixtureCase,
+  FixtureCaseResult,
+  FixturePackReport,
+  FixtureRunFailure,
+  expected_packs,
+  fixture_verdict,
+  json_read_failure_message,
+  parse_invariants,
+  read_fixture_document_result,
+  read_pack_manifest_result,
+  repo_root,
+} from "./canon-lib"
 
 const arg_spec = [{kind: "option", name: "pack", flags: ["--pack"], multi: true, default: []}]
 
-fn load_fixture(pack: string, predicate: string) -> dict {
-  return json_parse(harness.fs.read_text(path_join(repo_root(), pack, "fixtures", predicate + ".json")))
-}
-
-fn run_case(pack: string, predicate: string, case: dict) -> dict {
+fn run_case(pack: string, predicate: string, case: CanonFixtureCase) -> FixtureCaseResult {
   const eval_result = flow_evaluate_invariants(
     "",
     {files: case.files},
@@ -15,7 +23,7 @@ fn run_case(pack: string, predicate: string, case: dict) -> dict {
       path: path_join(repo_root(), pack, "invariants.harn"),
       predicates: [predicate],
       budget_ms: 50,
-      ctx: case?.ctx ?? {},
+      ctx: case.ctx ?? {},
     },
   )
   const records = eval_result?.records ?? []
@@ -27,11 +35,12 @@ fn run_case(pack: string, predicate: string, case: dict) -> dict {
   const actual = fixture_verdict(record)
   const expect = case.expect
   if actual == expect {
-    return {ok: true}
+    return {kind: "pass"}
   }
   return {
-    ok: false,
+    kind: "fail",
     failure: {
+      kind: "case",
       pack: pack,
       predicate: predicate,
       case: case.name,
@@ -42,34 +51,52 @@ fn run_case(pack: string, predicate: string, case: dict) -> dict {
   }
 }
 
-fn run_pack(pack: string) -> dict {
-  const parsed = parse_invariants(path_join(repo_root(), pack, "invariants.harn"), [])
+/**
+ * Execute one pack beneath an explicit canon root.
+ *
+ * @api_stability: internal
+ * @effects: [fs.read]
+ * @errors: []
+ */
+pub fn __run_pack_at(root: string, pack: string) -> FixturePackReport {
+  const parsed = parse_invariants(path_join(root, pack, "invariants.harn"), [])
   if len(parsed.errors) > 0 {
     return {
       pack: pack,
       executed: 0,
       skipped_semantic: 0,
-      failures: parsed.errors.map({ error -> {error: error} }).to_list(),
+      failures: parsed.errors.map({ error -> {kind: "setup", error: error} }).to_list(),
     }
   }
   let executed = 0
   let skipped_semantic = 0
-  let failures: list<dict> = []
+  let failures: list<FixtureRunFailure> = []
   for entry in parsed.entries {
     if entry.mode == "semantic" {
       skipped_semantic = skipped_semantic + 1
       continue
     }
-    const fixture = load_fixture(pack, entry.name)
+    const fixture_path = path_join(root, pack, "fixtures", entry.name + ".json")
+    const fixture_result = read_fixture_document_result(fixture_path)
+    if !is_ok(fixture_result) {
+      failures = failures
+        + [{kind: "setup", error: json_read_failure_message(unwrap_err(fixture_result))}]
+      continue
+    }
+    const fixture = unwrap(fixture_result)
     for case in fixture.cases {
       const result = run_case(pack, entry.name, case)
       executed = executed + 1
-      if !(result?.ok ?? false) {
+      if result.kind == "fail" {
         failures = failures + [result.failure]
       }
     }
   }
   return {pack: pack, executed: executed, skipped_semantic: skipped_semantic, failures: failures}
+}
+
+fn run_pack(pack: string) -> FixturePackReport {
+  return __run_pack_at(repo_root(), pack)
 }
 
 fn main(harness: Harness) {
@@ -78,7 +105,12 @@ fn main(harness: Harness) {
     harness.stdio.println(join(parsed._errors, "\n"))
     exit(2)
   }
-  const all_packs = expected_packs()
+  const manifest_result = read_pack_manifest_result()
+  if !is_ok(manifest_result) {
+    harness.stdio.println(json_read_failure_message(unwrap_err(manifest_result)))
+    exit(1)
+  }
+  const all_packs = expected_packs(unwrap(manifest_result))
   const requested = parsed?.pack ?? []
   let unknown: list<string> = []
   for pack in requested {
@@ -95,22 +127,22 @@ fn main(harness: Harness) {
   } else {
     all_packs
   }
-  let reports: list<dict> = []
+  let reports: list<FixturePackReport> = []
   for pack in packs {
     reports = reports + [run_pack(pack)]
   }
-  let failures: list<dict> = []
+  let failures: list<FixtureRunFailure> = []
   let executed = 0
   let skipped_semantic = 0
   for report in reports {
-    executed = executed + (report?.executed ?? 0)
-    skipped_semantic = skipped_semantic + (report?.skipped_semantic ?? 0)
-    failures = failures + (report?.failures ?? [])
+    executed = executed + report.executed
+    skipped_semantic = skipped_semantic + report.skipped_semantic
+    failures = failures + report.failures
   }
   if len(failures) > 0 {
     harness.stdio.println("Canon fixture execution failed:")
     for report in reports {
-      for failure in report?.failures ?? [] {
+      for failure in report.failures {
         harness.stdio.println("- " + report.pack + ": " + json_stringify(failure))
       }
     }

--- a/scripts/validate-canon.harn
+++ b/scripts/validate-canon.harn
@@ -1,19 +1,35 @@
 import { parse_args } from "std/cli"
 import {
+  CanonDate,
+  CanonFixtureCase,
+  CanonFixtureDocument,
+  CanonFixtureFile,
+  CanonPack,
+  CanonPackManifest,
+  FixtureExpectedVerdict,
+  InvariantEntry,
   duplicate_values,
   expected_packs,
   is_normalized_relative_path,
-  load_pack_manifest,
-  load_pack_manifest_document,
+  json_read_failure_message,
   parse_invariants,
   parse_ymd,
+  read_fixture_document_result,
+  read_pack_manifest_result,
   repo_root,
   set_difference,
   set_intersects,
   shifted_months,
   today_from_env_or_args,
-  validate_allowed_keys,
 } from "./canon-lib"
+
+type FixtureCaseValidation = {
+  errors: list<string>,
+  expects: list<FixtureExpectedVerdict>,
+  case_names: list<string>,
+}
+
+type FixtureValidationReport = {errors: list<string>, count: int}
 
 const EVAL_CRITICAL_PACK_ROUTES = {
   c: {extensions: ["c", "h"]},
@@ -37,72 +53,65 @@ const MAX_SEMANTIC = 3
 
 const PACK_DETERMINISTIC_LIMITS = {zig: [MIN_DETERMINISTIC, 15]}
 
-const VALID_EXPECTS = ["Allow", "Warn", "Block"]
-
-const FIXTURE_KEYS = ["predicate", "cases"]
-
-const CASE_KEYS = ["name", "expect", "files", "ctx"]
-
-const FILE_KEYS = ["path", "text"]
-
-const PACK_MANIFEST_ROOT_KEYS = ["schema_version", "packs"]
-
-const PACK_MANIFEST_KEYS = ["id", "title", "invariants", "fixtures", "extensions", "file_names"]
-
 const arg_spec = [{kind: "option", name: "today", flags: ["--today"], default: nil}]
 
 fn usage() -> string {
   return "Validate harn-canon pack structure and fixtures.\n\nUsage: harn run scripts/validate-canon.harn -- --today YYYY-MM-DD\n"
 }
 
-fn validate_routing_selectors(pack_id: string, pack: dict, errors: list<string>) -> list<string> {
+fn validate_routing_selector_values(
+  pack_id: string,
+  field: string,
+  values: list<string>,
+  errors: list<string>,
+) -> list<string> {
   let out = errors
-  for field in ["extensions", "file_names"] {
-    const values = pack[field] ?? []
-    if type_of(values) != "list" {
-      out = out + ["canon-packs.json: " + pack_id + " " + field + " must be a list"]
+  if values != values.sort() {
+    out = out + ["canon-packs.json: " + pack_id + " " + field + " must be sorted"]
+  }
+  const duplicates = duplicate_values(values)
+  if len(duplicates) > 0 {
+    out = out
+      + ["canon-packs.json: " + pack_id + " " + field + " has duplicates: " + join(duplicates, ", ")]
+  }
+  for value in values {
+    if value == "" {
+      out = out + ["canon-packs.json: " + pack_id + " " + field + " entries must be non-empty"]
       continue
     }
-    if values != values.sort() {
-      out = out + ["canon-packs.json: " + pack_id + " " + field + " must be sorted"]
-    }
-    const duplicates = duplicate_values(values)
-    if len(duplicates) > 0 {
+    if value != value.lower() {
       out = out
-        + ["canon-packs.json: " + pack_id + " " + field + " has duplicates: " + join(duplicates, ", ")]
+        + ["canon-packs.json: " + pack_id + " " + field + " entry " + value + " must be lowercase"]
     }
-    for value in values {
-      if type_of(value) != "string" || value == "" {
-        out = out + ["canon-packs.json: " + pack_id + " " + field + " entries must be strings"]
-        continue
-      }
-      if value != value.lower() {
-        out = out
-          + ["canon-packs.json: " + pack_id + " " + field + " entry " + value + " must be lowercase"]
-      }
-      if value.contains("/") || value.contains("\\") || value.starts_with(".") {
-        out = out
-          + [
-          "canon-packs.json: " + pack_id + " " + field + " entry " + value
-            + " must be a basename selector",
-        ]
-      }
-      if regex_match("^[a-z0-9][a-z0-9_+-]*$", value) == nil {
-        out = out
-          + [
-          "canon-packs.json: " + pack_id + " " + field + " entry " + value
-            + " has invalid characters",
-        ]
-      }
+    if value.contains("/") || value.contains("\\") || value.starts_with(".") {
+      out = out
+        + [
+        "canon-packs.json: " + pack_id + " " + field + " entry " + value
+          + " must be a basename selector",
+      ]
     }
-  }
-  if len(pack?.extensions ?? []) == 0 && len(pack?.file_names ?? []) == 0 {
-    out = out + ["canon-packs.json: " + pack_id + " needs at least one extension or file_names selector"]
+    if regex_match("^[a-z0-9][a-z0-9_+-]*$", value) == nil {
+      out = out
+        + [
+        "canon-packs.json: " + pack_id + " " + field + " entry " + value
+          + " has invalid characters",
+      ]
+    }
   }
   return out
 }
 
-fn validate_eval_critical_routes(packs_by_id: dict, errors: list<string>) -> list<string> {
+fn validate_routing_selectors(pack: CanonPack, errors: list<string>) -> list<string> {
+  const extensions = pack.extensions ?? []
+  let out = validate_routing_selector_values(pack.id, "extensions", extensions, errors)
+  out = validate_routing_selector_values(pack.id, "file_names", pack.file_names ?? [], out)
+  if len(extensions) == 0 && len(pack.file_names ?? []) == 0 {
+    out = out + ["canon-packs.json: " + pack.id + " needs at least one extension or file_names selector"]
+  }
+  return out
+}
+
+fn validate_eval_critical_routes(packs_by_id: dict<string, CanonPack>, errors: list<string>) -> list<string> {
   let out = errors
   for pack_id in keys(EVAL_CRITICAL_PACK_ROUTES).sort() {
     const pack = packs_by_id[pack_id]
@@ -110,43 +119,27 @@ fn validate_eval_critical_routes(packs_by_id: dict, errors: list<string>) -> lis
       out = out + ["canon-packs.json: missing eval-critical pack " + pack_id]
       continue
     }
-    const required = EVAL_CRITICAL_PACK_ROUTES[pack_id]
-    for field in keys(required).sort() {
-      const missing = set_difference(required[field], pack[field] ?? [])
-      if len(missing) > 0 {
-        out = out
-          + [
-          "canon-packs.json: eval-critical pack "
-            + pack_id
-            + " "
-            + field
-            + " must include "
-            + join(missing, ", "),
-        ]
-      }
+    const missing = set_difference(EVAL_CRITICAL_PACK_ROUTES[pack_id].extensions, pack.extensions ?? [])
+    if len(missing) > 0 {
+      out = out
+        + [
+        "canon-packs.json: eval-critical pack " + pack_id + " extensions must include "
+          + join(missing, ", "),
+      ]
     }
   }
   return out
 }
 
-fn validate_manifest(errors: list<string>) -> list<string> {
+fn validate_manifest(manifest: CanonPackManifest, errors: list<string>) -> list<string> {
   let out = errors
   let seen = {}
-  let packs_by_id = {}
-  const manifest = load_pack_manifest_document()
-  out = validate_allowed_keys("canon-packs.json", "manifest root", manifest, PACK_MANIFEST_ROOT_KEYS, out)
-  const packs = load_pack_manifest()
+  let packs_by_id: dict<string, CanonPack> = {}
   let pack_ids: list<string> = []
-  for index in range(0, len(packs)) {
-    const pack = packs[index]
-    if type_of(pack) != "dict" {
-      out = out + ["canon-packs.json: pack " + to_string(index) + " must be an object"]
-      continue
-    }
-    out = validate_allowed_keys("canon-packs.json", "pack " + to_string(index), pack, PACK_MANIFEST_KEYS, out)
-    const pack_id = pack?.id
-    if type_of(pack_id) != "string" || pack_id == "" {
-      out = out + ["canon-packs.json: pack " + to_string(index) + " needs a non-empty id"]
+  for pack in manifest.packs {
+    const pack_id = pack.id
+    if pack_id == "" {
+      out = out + ["canon-packs.json: pack needs a non-empty id"]
       continue
     }
     if seen[pack_id] ?? false {
@@ -157,13 +150,13 @@ fn validate_manifest(errors: list<string>) -> list<string> {
     pack_ids = pack_ids + [pack_id]
     const expected_invariants = pack_id + "/invariants.harn"
     const expected_fixtures = pack_id + "/fixtures"
-    if pack?.invariants != expected_invariants {
+    if pack.invariants != expected_invariants {
       out = out + ["canon-packs.json: " + pack_id + " invariants must be " + expected_invariants]
     }
-    if pack?.fixtures != expected_fixtures {
+    if pack.fixtures != expected_fixtures {
       out = out + ["canon-packs.json: " + pack_id + " fixtures must be " + expected_fixtures]
     }
-    if type_of(pack?.title) != "string" || trim(pack.title) == "" {
+    if trim(pack.title) == "" {
       out = out + ["canon-packs.json: " + pack_id + " needs a non-empty title"]
     }
     if !harness.fs.exists(path_join(repo_root(), expected_invariants)) {
@@ -172,7 +165,7 @@ fn validate_manifest(errors: list<string>) -> list<string> {
     if !harness.fs.exists(path_join(repo_root(), expected_fixtures)) {
       out = out + ["canon-packs.json: " + expected_fixtures + " does not exist"]
     }
-    out = validate_routing_selectors(pack_id, pack, out)
+    out = validate_routing_selectors(pack, out)
   }
   if pack_ids != pack_ids.sort() {
     out = out + ["canon-packs.json: packs must be sorted by id"]
@@ -180,10 +173,10 @@ fn validate_manifest(errors: list<string>) -> list<string> {
   return validate_eval_critical_routes(packs_by_id, out)
 }
 
-fn validate_readme_coverage(errors: list<string>) -> list<string> {
+fn validate_readme_coverage(manifest: CanonPackManifest, errors: list<string>) -> list<string> {
   let out = errors
   const readme = harness.fs.read_text(path_join(repo_root(), "README.md"))
-  for pack in expected_packs() {
+  for pack in expected_packs(manifest) {
     if !readme.contains("](./" + pack + "/)") {
       out = out + ["README.md: missing pack link for " + pack + "/"]
     }
@@ -191,7 +184,7 @@ fn validate_readme_coverage(errors: list<string>) -> list<string> {
   return out
 }
 
-fn validate_semantic_fallbacks(pack: string, entries: list, errors: list<string>) -> list<string> {
+fn validate_semantic_fallbacks(pack: string, entries: list<InvariantEntry>, errors: list<string>) -> list<string> {
   let out = errors
   let deterministic = {}
   for entry in entries {
@@ -202,12 +195,12 @@ fn validate_semantic_fallbacks(pack: string, entries: list, errors: list<string>
   for entry in entries {
     const predicate = entry.name
     if entry.mode == "deterministic" {
-      if trim(entry?.mode_args ?? "") != "" {
+      if trim(entry.mode_args) != "" {
         out = out + [pack + ": deterministic predicate " + predicate + " must not declare mode args"]
       }
       continue
     }
-    if entry?.fallback == nil {
+    if entry.fallback == nil {
       out = out
         + [
         pack + ": semantic predicate " + predicate
@@ -230,9 +223,9 @@ fn validate_semantic_fallbacks(pack: string, entries: list, errors: list<string>
 
 fn validate_evidence(
   pack: string,
-  entries: list,
-  evidence_defs: dict,
-  today: dict,
+  entries: list<InvariantEntry>,
+  evidence_defs: dict<string, list<string>>,
+  today: CanonDate,
   errors: list<string>,
 ) -> list<string> {
   let out = errors
@@ -294,30 +287,12 @@ fn validate_case_file(
   rel_path: string,
   case_index: int,
   file_index: int,
-  file_fixture,
+  file_fixture: CanonFixtureFile,
   errors: list<string>,
 ) -> list<string> {
   let out = errors
-  if type_of(file_fixture) != "dict" {
-    return out
-      + [
-      rel_path
-        + ": case "
-        + to_string(case_index)
-        + " file "
-        + to_string(file_index)
-        + " must be an object",
-    ]
-  }
-  out = validate_allowed_keys(
-    rel_path,
-    "case " + to_string(case_index) + " file " + to_string(file_index),
-    file_fixture,
-    FILE_KEYS,
-    out,
-  )
-  const file_path = file_fixture?.path
-  if type_of(file_path) != "string" || file_path == "" {
+  const file_path = file_fixture.path
+  if file_path == "" {
     out = out
       + [
       rel_path + ": case " + to_string(case_index) + " file " + to_string(file_index)
@@ -334,84 +309,55 @@ fn validate_case_file(
         + " path must be normalized and relative",
     ]
   }
-  if type_of(file_fixture?.text) != "string" {
-    out = out
-      + [
-      rel_path + ": case " + to_string(case_index) + " file " + to_string(file_index)
-        + " needs text",
-    ]
-  }
   return out
 }
 
-fn validate_fixture_case(rel_path: string, index: int, case, errors: list<string>) -> dict {
+fn validate_fixture_case(rel_path: string, index: int, case: CanonFixtureCase, errors: list<string>) -> FixtureCaseValidation {
   let out = errors
-  let expects: list<string> = []
+  let expects: list<FixtureExpectedVerdict> = [case.expect]
   let case_names: list<string> = []
-  if type_of(case) != "dict" {
-    return {
-      errors: out + [rel_path + ": case " + to_string(index) + " must be an object"],
-      expects: expects,
-      case_names: case_names,
-    }
-  }
-  out = validate_allowed_keys(rel_path, "case " + to_string(index), case, CASE_KEYS, out)
-  const case_name = case?.name
-  if type_of(case_name) != "string" || case_name == "" {
+  const case_name = case.name
+  if case_name == "" {
     out = out + [rel_path + ": case " + to_string(index) + " needs a name"]
   } else if regex_match("^[a-z][a-z0-9_]*$", case_name) == nil {
     out = out + [rel_path + ": case " + to_string(index) + " name must be snake_case"]
   } else {
     case_names = case_names + [case_name]
   }
-  const expect = case?.expect
-  if !VALID_EXPECTS.contains(expect) {
-    out = out + [rel_path + ": case " + to_string(index) + " has invalid expect " + to_string(expect)]
-  } else {
-    expects = expects + [expect]
-  }
-  if keys(case).contains("ctx") && type_of(case.ctx) != "dict" {
-    out = out + [rel_path + ": case " + to_string(index) + " ctx must be an object"]
-  }
-  const files = case?.files
-  if type_of(files) != "list" || len(files) == 0 {
+  if len(case.files) == 0 {
     out = out + [rel_path + ": case " + to_string(index) + " files must be a non-empty list"]
     return {errors: out, expects: expects, case_names: case_names}
   }
-  for file_index in range(0, len(files)) {
-    out = validate_case_file(rel_path, index, file_index, files[file_index], out)
+  let file_index = 0
+  for file_fixture in case.files {
+    out = validate_case_file(rel_path, index, file_index, file_fixture, out)
+    file_index = file_index + 1
   }
   return {errors: out, expects: expects, case_names: case_names}
 }
 
-fn validate_fixture_document(pack_dir: string, fixture_path: string, errors: list<string>) -> list<string> {
+pub fn validate_fixture_value(
+  rel_path: string,
+  expected_predicate: string,
+  fixture: CanonFixtureDocument,
+  errors: list<string> = [],
+) -> list<string> {
   let out = errors
-  const rel_path = basename(pack_dir) + "/fixtures/" + basename(fixture_path)
-  const loaded = try {
-    json_parse(harness.fs.read_text(fixture_path))
-  }
-  if is_err(loaded) {
-    return out + [rel_path + ": invalid JSON: " + to_string(unwrap_err(loaded))]
-  }
-  const fixture = unwrap(loaded)
-  if type_of(fixture) != "dict" {
-    return out + [rel_path + ": fixture must be an object"]
-  }
-  if fixture?.predicate != basename(fixture_path).replace(".json", "") {
+  if fixture.predicate != expected_predicate {
     out = out + [rel_path + ": predicate must match fixture file name"]
   }
-  const cases = fixture?.cases
-  if type_of(cases) != "list" || len(cases) == 0 {
+  if len(fixture.cases) == 0 {
     return out + [rel_path + ": cases must be a non-empty list"]
   }
-  out = validate_allowed_keys(rel_path, "fixture", fixture, FIXTURE_KEYS, out)
-  let expects: list<string> = []
+  let expects: list<FixtureExpectedVerdict> = []
   let case_names: list<string> = []
-  for index in range(0, len(cases)) {
-    const result = validate_fixture_case(rel_path, index, cases[index], out)
+  let index = 0
+  for case in fixture.cases {
+    const result = validate_fixture_case(rel_path, index, case, out)
     out = result.errors
     expects = expects + result.expects
     case_names = case_names + result.case_names
+    index = index + 1
   }
   const duplicate_case_names = duplicate_values(case_names)
   if len(duplicate_case_names) > 0 {
@@ -426,7 +372,18 @@ fn validate_fixture_document(pack_dir: string, fixture_path: string, errors: lis
   return out
 }
 
-fn validate_fixtures(pack_dir: string, predicate_names: list<string>, errors: list<string>) -> dict {
+fn validate_fixture_document(pack_dir: string, fixture_path: string, errors: list<string>) -> list<string> {
+  const rel_path = basename(pack_dir) + "/fixtures/" + basename(fixture_path)
+  const loaded = read_fixture_document_result(fixture_path)
+  if !is_ok(loaded) {
+    return errors + [rel_path + ": " + unwrap_err(loaded).detail]
+  }
+  const fixture = unwrap(loaded)
+  const expected_predicate = basename(fixture_path).replace(".json", "")
+  return validate_fixture_value(rel_path, expected_predicate, fixture, errors)
+}
+
+fn validate_fixtures(pack_dir: string, predicate_names: list<string>, errors: list<string>) -> FixtureValidationReport {
   let out = errors
   const fixtures_dir = path_join(pack_dir, "fixtures")
   if !harness.fs.exists(fixtures_dir) {
@@ -483,8 +440,17 @@ fn main(harness: Harness) {
     exit(1)
   }
   const today = unwrap(today_result)
+  const manifest_result = read_pack_manifest_result()
+  if !is_ok(manifest_result) {
+    harness.stdio
+      .println(
+      "Canon validation failed:\n- " + json_read_failure_message(unwrap_err(manifest_result)),
+    )
+    exit(1)
+  }
+  const manifest = unwrap(manifest_result)
   let errors: list<string> = []
-  const expected = expected_packs()
+  const expected = expected_packs(manifest)
   const actual = pack_dirs()
   for pack in set_difference(expected, actual) {
     errors = errors + [pack + ": expected pack directory is missing"]
@@ -492,8 +458,8 @@ fn main(harness: Harness) {
   for pack in set_difference(actual, expected) {
     errors = errors + [pack + ": pack directory is not listed in EXPECTED_PACKS"]
   }
-  errors = validate_manifest(errors)
-  errors = validate_readme_coverage(errors)
+  errors = validate_manifest(manifest, errors)
+  errors = validate_readme_coverage(manifest, errors)
   let total_predicates = 0
   let total_fixtures = 0
   for pack in expected {


### PR DESCRIPTION
Closes #122.

Canon now validates its owned JSON shapes once at the file boundary with closed typed schemas. Manifest packs, fixture documents, cases, files, invariant metadata, dates, verdicts, execution reports, and setup/case failures have explicit Harn types; callers consume those contracts instead of repeating type_of checks and optional-dict fallbacks.

The fixture ctx field remains intentionally open because predicate-specific context is owned by each pack. The executor now reports malformed fixture input as a typed setup failure instead of crashing, and CI includes a focused 10-case adversarial boundary suite covering unknown keys, nested type failures, routing selector variants, semantic invariants, and executor setup errors.

Verification used the checksum-verified published Harn v0.10.15 binary pinned by exact main 966bf1aa:
- strict check, strict lint, and fmt for all four scripts
- 10/10 typed boundary tests
- 34 packs, 340 predicates, and 340 fixtures validated
- 651 deterministic fixture cases executed; 88 semantic predicates skipped by design
- all predicate-pack check/lint invocations terminal with only pre-existing non-fatal evidence-marker warnings
- side-effect builtin guard and git diff --check

All handwritten source files remain below 1,500 lines; the largest is 648 lines.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-canon/pr/125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786548358&installation_id=145974243&pr_number=125&repository=burin-labs%2Fharn-canon&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-canon%2Fpull%2F125&signature=495705f9bfad9bc2d071faf4877735d52c6e5ffbba9dbc6a2bd49ba6d3b9bfe3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->