### PR TITLE
chore: restore fleet-owned projections

### DIFF
--- a/.github/workflows/bump-harn.yml
+++ b/.github/workflows/bump-harn.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   bump:
-    uses: burin-labs/harn/.github/workflows/bump-harn.yml@0ff3506ddecab325f100a4d7d363e88e91595902
+    uses: burin-labs/harn/.github/workflows/bump-harn.yml@d2daff39fc9b4930aa0a3a1c75eadf7197871ff5
     with:
       version: ${{ inputs.version }}
       validate-command: harn package verify .


### PR DESCRIPTION
`fleet.toml` in `burin-labs/harn-bump-fleet` owns the exact bytes of the
files below, and they had drifted from it. This pull request restores the
rendered projection; it does not change what the manifest says.

Edit the projection at its owner and let the fleet re-render it. An edit
made here is reverted by the next convergence run.

- `.github/workflows/bump-harn.yml` — fleet.toml bump adapter projection

Repository: `burin-labs/harn-canon`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-canon/pr/174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789070086&installation_model_id=426921&pr_number=174&repository=burin-labs%2Fharn-canon&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-canon%2Fpull%2F174&signature=6380ccd1487159a28fa4f20a06c30a5c9312ec2a6b9f613c32c9aea0dfad65e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->