### PR TITLE
Use typed read results in canon scripts

### DIFF
--- a/scripts/canon-lib.harn
+++ b/scripts/canon-lib.harn
@@ -1,4 +1,9 @@
-import { SchemaValidationFailure, StructuredReadFailure, read_json_typed_result } from "std/fs"
+import {
+  SchemaValidationFailure,
+  StructuredReadFailure,
+  TypedReadResult,
+  read_json_typed_result,
+} from "std/fs"
 import {
   schema_closed_object,
   schema_dict,
@@ -64,8 +69,6 @@ pub type CanonFixtureCase = {
 }
 
 pub type CanonFixtureDocument = {predicate: string, cases: list<CanonFixtureCase>}
-
-pub type CanonJsonReadFailure = StructuredReadFailure | SchemaValidationFailure
 
 pub type FixtureCaseFailure = {
   kind: "case",
@@ -137,19 +140,19 @@ pub fn repo_root() -> string {
   return ROOT_DIR
 }
 
-pub fn read_pack_manifest_result() -> Result<CanonPackManifest, CanonJsonReadFailure> {
+pub fn read_pack_manifest_result() -> TypedReadResult<CanonPackManifest> {
   return read_pack_manifest_path_result(PACK_MANIFEST_PATH)
 }
 
-pub fn read_pack_manifest_path_result(path: string) -> Result<CanonPackManifest, CanonJsonReadFailure> {
+pub fn read_pack_manifest_path_result(path: string) -> TypedReadResult<CanonPackManifest> {
   return read_json_typed_result<CanonPackManifest>(path, pack_manifest_schema())
 }
 
-pub fn read_fixture_document_result(path: string) -> Result<CanonFixtureDocument, CanonJsonReadFailure> {
+pub fn read_fixture_document_result(path: string) -> TypedReadResult<CanonFixtureDocument> {
   return read_json_typed_result<CanonFixtureDocument>(path, fixture_document_schema())
 }
 
-pub fn json_read_failure_message(failure: CanonJsonReadFailure) -> string {
+pub fn structured_read_failure_message(failure: StructuredReadFailure | SchemaValidationFailure) -> string {
   return failure.path + ": " + failure.detail
 }
 

--- a/scripts/execute-fixtures.harn
+++ b/scripts/execute-fixtures.harn
@@ -6,11 +6,11 @@ import {
   FixtureRunFailure,
   expected_packs,
   fixture_verdict,
-  json_read_failure_message,
   parse_invariants,
   read_fixture_document_result,
   read_pack_manifest_result,
   repo_root,
+  structured_read_failure_message,
 } from "./canon-lib"
 
 const arg_spec = [{kind: "option", name: "pack", flags: ["--pack"], multi: true, default: []}]
@@ -80,7 +80,7 @@ pub fn __run_pack_at(root: string, pack: string) -> FixturePackReport {
     const fixture_result = read_fixture_document_result(fixture_path)
     if !is_ok(fixture_result) {
       failures = failures
-        + [{kind: "setup", error: json_read_failure_message(unwrap_err(fixture_result))}]
+        + [{kind: "setup", error: structured_read_failure_message(unwrap_err(fixture_result))}]
       continue
     }
     const fixture = unwrap(fixture_result)
@@ -107,7 +107,7 @@ fn main(harness: Harness) {
   }
   const manifest_result = read_pack_manifest_result()
   if !is_ok(manifest_result) {
-    harness.stdio.println(json_read_failure_message(unwrap_err(manifest_result)))
+    harness.stdio.println(structured_read_failure_message(unwrap_err(manifest_result)))
     exit(1)
   }
   const all_packs = expected_packs(unwrap(manifest_result))

--- a/scripts/validate-canon.harn
+++ b/scripts/validate-canon.harn
@@ -11,7 +11,6 @@ import {
   duplicate_values,
   expected_packs,
   is_normalized_relative_path,
-  json_read_failure_message,
   parse_invariants,
   parse_ymd,
   read_fixture_document_result,
@@ -20,6 +19,7 @@ import {
   set_difference,
   set_intersects,
   shifted_months,
+  structured_read_failure_message,
   today_from_env_or_args,
 } from "./canon-lib"
 
@@ -444,7 +444,7 @@ fn main(harness: Harness) {
   if !is_ok(manifest_result) {
     harness.stdio
       .println(
-      "Canon validation failed:\n- " + json_read_failure_message(unwrap_err(manifest_result)),
+      "Canon validation failed:\n- " + structured_read_failure_message(unwrap_err(manifest_result)),
     )
     exit(1)
   }


### PR DESCRIPTION
## Summary
- replace the repo-local `CanonJsonReadFailure` alias with Harn stdlib `TypedReadResult<T>` at the canon JSON read boundary
- rename the shared error rendering helper to `structured_read_failure_message`
- keep validation and fixture behavior unchanged

## Verification
Using pinned Harn from `.harn-version` (`harn 0.10.17`) downloaded to `/private/tmp/harn-canon-bin-v0.10.17-aarch64-apple-darwin/harn`:

- `harn fmt --check scripts/canon-lib.harn scripts/validate-canon.harn scripts/execute-fixtures.harn scripts/canon-boundary-test.harn`
- `harn check` + `harn lint --strict` for each CI script
- `harn test scripts/canon-boundary-test.harn --timeout 30000` (10/10)
- `HARN_CANON_TODAY=$(date -u +%F) harn run scripts/validate-canon.harn` (34 packs, 340 predicates, 340 fixtures)
- `harn run scripts/execute-fixtures.harn` (651 deterministic cases; 88 semantic skipped)
- `git diff --check`

Note: local fixture execution printed a non-fatal SQLite WAL setup warning, then completed successfully.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-canon/pr/127"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786693628&installation_id=145974243&pr_number=127&repository=burin-labs%2Fharn-canon&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-canon%2Fpull%2F127&signature=48fe5429ad7a0a7136bd3b06e28acd2f4439322bbc18a30943a146cd8fd5429c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->