### PR TITLE
docs: describe harn-canon runtime boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,14 @@ update that file when validating a new runtime.
 
 ## Status
 
-**Early - design-first.** All v0 seed packs are present. The runtime is still evolving in `burin-labs/harn`, so this repo keeps the pack corpus evidence-rich and fixture-backed.
+**Runtime-backed seed library.** This package contributes its pack manifest through
+`harn.canon`. Harn owns root discovery, changed-slice evaluation, and feedback
+delivery; product hosts consume that Harn contract instead of copying predicate
+routing or policy.
 
-Use this repo to review pack shape, evidence, and fixture coverage independently of runtime work in Harn.
+The packs remain v0: each predicate must earn its place with current evidence
+and a fixture-backed behavior contract. Use this repository to improve pack
+quality and coverage without recreating the runtime layer.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- replace the stale design-only runtime claim with the shipped Harn runtime boundary
- keep harn-canon responsible for pack data and routing, while Harn owns discovery, evaluation, and feedback
- preserve the v0 pack-quality bar without implying a second runtime implementation

## Verification
- `HARN_CANON_TODAY=$(date -u +%F) harn run scripts/validate-canon.harn`
- `harn run scripts/execute-fixtures.harn`
- `harn check scripts/canon-lib.harn scripts/validate-canon.harn scripts/execute-fixtures.harn`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-canon/pr/132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786886251&installation_id=145974243&pr_number=132&repository=burin-labs%2Fharn-canon&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-canon%2Fpull%2F132&signature=e6e9869f9969ae751b811aa4e89e6e3a8c283f747ebaeea477992a579f17e3f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->