### PR TITLE
ci: pass canon validation date explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: burin-labs/harn/.github/actions/setup-harn@e2089cd9628995bf2080cd1515086a891dff34f4
       - name: Validate canon packs
         shell: bash
-        run: HARN_CANON_TODAY="$(date -u +%F)" harn run scripts/validate-canon.harn
+        run: harn run scripts/validate-canon.harn -- --today "$(date -u +%F)"
       - name: Reject side-effect builtins in predicates
         shell: bash
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ and evidence-backed.
 ## Validation
 
 - Structure and fixtures:
-  `HARN_CANON_TODAY=$(date -u +%F) harn run scripts/validate-canon.harn`
+  `harn run scripts/validate-canon.harn -- --today $(date -u +%F)`
 - Deterministic fixtures: `harn run scripts/execute-fixtures.harn`
 - Validator syntax:
   `harn check scripts/canon-lib.harn scripts/validate-canon.harn scripts/execute-fixtures.harn`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ add syntactically-malicious or unlintable Harn code fail before merge.
 
 ## Review flow
 
-Run `HARN_CANON_TODAY=$(date -u +%F) harn run scripts/validate-canon.harn`
+Run `harn run scripts/validate-canon.harn -- --today $(date -u +%F)`
 before opening a PR. CI runs the same validator and checks:
 
 - expected pack directories


### PR DESCRIPTION
## Summary

- pass the canon evidence date as an explicit validator argument
- remove the project-only HARN_CANON_TODAY variable from CI and contributor commands before the target runtime enforces Harn’s closed environment namespace

This is the backward-compatible prerelease slice of #147. The production runtime bump remains automated through the reusable fleet workflow.

## Verification

- Harn v0.10.42: harn run scripts/validate-canon.harn -- --today 2026-08-01 (34 packs, 340 predicates, 340 fixtures)
- actionlint .github/workflows/ci.yml
- git diff --check

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-canon/pr/150"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788202769&installation_model_id=426921&pr_number=150&repository=burin-labs%2Fharn-canon&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-canon%2Fpull%2F150&signature=792db76efa1a0ebdc77939ac7cca0fd9795ddc49de661c8932d3e2663cb2b825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->