### PR TITLE
ci: adopt generated Harn bump adapter

### DIFF
--- a/.github/workflows/bump-harn.yml
+++ b/.github/workflows/bump-harn.yml
@@ -1,6 +1,6 @@
 name: Bump Harn Runtime
 
-# fleet.toml in harn-bump-fleet owns the schedule and dispatches this adapter.
+# fleet.toml in harn-bump-fleet owns this generated dispatch adapter.
 on:
   workflow_dispatch:
     inputs:
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   bump:
-    uses: burin-labs/harn/.github/workflows/bump-harn.yml@88bdd139836493d3e1a11ef68856a0d8802a4066
+    uses: burin-labs/harn/.github/workflows/bump-harn.yml@d23dc77198ea45210eb3fb205031c349533d920f
     with:
       version: ${{ inputs.version }}
       validate-command: harn package verify .


### PR DESCRIPTION
## What changed

Adopt the byte-exact runtime-bump adapter generated from `harn-bump-fleet/fleet.toml`. The caller keeps only dispatch inputs and repository-specific commands; Harn owns orchestration in the immutable reusable workflow at `d23dc771`.

The fleet renderer and exact conformance policy landed in burin-labs/harn-bump-fleet#612 (452/452 tests and post-merge CI green).

## Verification

- generated bytes match the typed fleet projection
- `actionlint .github/workflows/bump-harn.yml`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-canon/pr/155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788311109&installation_model_id=426921&pr_number=155&repository=burin-labs%2Fharn-canon&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-canon%2Fpull%2F155&signature=b3621d4ec92be3cfd50f357ef771b88040befc2a033bc40610530510d5211874"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->