### PR TITLE
chore: restore fleet-owned projections

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   harn:
-    uses: burin-labs/.github/.github/workflows/harn-package.yml@c3d3025db6297d736400911029f34f7983744deb
+    uses: burin-labs/.github/.github/workflows/harn-package.yml@c7af1fc6b6a2486f279083aa91e963ab498424ba
     with:
       validate-command: |-
         harn run scripts/validate-canon.harn -- --today "$(date -u +%F)"
@@ -26,6 +26,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Enforce required jobs
-        uses: burin-labs/.github/.github/actions/require-successful-needs@c3d3025db6297d736400911029f34f7983744deb
+        uses: burin-labs/.github/.github/actions/require-successful-needs@c7af1fc6b6a2486f279083aa91e963ab498424ba
         with:
           results-json: ${{ toJSON(needs.*.result) }}


### PR DESCRIPTION
`fleet.toml` in `burin-labs/harn-bump-fleet` owns the exact bytes of the
files below, and they had drifted from it. This pull request restores the
rendered projection; it does not change what the manifest says.

Edit the projection at its owner and let the fleet re-render it. An edit
made here is reverted by the next convergence run.

- `.github/workflows/ci.yml` — fleet.toml package CI projection

Repository: `burin-labs/harn-canon`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-canon/pr/160"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788446602&installation_model_id=426921&pr_number=160&repository=burin-labs%2Fharn-canon&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-canon%2Fpull%2F160&signature=ea0c5934ec908da8be7d852997a5bef6a7a138df61905c45786989a9668b1574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->