### PR TITLE
chore: restore fleet-owned projections

### DIFF
--- a/.github/workflows/bump-harn.yml
+++ b/.github/workflows/bump-harn.yml
@@ -14,9 +14,9 @@ permissions:
 
 jobs:
   bump:
-    uses: burin-labs/harn/.github/workflows/bump-harn.yml@bc6baec13ea39b4e1efa01a5f8fab2447152e4e4
+    uses: burin-labs/harn/.github/workflows/bump-harn.yml@a13ede819023dd37f4b07566a6e50db77688bdc1
     with:
-      orchestration-sha: bc6baec13ea39b4e1efa01a5f8fab2447152e4e4
+      orchestration-sha: a13ede819023dd37f4b07566a6e50db77688bdc1
       version: ${{ inputs.version }}
       validate-command: harn package verify .
       publish-failure-for-repair: true


### PR DESCRIPTION
`fleet.toml` in `burin-labs/harn-bump-fleet` owns the projections below,
and they had drifted from it. This pull request restores the rendered
projection; it does not change what the manifest says or replace
repository-owned workflow jobs.

Edit the projection at its owner and let the fleet re-render it. An edit
made here is reverted by the next convergence run.

- `.github/workflows/bump-harn.yml` — fleet.toml bump adapter projection

Repository: `burin-labs/harn-canon`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/burin-labs/codesmith/harn-canon/pr/252"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791191941&installation_model_id=426921&pr_number=252&repository=burin-labs%2Fharn-canon&return_to=https%3A%2F%2Fgithub.com%2Fburin-labs%2Fharn-canon%2Fpull%2F252&signature=ec9ec8cf4ef4c7b38b4f066b594dc4b5ec55a62b6be0a62db0c458b6b6775f9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->