### PR TITLE
[Core] Add a pull request title convention, template, and label taxonomy

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,55 @@
+# Label taxonomy for harn-canon.
+#
+# The priority, status, and effort categories are the shared org taxonomy and
+# must match burin-labs/.github/.github/labels.yml verbatim. Type labels reuse
+# the repository defaults (bug, enhancement, epic) instead of duplicating them.
+#
+# This file is a record of intent. Applying it to the repository is a settings
+# change and belongs to the founder.
+
+- name: priority/p0
+  description: Must have, ships before anything else in flight
+  color: b60205
+- name: priority/p1
+  description: High priority
+  color: d93f0b
+- name: priority/p2
+  description: Medium priority
+  color: fbca04
+- name: priority/p3
+  description: Lower priority
+  color: 0e8a16
+
+- name: status/blocked
+  description: Cannot proceed until a named dependency clears
+  color: d93f0b
+- name: status/in-progress
+  description: An agent or engineer is actively working this
+  color: 0e8a16
+- name: status/needs-decision
+  description: Needs a founder or code-owner ruling before work continues
+  color: fbca04
+- name: status/ready
+  description: Scoped and unblocked, ready to pick up
+  color: 0e8a16
+
+- name: effort/small
+  description: Hours
+  color: c2e0c6
+- name: effort/medium
+  description: A day or two
+  color: fbca04
+- name: effort/large
+  description: Multi-day or multi-PR
+  color: d93f0b
+
+- name: area/stack
+  description: Per-language or per-stack seed pack
+  color: 8957e5
+- name: area/core
+  description: Validator scripts, manifest, CI, and repository-wide policy
+  color: 1d76db
+
+- name: seed-pack
+  description: Initial predicate pack for a language/stack
+  color: c2e0c6

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,44 @@
+## What changed
+
+<!--
+Three to five sentences. Say what you changed and why, in plain language.
+
+Example:
+The Python pack accepted `except Exception: pass` because the predicate only
+matched a bare `except:`. It now also matches a broad `except Exception`
+whose body is a single `pass`, which is the form that actually shows up in
+review. Two fixtures cover it: one slice that must block and one that swallows
+a specific exception on purpose and must stay allowed. Evidence is the CPython
+tutorial section on handling exceptions, refreshed to a current source date.
+-->
+
+## Pack and scope
+
+<!-- Which language or stack pack this touches. One pack per pull request. -->
+
+## Evidence
+
+<!--
+For a new or changed predicate:
+- The `_EVIDENCE_*` constant it cites, with at least two independent URLs no
+  older than 18 months.
+- The `confidence` value and what it is calibrated against.
+- The `source_date` you scanned on.
+-->
+
+## Validation
+
+<!-- Paste what you ran and what it reported. -->
+
+- [ ] `harn run scripts/validate-canon.harn -- --today $(date -u +%F)`
+- [ ] `harn run scripts/execute-fixtures.harn`
+- [ ] `harn check --strict-types . && harn lint --strict .`
+
+## Checklist
+
+- [ ] The title follows `[Area] Sentence case summary`.
+- [ ] Every new predicate has a fixture it blocks and one it allows.
+- [ ] The pack README has a row for every predicate.
+- [ ] No predicate calls a side-effect builtin. See the trust model in
+      [CONTRIBUTING.md](../CONTRIBUTING.md).
+- [ ] Routing selectors, if any, are in `canon-packs.json` and nowhere else.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,9 @@ and evidence-backed.
 - Rebase on `origin/main` before opening a PR.
 - Keep PRs focused. One language or stack per behavior change remains the
   default shape for predicate work.
+- Title pull requests `[Area] Sentence case summary`, where the area is the
+  pack directory or `core` for validator, manifest, and CI work. See
+  [CONTRIBUTING.md](CONTRIBUTING.md).
 
 <!-- BEGIN HARN SHARED AGENT CONTRACT: managed by harn-bump-fleet -->
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,23 @@ If you can't meet the evidence bar, file an issue instead and we'll discuss whet
 - Predicate function names use `snake_case` and describe the rule, not the fix: `no_floating_promises`, not `require_await`.
 - Remediation text must be plain English, ≤200 chars, and actionable.
 
