### PR TITLE
ci: repin shared Harn package workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   package:
-    uses: burin-labs/.github/.github/workflows/harn-package.yml@1acf9aba857a8eb512014d7097bfb22b2e751ff8
+    uses: burin-labs/.github/.github/workflows/harn-package.yml@c5c3362bd344a549d6e5ed5418d5932405443738
 
   canon-contract:
     name: Canon structure and fixture validation


### PR DESCRIPTION
Repins the reusable Harn package workflow to the exact commit from burin-labs/.github#31.

The new `strict` input defaults to `false`, so this changes the immutable owner reference without changing this package’s checks.

Evidence: the branch contains one exact workflow-reference replacement; the owner workflow contract suite and the fleet policy anchor both pass for the new commit.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-canon/pr/153"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788273749&installation_model_id=426921&pr_number=153&repository=burin-labs%2Fharn-canon&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-canon%2Fpull%2F153&signature=2612c2634b3e1706c0b42c445eb00d245c85d6db0ab84629d5ac9ce2e07a5e95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->