### PR TITLE
chore: restore fleet-owned projections

### DIFF
--- a/.github/workflows/bump-harn.yml
+++ b/.github/workflows/bump-harn.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   bump:
-    uses: burin-labs/harn/.github/workflows/bump-harn.yml@9c23c53d22d0bbc307ae83905bd0c0368252cd59
+    uses: burin-labs/harn/.github/workflows/bump-harn.yml@5a34da720f3140d43a5cd4f8611941dd31a64f69
     with:
       version: ${{ inputs.version }}
       validate-command: harn package verify .


### PR DESCRIPTION
`fleet.toml` in `burin-labs/harn-bump-fleet` owns the exact bytes of the
files below, and they had drifted from it. This pull request restores the
rendered projection; it does not change what the manifest says.

Edit the projection at its owner and let the fleet re-render it. An edit
made here is reverted by the next convergence run.

- `.github/workflows/bump-harn.yml` — fleet.toml bump adapter projection

Repository: `burin-labs/harn-canon`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-canon/pr/171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789050760&installation_model_id=426921&pr_number=171&repository=burin-labs%2Fharn-canon&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-canon%2Fpull%2F171&signature=c152db29f6d6d0ac1c991aa06403d82c3698a984f6080e8c6a7a5d9abde1692d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->