### PR TITLE
Pin the canonical package verification policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   package:
-    uses: burin-labs/.github/.github/workflows/harn-package.yml@bcdcf64e5c7021f649432b77fe2e1f9f489c4824
+    uses: burin-labs/.github/.github/workflows/harn-package.yml@1acf9aba857a8eb512014d7097bfb22b2e751ff8
 
   canon-contract:
     name: Canon structure and fixture validation


### PR DESCRIPTION
Pins the thin package CI adapter to the latest immutable organization-owned reusable workflow. The semantic verification policy remains centralized in `burin-labs/.github`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-canon/pr/145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787782220&installation_model_id=426921&pr_number=145&repository=burin-labs%2Fharn-canon&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-canon%2Fpull%2F145&signature=9f6e718932e0adb6bc51f0cb2be71713a1380cf05d466212977dbb9c6ab71b17"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->