+## Pull request titles
+
+Use `[Area] Sentence case summary`. The area is the pack or subsystem you
+touched, in square brackets. Use the pack directory name for predicate work,
+and `core` for the validator scripts, the manifest, or CI. The summary starts
+with a capital letter, stays in sentence case, and does not end with a period.
+
+```
+[python] Block a broad except that only passes
+[terraform] Raise confidence on the public bucket predicate
+[core] Fail validation when a pack README is missing a predicate row
+[docs] Explain how semantic fallbacks are recorded
+```
+
+Say what the change does, not which file it edits. `[rust] Add predicate` and
+`[rust] Update invariants.harn` both tell a reviewer nothing.
+
 ## Trust model
 
 **Predicate packs in this repo are trusted code that runs on consumer machines.**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,19 +31,24 @@ If you can't meet the evidence bar, file an issue instead and we'll discuss whet
 ## Pull request titles
 
 Use `[Area] Sentence case summary`. The area is the pack or subsystem you
-touched, in square brackets. Use the pack directory name for predicate work,
-and `core` for the validator scripts, the manifest, or CI. The summary starts
-with a capital letter, stays in sentence case, and does not end with a period.
+touched, in square brackets. Use the pack name, capitalized, for predicate
+work, and `Core` for the validator scripts, the manifest, or CI. The summary
+starts with a capital letter, stays in sentence case, and does not end with a
+period.
+
+Capitalize the area tag exactly as it is written here. The shared
+`pr-title-check` action matches the tag literally, so a lower-case tag
+fails once the check is wired in.
 
 ```
-[python] Block a broad except that only passes
-[terraform] Raise confidence on the public bucket predicate
-[core] Fail validation when a pack README is missing a predicate row
-[docs] Explain how semantic fallbacks are recorded
+[Python] Block a broad except that only passes
+[Terraform] Raise confidence on the public bucket predicate
+[Core] Fail validation when a pack README is missing a predicate row
+[Docs] Explain how semantic fallbacks are recorded
 ```
 
-Say what the change does, not which file it edits. `[rust] Add predicate` and
-`[rust] Update invariants.harn` both tell a reviewer nothing.
+Say what the change does, not which file it edits. `[Rust] Add predicate` and
+`[Rust] Update invariants.harn` both tell a reviewer nothing.
 
 ## Trust model
 


### PR DESCRIPTION
Part of the org-wide repo hygiene sweep. Unlike the connector repositories in
this batch, `harn-canon` was judged a **real repository, not a scaffold**: 30+
per-language predicate packs, a substantive `CONTRIBUTING.md` with an evidence
bar and a trust model, `CODEOWNERS`, its own validator scripts, and 160+ issues
of genuine history. It gets the fuller treatment, and the existing contributor
guidance is left alone rather than rewritten.

## What this adds

- **A pull request title convention** in `CONTRIBUTING.md`: `[Area] Sentence
  case summary`, where the area is the pack directory or `core` for validator,
  manifest, and CI work. Includes four worked examples and a note that
  `[rust] Add predicate` tells a reviewer nothing. One pointer line mirrors
  into `AGENTS.md` beside the existing git rules.
- **`.github/pull_request_template.md`** shaped around what this repository
  actually reviews: which pack was touched, the `_EVIDENCE_*` constant with its
  confidence and source date, the three validation commands, and a checklist
  covering fixture coverage, README rows, the side-effect builtin ban, and
  routing selectors staying in `canon-packs.json`.
- **`.github/labels.yml`** records the shared org priority, status, and effort
  categories verbatim from `burin-labs/.github`, alongside the existing
  `area/stack` and `seed-pack` and a new `area/core`.

## Labels

The missing shared labels were created through the API. The `priority/p1`,
`priority/p2`, and `priority/p3` labels already present matched the shared
taxonomy in name, description, and color, so they were left untouched. No
colon-notation labels existed, so nothing needed renaming.

Issues #147, #152, and #163 (closed since 2026-08-02) were labeled additively
with a type and `area/core`.

## What this deliberately does not touch

- The existing `CONTRIBUTING.md` sections on scope, the evidence bar, the trust
  model, and the review flow. They are already correct and in house style.
- Nothing between the `HARN SHARED AGENT CONTRACT` markers in `AGENTS.md`.
- `.github/workflows/ci.yml` and `.github/dependabot.yml`.
- No repository or organization settings were changed. No settings proposal was
  written for this repository, because its issue tracker is genuinely used.

## Verification

`.github/labels.yml` parses under `yaml.safe_load`. The `AGENTS.md` diff was
checked to confirm it adds no line inside the shared contract markers.

## Follow-up

`pr-title-check` was not wired in. `burin-labs/.github#84` is still open, so
there is no merge SHA to pin to. Wire it once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016h6hA5VoveYLHhTEkLgDMG

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-canon/pr/245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790909384&installation_model_id=426921&pr_number=245&repository=burin-labs%2Fharn-canon&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-canon%2Fpull%2F245&signature=c59e675db233fdccd9719d4411b6f3e57afaa7326d4a6d4487bc9e039eef665d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->