### PR TITLE
fix(security): route disclosure to security@harn.cloud

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Reporting a vulnerability
 
-Email **security@burinlabs.com** with the details. Encrypt with our public key
+Email **security@harn.cloud** with the details. Encrypt with our public key
 if the report contains exploit material (key available on request).
 
 Please include:


### PR DESCRIPTION
## What

One line: the disclosure address in `.github/SECURITY.md` moves from
`security@burinlabs.com` to `security@harn.cloud`.

## Why

The old address is undeliverable. `burinlabs.com` is not a registered domain:

```
$ whois burinlabs.com
No match for domain "BURINLABS.COM".

$ dig +short MX burinlabs.com   # (empty)
$ dig +short A  burinlabs.com   # (empty)
```

Every vulnerability report this repo's policy has ever solicited would have
bounced.

The sharper problem is that an unregistered domain is registrable by anyone.
This is a **public** repo telling researchers where to send vulnerability
reports, so whoever registers `burinlabs.com` inherits that inbox. A bounced
report is a missed report; a delivered-to-a-stranger report is a disclosed
vulnerability.

`security@harn.cloud` is verified live — Cloudflare Email Routing, MX present
(`route1/2/3.mx.cloudflare.net`), rule active to a verified destination with
delivery confirmed.

## Scope

The dead address appeared in 11 files across 10 public repos. `burin-labs/.github`
(the org default), `harn`, `harn-bump-fleet`, and `homebrew-burin` are already
fixed; this PR is one of the remaining seven, which close out the last of the
exposure.

Nothing else changes — no policy, scope, or response-window edits.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-canon/pr/205"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789488155&installation_model_id=426921&pr_number=205&repository=burin-labs%2Fharn-canon&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-canon%2Fpull%2F205&signature=05444335b73c24dea68c270e382043cfb5b59d2e8e5332f0b63c1a0743430e14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->