### PR TITLE
ci: fold canon validation into shared package workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,37 +11,21 @@ permissions:
   contents: read
 
 jobs:
-  package:
-    uses: burin-labs/.github/.github/workflows/harn-package.yml@a556b40acf7cbb278bd9b25b293fd99603656ef8
+  harn:
+    uses: burin-labs/.github/.github/workflows/harn-package.yml@c3d3025db6297d736400911029f34f7983744deb
+    with:
+      validate-command: |-
+        harn run scripts/validate-canon.harn -- --today "$(date -u +%F)"
+        harn run --no-sandbox scripts/assert-flow-capability-contract.harn -- --harn-bin "$(command -v harn)"
+        harn run scripts/execute-fixtures.harn
 
-  canon-contract:
-    name: Canon structure and fixture validation
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
-        with:
-          persist-credentials: false
-      - name: Install pinned Harn
-        id: harn
-        uses: burin-labs/harn/.github/actions/setup-harn@cf52e20564cb722f2f060bc222fa79d996cd3c30
-      - name: Validate canon packs
-        shell: bash
-        run: harn run scripts/validate-canon.harn -- --today "$(date -u +%F)"
-      - name: Verify typed Flow capability boundary
-        run: >-
-          harn run --no-sandbox scripts/assert-flow-capability-contract.harn --
-          --harn-bin "${{ steps.harn.outputs.path }}"
-      - name: Execute deterministic fixture cases
-        run: harn run scripts/execute-fixtures.harn
-
-  status:
+  ci-status:
     name: CI status
-    if: always()
-    needs: [package, canon-contract]
+    if: ${{ always() }}
+    needs: [harn]
     runs-on: ubuntu-latest
     steps:
-      - name: Require successful verification jobs
-        uses: burin-labs/.github/.github/actions/require-successful-needs@a556b40acf7cbb278bd9b25b293fd99603656ef8
+      - name: Enforce required jobs
+        uses: burin-labs/.github/.github/actions/require-successful-needs@c3d3025db6297d736400911029f34f7983744deb
         with:
           results-json: ${{ toJSON(needs.*.result) }}


### PR DESCRIPTION
Replace the duplicate checkout/runtime-install job with the canonical package workflow's typed validation hook. The same pinned Harn process now performs strict package verification and all three canon-specific gates, while the fleet manifest owns the exact adapter bytes.

Verification:
- actionlint
- package verify --strict: 8 passed, 0 failed
- structure: 34 packs / 340 predicates / 340 fixtures
- typed Flow capability contract: 5/5
- deterministic fixtures: 847/847
- fleet projection check: clean

Depends on the immutable shared workflow owner at c3d3025; fleet ownership is tracked by burin-labs/harn-bump-fleet#614.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-canon/pr/156"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788312943&installation_model_id=426921&pr_number=156&repository=burin-labs%2Fharn-canon&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-canon%2Fpull%2F156&signature=6960a5e15ebd4d60f96d3b4bcd662a78ffd62c516010501fd6bc14f56c3c321e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->