### PR TITLE
refactor: resolve canon root at runtime

### DIFF
--- a/scripts/canon-lib.harn
+++ b/scripts/canon-lib.harn
@@ -14,10 +14,6 @@ import {
   schema_string,
 } from "std/schema"
 
-const ROOT_DIR = path_normalize(path_join(source_dir(), ".."))
-
-const PACK_MANIFEST_PATH = path_join(ROOT_DIR, "canon-packs.json")
-
 const INVARIANT_RE =
   "@invariant\\s*@(deterministic|semantic)(\\s*\\([^)]*\\))?\\s*@archivist\\(\\s*evidence:\\s*(_EVIDENCE_[A-Za-z0-9_]+)\\s*,\\s*confidence:\\s*((?:0(?:\\.\\d+)?|1(?:\\.0+)?))\\s*,\\s*source_date:\\s*\"(\\d{4}-\\d{2}-\\d{2})\"\\s*\\)[\\s\\S]*?pub\\s+fn\\s+([A-Za-z_][A-Za-z0-9_]*)\\s*\\("
 
@@ -140,11 +136,11 @@ pub fn fixture_document_schema() -> Schema<CanonFixtureDocument> {
 }
 
 pub fn repo_root() -> string {
-  return ROOT_DIR
+  return path_normalize(path_join(source_dir(), ".."))
 }
 
 pub fn read_pack_manifest_result() -> TypedReadResult<CanonPackManifest> {
-  return read_pack_manifest_path_result(PACK_MANIFEST_PATH)
+  return read_pack_manifest_path_result(path_join(repo_root(), "canon-packs.json"))
 }
 
 pub fn read_pack_manifest_path_result(path: string) -> TypedReadResult<CanonPackManifest> {


### PR DESCRIPTION
Part of #147.

Moves `source_dir()` out of module-load constants and into `repo_root()`. This preserves current behavior while giving Harn capability migration a callable seam through which it can thread `HarnessFs`; module-global authority cannot be migrated safely because no runtime grant exists at module initialization.

Verification:
- `harn fmt --check scripts/canon-lib.harn`
- `harn check scripts/canon-lib.harn scripts/validate-canon.harn scripts/execute-fixtures.harn`
- `harn run scripts/validate-canon.harn -- --today 2026-08-01` (34 packs / 340 predicates / 340 fixtures)
- `harn run scripts/execute-fixtures.harn` (847 cases)
- `harn test scripts/canon-boundary-test.harn` (10/10)
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-canon/pr/151"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788204037&installation_model_id=426921&pr_number=151&repository=burin-labs%2Fharn-canon&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-canon%2Fpull%2F151&signature=71241d0218be62bdb5b97064e245f062e9e811f3eac144eee7ac44309abf41bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->