### PR TITLE
Gate the Harn bump on ci.yml's real checks, not a generic sweep

### DIFF
--- a/.github/workflows/bump-harn.yml
+++ b/.github/workflows/bump-harn.yml
@@ -1,10 +1,9 @@
 # Bump Harn Runtime — thin caller of the reusable workflow (harn#5299).
 #
-# Replaces the ~267L copied shell/YAML state machine with a trigger wrapper that
-# calls burin-labs/harn's published `workflow_call` workflow. All orchestration
-# (pin resolve, readiness gate, lockfile refresh, signed commit, PR + auto-merge)
-# lives in Harn (`std/bump/runtime`/`std/bump/live`), not here. The only
-# repo-specific parts are the schedule and the single validate-command.
+# All orchestration (pin resolve, readiness gate, lockfile refresh, signed
+# commit, PR + auto-merge) lives in Harn (`std/bump/runtime`/`std/bump/live`),
+# not here. The only repo-specific parts are the schedule and the single
+# validate-command.
 name: Bump Harn Runtime
 on:
   workflow_dispatch:
@@ -30,18 +29,41 @@ jobs:
       # lockfile refresh; non-zero exit blocks the commit. POSIX-sh only — the
       # runtime executes this through the host default shell (std/command shell
       # mode), which on a runner may resolve to /bin/sh (dash), not bash. No
-      # bashisms (mapfile/pipefail/(( ))): keep this portable so the identical
-      # template is safe across every fleet repo regardless of runner shell.
+      # bashisms (mapfile/pipefail/(( ))): keep this portable regardless of
+      # runner shell.
+      #
+      # This mirrors `.github/workflows/ci.yml`, which is deliberately NOT a
+      # `git ls-files '*.harn'` sweep. harn-canon has two populations of .harn
+      # source with different gates:
+      #   * the four repo scripts, held to `harn lint --strict`;
+      #   * ~34 `invariants.harn` predicate packs, held to plain `harn lint`
+      #     (they are trusted code executed on consumer machines by
+      #     `harn lint`, and are not formatter-gated by ci.yml).
+      # Sweeping both into one strict pass would fail the bump on packs that
+      # ci.yml intentionally lets through.
+      #
+      # Deviation from ci.yml, deliberate: ci.yml runs `harn fmt --check`
+      # because it verifies a PR; here `harn fmt` REWRITES, so a formatter
+      # change in the new runtime lands in the bump commit and the PR's own
+      # ci.yml `--check` then passes. Verifying here would instead wedge the
+      # daily bump permanently on any formatter change.
       validate-command: |
         set -eu
-        files=$(git ls-files '*.harn')
-        if [ -n "$files" ]; then
-          # Word-splitting on $files is intentional: pass every .harn path as a
-          # separate arg. Fleet .harn paths never contain whitespace.
-          harn fmt $files
-          harn check $files
-          harn lint $files
+        scripts='scripts/canon-lib.harn scripts/validate-canon.harn scripts/execute-fixtures.harn scripts/canon-boundary-test.harn'
+        # Word-splitting on $scripts is intentional: one arg per path.
+        harn fmt $scripts
+        for script in $scripts; do
+          harn check "$script"
+          harn lint --strict "$script"
+        done
+        harn test scripts/canon-boundary-test.harn --timeout 30000
+        HARN_CANON_TODAY="$(date -u +%F)" harn run scripts/validate-canon.harn
+        packs=$(find . -name invariants.harn -type f -not -path './.git/*')
+        if [ -n "$packs" ]; then
+          harn check $packs
+          harn lint $packs
         fi
+        harn run scripts/execute-fixtures.harn
     secrets:
       app-client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
       app-private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

This repo already calls Harn's reusable `bump-harn.yml`, but it adopted the **stock template** verbatim — a `git ls-files '*.harn'` sweep with non-strict `fmt`/`check`/`lint`. That is not what `ci.yml` enforces, and the gap runs in both directions.

harn-canon has two populations of `.harn` source with deliberately different gates:

| population | ci.yml gate |
| --- | --- |
| the four repo scripts | `harn lint --strict` |
| ~34 `invariants.harn` predicate packs | plain `harn lint` (trusted code executed on consumer machines by `harn lint`; not formatter-gated) |

The generic sweep dropped `--strict` from the scripts *and* pulled the packs into the strict pass — simultaneously weaker than CI and liable to fail on packs `ci.yml` intentionally lets through.

It also ran none of the checks that actually exercise the runtime. A Harn bump could go green having proved only that the files still parse.

## What changed

`validate-command` now mirrors `ci.yml`:

- `harn fmt` over the explicit four-script list
- per-script `harn check` + `harn lint --strict`
- `harn test scripts/canon-boundary-test.harn --timeout 30000`
- `HARN_CANON_TODAY="$(date -u +%F)" harn run scripts/validate-canon.harn`
- `harn check` + `harn lint` over every `invariants.harn`
- `harn run scripts/execute-fixtures.harn`

Schedule (`37 9 * * *`), the pinned reusable ref, and `workflow_dispatch:` at two-space indentation are unchanged.

## Two deliberate deviations

**`harn fmt` rewrites instead of `--check`.** `ci.yml` verifies a PR, so `--check` is right there. Here the command runs *before* the bump commit, so rewriting means a formatter change in a new runtime lands in the bump and the PR's own `ci.yml --check` then passes. Verifying here would wedge the daily bump permanently on any formatter change.

**The side-effect-builtin `grep` from `ci.yml` is not folded in.** It is a PR content policy on predicate packs; a runtime bump adds no source, so it cannot newly violate it. It stays in `ci.yml`.

## Verification

- Extracted the `validate-command` out of the YAML with `ruby -ryaml` and ran it **verbatim under `/bin/dash`** (not bash): exit 0. Full run, including all 34 packs — "Executed 651 deterministic fixture cases across 34 packs".
- `actionlint` clean.
- `grep -c '^  workflow_dispatch:$'` → `1` (load-bearing for harn-bump-fleet's discovery test).
- `.harn-version` is **bare semver `0.10.39`**, no leading `v` — confirmed against `ci.yml`, which hard-errors on a leading `v`, and compatible with the reusable workflow's `strip_v`.
- `git status` clean after the run: `harn fmt` is a no-op at the current pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-canon/pr/140"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787592519&installation_model_id=426921&pr_number=140&repository=burin-labs%2Fharn-canon&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-canon%2Fpull%2F140&signature=3b4af7e8239963becd626fb210f58b052813f7a104a09e4428ff7e5ca90b76bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->